### PR TITLE
Fix issue resulting in empty context entry being sent to LLM

### DIFF
--- a/main.php
+++ b/main.php
@@ -500,7 +500,7 @@ if ($gameRequest[0] == "funcret") {
 
     // Won't use  functions.
     // $prompt and $contextData will be created
-    if (!empty($request)) {
+    if (!empty($request) && $request != "") {
         $prompt[] = array('role' => $LAST_ROLE, 'content' => $request);
         $contextData = array_merge($head, ($contextDataFull), $prompt);
     }

--- a/main.php
+++ b/main.php
@@ -500,9 +500,13 @@ if ($gameRequest[0] == "funcret") {
 
     // Won't use  functions.
     // $prompt and $contextData will be created
-    $prompt[] = array('role' => $LAST_ROLE, 'content' => $request);
-
-    $contextData = array_merge($head, ($contextDataFull), $prompt);
+    if (!empty($request)) {
+        $prompt[] = array('role' => $LAST_ROLE, 'content' => $request);
+        $contextData = array_merge($head, ($contextDataFull), $prompt);
+    }
+    else {
+        $contextData = array_merge($head, ($contextDataFull));
+    }
 
 
 }  else {


### PR DESCRIPTION
Some LLM's reject the request due to this with the following response: 
```
data: {"error":{"message":"{\"message\":\"invalid request: all elements in history must have a message.\"}","code":400}}
```