### PR TITLE
change stop all magic word

### DIFF
--- a/main.php
+++ b/main.php
@@ -4,7 +4,7 @@
 /* Definitions and main includes */
 error_reporting(E_ALL);
 
-define("STOPALL_MAGIC_WORD", "/safe\s*stop/i");
+define("STOPALL_MAGIC_WORD", "/halt/i");
 
 define("MAXIMUM_SENTENCE_SIZE", 125);
 define("MINIMUM_SENTENCE_SIZE", 50);

--- a/main.php
+++ b/main.php
@@ -4,6 +4,8 @@
 /* Definitions and main includes */
 error_reporting(E_ALL);
 
+define("STOPALL_MAGIC_WORD", "/safe\s*stop/i");
+
 define("MAXIMUM_SENTENCE_SIZE", 125);
 define("MINIMUM_SENTENCE_SIZE", 50);
 
@@ -298,13 +300,11 @@ require(__DIR__.DIRECTORY_SEPARATOR."processor".DIRECTORY_SEPARATOR."request.php
 /*
  Safe stop
 */
-
-if (stripos($gameRequest[3], "stop") !== false) {
+if (preg_match(STOPALL_MAGIC_WORD, $gameRequest[3]) === 1) {  
     echo "{$GLOBALS["HERIKA_NAME"]}|command|StopAll@\r\n";
     @ob_flush();
     $alreadysent[md5("{$GLOBALS["HERIKA_NAME"]}|command|StopAll@\r\n")] = "Herika|command|StopAll@\r\n";
 }
-
 
 if (!isset($GLOBALS["CACHE_PEOPLE"])) {
     $GLOBALS["CACHE_PEOPLE"]=DataBeingsInRange();


### PR DESCRIPTION
safe "stop" can easily be triggered during conversation. make it a bit harder to get triggered with `safe stop`.

i can also make it configurable on the UI, but I don't know if it's worth it to store in db, but let me know (`conf_opts` seems to get clean up every time db is reset, etc).