### PR TITLE
Add support for local whispercpp

### DIFF
--- a/stt/stt-localwhisper.php
+++ b/stt/stt-localwhisper.php
@@ -17,7 +17,7 @@ function stt($file)
     $fileContent = file_get_contents($filePath);
     $filename = basename($filePath);
     $multipartBody = "--{$boundary}\r\n"
-        . "Content-Disposition: form-data; name=\"wav_file\"; filename=\"{$filename}\"\r\n"
+        . "Content-Disposition: form-data; name=\"file\"; filename=\"{$filename}\"\r\n"
         . "Content-Type: audio/wav\r\n\r\n"
         . $fileContent . "\r\n"
         . "--{$boundary}--\r\n";


### PR DESCRIPTION
Now localwhisper will expect a whispercpp server running instead of the old faster_whisper Python server.

Overall whispercpp is a better option, it will work well both for CPU and GPU (there are separate whispercpp binaries for CPU and GPU) It also supports optimized models like distil-whisper and such. The caveat is that whispercpp only accepts 16000Hz input so we need to run ffmpeg to convert the .wav before sending it via HTTP. That should add only minimal latency like 50-200ms. It's worth it because distil-whisper models are insanely fast and use less VRAM (English-only though).

Example running whispercpp binary:
./server -m models/distil-large --port 8070

On a 4090 distil-large is absolutely instant in terms of latency, while largev2 on older faster_whisper server had noticably longer response time