### PR TITLE
Add timestamp checker endpoint for Herika app

### DIFF
--- a/lastgamets.php
+++ b/lastgamets.php
@@ -1,0 +1,44 @@
+<?php
+
+/* Definitions and main includes */
+error_reporting(E_ALL);
+
+$path = dirname((__FILE__)) . DIRECTORY_SEPARATOR;
+require_once($path . "conf".DIRECTORY_SEPARATOR."conf.php");
+require_once($path . "lib" .DIRECTORY_SEPARATOR."model_dynmodel.php");
+require_once($path . "lib" .DIRECTORY_SEPARATOR."{$GLOBALS["DBDRIVER"]}.class.php");
+require_once($path . "lib" .DIRECTORY_SEPARATOR."data_functions.php");
+require_once($path . "lib" .DIRECTORY_SEPARATOR."chat_helper_functions.php");
+require_once($path . "lib" .DIRECTORY_SEPARATOR."memory_helper_vectordb.php");
+require_once($path . "lib" .DIRECTORY_SEPARATOR."memory_helper_embeddings.php");
+
+$db = new sql();
+
+$response = '';
+
+try {
+    // Attempt to fetch the newest entry from eventlog based on the highest 'gamets' and 'ts'
+    //$query = "SELECT ts, gamets FROM eventlog ORDER BY gamets DESC LIMIT 1";
+    $query = "SELECT ts, gamets FROM eventlog ORDER BY gamets DESC, ts DESC LIMIT 1";
+    $result = $db->fetchAll($query);
+
+    // Check if the result has at least one row
+    if (count($result) > 0) {
+        // Grab the 'ts' and 'gamets' from the newest entry in eventlog
+        $ts = $result[0]['ts'];
+        $gamets = $result[0]['gamets'];
+        $response = $ts . '|' . $gamets;
+    } else {
+        // If the result is empty, send a unique message indicating this
+        $response = 'DB_EMPTY';
+        http_response_code(200);
+    }
+} catch (Exception $e) {
+    // Send an appropriate error
+    $response = 'Error: ' . $e->getMessage();
+    http_response_code(500); // Internal Server Error
+}
+
+// Output the response
+echo $response;
+?>


### PR DESCRIPTION
Herika Android app cannot know what the latest ts/gamets timestamps are in eventlog history therefore it will always clash with existing DB unless the user carefully inputs timestamps into the app which is problematic. Any mistake can lead to a desync and then either Herika app or Skyrim mod will be getting the wrong context for responses due to messed up ordering.

This patch adds a simple http endpoint that checks the latest eventlog entry in DB and returns ts and gamets in response. Herika app is updated to check that endpoint every time before it sends inputtext or chat events. Now the Skyrim mod and Herika app should never clash with each other even if running on an existing DB.

If the app does not detect the new endpoint, it will fall back to the previous way of handling timestamps which is starting from 0 or starting from whatever was the last one inputted by the user in app config (which is not recommended).

NOTES:
This endpoint should not affect users that are not using the app in any way, as it is completely separate.