### PR TITLE
Update to openrouter configs to incorporate newly available sampler settings

### DIFF
--- a/conf/conf.sample.php
+++ b/conf/conf.sample.php
@@ -141,8 +141,8 @@ $CONNECTOR["openrouter"]["top_k"]=0;	//LLM parameter top_k
 $CONNECTOR["openrouter"]["top_p"]=1;	//LLM parameter top_p
 $CONNECTOR["openrouter"]["presence_penalty"]=0;	//LLM parameter presence_penalty
 $CONNECTOR["openrouter"]["frequency_penalty"]=0;	//LLM parameter frequency_penalty
-$CONNECTOR["openrouter"]["repetition_penalty"]=1;	//LLM parameter repetition_penalty
-$CONNECTOR["openrouter"]["min_p"]=0;	//LLM parameter min_p
+$CONNECTOR["openrouter"]["repetition_penalty"]=1.1;	//LLM parameter repetition_penalty
+$CONNECTOR["openrouter"]["min_p"]=0.15;	//LLM parameter min_p
 $CONNECTOR["openrouter"]["top_a"]=0;	//LLM parameter top_a
 
 

--- a/conf/conf.sample.php
+++ b/conf/conf.sample.php
@@ -136,10 +136,14 @@ $CONNECTOR["openrouter"]["xreferer"]="http://localhost:8081/saig-gwserver/";
 $CONNECTOR["openrouter"]["xtitle"]="Herika";
 $CONNECTOR["openrouter"]["API_KEY"]="";
 $CONNECTOR["openrouter"]["MAX_TOKENS_MEMORY"]="512";
-$CONNECTOR["openrouter"]["temperature"]=0.7;    		//LLM parameter temperature
-$CONNECTOR["openrouter"]["presence_penalty"]=0; 		//LLM parameter presence_penalty
-$CONNECTOR["openrouter"]["frequency_penalty"]=0;        	//LLM parameter frequency_penalty
-$CONNECTOR["openrouter"]["top_p"]=1;    			//LLM parameter top_p
+$CONNECTOR["openrouter"]["temperature"]=0.9;	//LLM parameter temperature
+$CONNECTOR["openrouter"]["top_k"]=0;	//LLM parameter top_k
+$CONNECTOR["openrouter"]["top_p"]=1;	//LLM parameter top_p
+$CONNECTOR["openrouter"]["presence_penalty"]=0;	//LLM parameter presence_penalty
+$CONNECTOR["openrouter"]["frequency_penalty"]=0;	//LLM parameter frequency_penalty
+$CONNECTOR["openrouter"]["repetition_penalty"]=1;	//LLM parameter repetition_penalty
+$CONNECTOR["openrouter"]["min_p"]=0;	//LLM parameter min_p
+$CONNECTOR["openrouter"]["top_a"]=0;	//LLM parameter top_a
 
 
 $CONNECTOR["oobabooga"]["HOST"]="127.0.0.1";

--- a/conf/conf.sample.php
+++ b/conf/conf.sample.php
@@ -141,8 +141,8 @@ $CONNECTOR["openrouter"]["top_k"]=0;	//LLM parameter top_k
 $CONNECTOR["openrouter"]["top_p"]=1;	//LLM parameter top_p
 $CONNECTOR["openrouter"]["presence_penalty"]=0;	//LLM parameter presence_penalty
 $CONNECTOR["openrouter"]["frequency_penalty"]=0;	//LLM parameter frequency_penalty
-$CONNECTOR["openrouter"]["repetition_penalty"]=1.1;	//LLM parameter repetition_penalty
-$CONNECTOR["openrouter"]["min_p"]=0.15;	//LLM parameter min_p
+$CONNECTOR["openrouter"]["repetition_penalty"]=1.15;	//LLM parameter repetition_penalty
+$CONNECTOR["openrouter"]["min_p"]=0.1;	//LLM parameter min_p
 $CONNECTOR["openrouter"]["top_a"]=0;	//LLM parameter top_a
 
 

--- a/conf/conf_schema.json
+++ b/conf/conf_schema.json
@@ -58,12 +58,15 @@
       "temperature": {"type":"number","description":"LLM parameter temperature","helpurl":"https://openrouter.ai/docs#format"},
       "presence_penalty": {"type":"number","description":"LLM parameter presence_penalty","helpurl":"https://openrouter.ai/docs#format"},
       "frequency_penalty": {"type":"number","description":"LLM parameter frequency_penalty","helpurl":"https://openrouter.ai/docs#format"},
+      "repetition_penalty": {"type":"number","description":"LLM parameter repetition_penalty","helpurl":"https://openrouter.ai/docs#format"},
       "top_p": {"type":"number","description":"LLM parameter top_p","helpurl":"https://openrouter.ai/docs#format"},
+      "top_k": {"type":"number","description":"LLM parameter top_k","helpurl":"https://openrouter.ai/docs#format"},
+      "min_p": {"type":"number","description":"LLM parameter min_p","helpurl":"https://openrouter.ai/docs#format"},
+      "top_a": {"type":"number","description":"LLM parameter top_a","helpurl":"https://openrouter.ai/docs#format"},
       "API_KEY":  {"type":"apikey","description":"OpenRouter key","code":"OPENAI_API_KEY"},
       "MAX_TOKENS_MEMORY": {"type":"integer","description":"Maximum tokens to generate when summarizing, such as writing to diary."},
       "xreferer": {"type":"string","description":"Stub needed header. Keep default."},
-      "xtitle": {"type":"string","description":"Stub needed header. Keep default."}
-            
+      "xtitle": {"type":"string","description":"Stub needed header. Keep default."}      
     },
     "oobabooga": {
       "_title":"Oobabooga text-generation-webui API",

--- a/connector/openrouter.php
+++ b/connector/openrouter.php
@@ -50,9 +50,13 @@ class connector
             'stream' => true,
             'max_tokens'=>$MAX_TOKENS,
             'temperature' => ($GLOBALS["CONNECTOR"][$this->name]["temperature"]) ?: 1,
+            'top_k' => ($GLOBALS["CONNECTOR"][$this->name]["top_k"]) ?: 0,
+            'top_p' => ($GLOBALS["CONNECTOR"][$this->name]["top_p"]) ?: 1,
             'presence_penalty' => ($GLOBALS["CONNECTOR"][$this->name]["presence_penalty"]) ?: 0,
             'frequency_penalty' => ($GLOBALS["CONNECTOR"][$this->name]["frequency_penalty"]) ?: 0,
-            'top_p' => ($GLOBALS["CONNECTOR"][$this->name]["top_p"]) ?: 1,
+            'repetition_penalty' => ($GLOBALS["CONNECTOR"][$this->name]["repetition_penalty"]) ?: 1,
+            'min_p' => ($GLOBALS["CONNECTOR"][$this->name]["min_p"]) ?: 0,
+            'top_a' => ($GLOBALS["CONNECTOR"][$this->name]["top_a"]) ?: 0,     
         );
 
         // Override

--- a/connector/openrouter.php
+++ b/connector/openrouter.php
@@ -54,8 +54,8 @@ class connector
             'top_p' => ($GLOBALS["CONNECTOR"][$this->name]["top_p"]) ?: 1,
             'presence_penalty' => ($GLOBALS["CONNECTOR"][$this->name]["presence_penalty"]) ?: 0,
             'frequency_penalty' => ($GLOBALS["CONNECTOR"][$this->name]["frequency_penalty"]) ?: 0,
-            'repetition_penalty' => ($GLOBALS["CONNECTOR"][$this->name]["repetition_penalty"]) ?: 1,
-            'min_p' => ($GLOBALS["CONNECTOR"][$this->name]["min_p"]) ?: 0,
+            'repetition_penalty' => ($GLOBALS["CONNECTOR"][$this->name]["repetition_penalty"]) ?: 1.15,
+            'min_p' => ($GLOBALS["CONNECTOR"][$this->name]["min_p"]) ?: 0.1,
             'top_a' => ($GLOBALS["CONNECTOR"][$this->name]["top_a"]) ?: 0,     
         );
 


### PR DESCRIPTION
[See here.](https://openrouter.ai/docs#llm-parameters)

Openrouter recently made available several new sampler settings that allow for *much better* responses with many of their hosted LLMs.  I would even consider these new settings as *required* for some of the LLMs hosted (particularly min_p with mixtral models, and repetition_penalty on most others.)