### PR TITLE
Avoid stripping entire sentence if it starts and ends with *

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -282,7 +282,14 @@ function returnLines($lines,$writeOutput=true)
         $sentence=$output;
 
         if (isset($GLOBALS["strip_emotes_from_output"]) && $GLOBALS["strip_emotes_from_output"] == true) {
-            $output = preg_replace('/\*([^*]+)\*/', '', $sentence); // Remove text bewteen * *
+            // Check to see if the LLM responded with the entire message in **'s.
+            if (str_starts_with($output, "*") && str_ends_with($output, "*")) {
+                $output = ltrim($output, "*");
+                $output = rtrim($output, "*");
+            }
+            else {
+                $output = preg_replace('/\*([^*]+)\*/', '', $sentence); // Remove text bewteen * *
+            }
         }
         else {
             $output = preg_replace('/\*(\w+\s+\w+.*)\*/', '', $sentence); // Remove text bewteen * * if two or more words inside


### PR DESCRIPTION
Some LLM's will encapsulate entire responses with *'s. Prevent this from killing the whole  sentence.