### PR TITLE
Fix bug causing last entry of NPC context to be missing

### DIFF
--- a/connector/openrouterjson.php
+++ b/connector/openrouterjson.php
@@ -136,10 +136,12 @@ class connector
         $contextDataOrig=array_values($contextData);
         $lastrole="";
         $assistantAppearedInhistory=false;
+        $lastTargetBuffer="";
+        $assistantRoleBuffer="";
         foreach ($contextDataOrig as $n=>$element) {
             
             
-            if ($n>=(sizeof($contextDataOrig)-2)) {
+            if ($n>=(sizeof($contextDataOrig)-1)) {
                 // Last element
                 $pb["user"].=$element["content"];
                 $contextDataCopy[]=$element;


### PR DESCRIPTION
This fixes an issue where the latest response from NPC's is not consistently included in the context.

Example (Before):
```           [49] => Array
                (
                    [role] => user
                    [content] => Min:Go away creep

                )

            [50] => Array
                (
                    [role] => user
                    [content] => Min:That's right, I will report you.

                )
```

After talking to the NPC again, the earlier context shows up:
```            [47] => Array
                (
                    [role] => user
                    [content] => Min:Go away creep

                )

            [48] => Array
                (
                    [role] => assistant
                    [content] => {"character": "Bashnag", "listener": "Min", "mood": "", "action": "Talk","target": "", "message":"A deal was offered and you expressed interest.  What I perceived as your disapproval was actually your intention to report me, rather than your sudden change of heart."}
                )

            [49] => Array
                (
                    [role] => user
                    [content] => Min:That's right, I will report you.
```

After (With this PR):
```
            [42] => Array
                (
                    [role] => user
                    [content] => Min:Why do you want me to do that?

                )

            [43] => Array
                (
                    [role] => assistant
                    [content] => {"character": "Bashnag", "listener": "Min", "mood": "", "action": "Talk","target": "", "message":"I will not engage further with you."}
                )

            [44] => Array
                (
                    [role] => user
                    [content] => Min:What if I want to agree to your ritual now?

                )

            [45] => Array
                (
                    [role] => user
                    [content] => Choose a coherent ACTION that is available to you in order to obey or physically interact with min. You can also use an ACTION to interact with the world, provide services, or indicate your arousal. Use this JSON object to give your answer: {"character":"Bashnag","listener":"specify who Bashnag is talking to","mood":"amused|lovely|playful|irritated|sexy|assisting|sassy|seductive|smirking|kindly|neutral|sardonic|default|smug|teasing|sarcastic|mocking|assertive","action":"RemoveClothes|Attack|IncreaseArousal|StartCunnilingus|SpankTits|TryToRemember|StartOrgy|StartFingering|Grope|StartCuddleSex|BeginTrading|TrainSkill|Masturbate|LookAt|PinchNipples|StartVaginal|Talk|PutOnClothes|InspectSurroundings|StartAnal|StartKissingSex|SpankAss|StartHandjob|DecreaseArousal|StartBlowjob","target":"action's target|destination name","message":"dialogues lines"}
                )
```