### PR TITLE
Diary page bugfixes

### DIFF
--- a/ui/addons/diary/script.js
+++ b/ui/addons/diary/script.js
@@ -9,33 +9,32 @@ function toggleClass(e, toggleClassName) {
 }
 
 function movePage(e, page) {
-  if (page == currentPage) {
+  if (page >= currentPage) {
     currentPage+=2;
     toggleClass(e, "left-side");
     toggleClass(e.nextElementSibling, "left-side");
     
   }
-  else if (page = currentPage - 1) {
+  else if (page < currentPage && e.className.includes("left-side")) {
     currentPage-=2;
-    toggleClass(e, "left-side");
-    toggleClass(e.previousElementSibling, "left-side");
+	toggleClass(e, "left-side");
+	toggleClass(e.previousElementSibling, "left-side");
   }
   
 }
 
-let i=1;
-
 function moveToLast() {
-  i=currentPage;
   console.log("Current Page"+currentPage);
   movePageAndWait();
 }
 
 function movePageAndWait() {
-    total=document.querySelectorAll('body > div.book > div').length-1;
-    movePage(document.querySelector('body > div.book > div:nth-child('+i+')'), i);
-    i+=2;
-    if (i<total)
-      setTimeout(movePageAndWait, 100);
+	const total=document.querySelectorAll('body > div.book > div').length-1;
+	if (currentPage<total) {
+		movePage(document.querySelector('body > div.book > div:nth-child('+currentPage+')'), currentPage);
+	}
+	if (currentPage<total) {
+		setTimeout(movePageAndWait, 100);
+	}
 }
 

--- a/ui/addons/diary/style.css
+++ b/ui/addons/diary/style.css
@@ -28,6 +28,7 @@ body {
   height: 654.5px;
   transform: translate(-50%, -50%) rotatex(10deg) rotatey(-10deg);
   transform-style: preserve-3d;
+  pointer-events: none;
 }
 
 .page {
@@ -38,6 +39,7 @@ body {
   top: 0;
   right: 0;
   transition: transform 1s;
+  pointer-events: all;
 }
 
 .page:nth-child(1) {


### PR DESCRIPTION
This PR fixes three issues with the AI diary page.

1. On firefox, clicking the right-side page does nothing. The user has to use the Last Page button to navigate. (I saw the same issue with the codepen this page was based on). No problem on chrome. Fixed by adding pointer-events to the css for ".book" so it doesn't block clicking the page.
2. Clicking the Last Page button when already on the last page was breaking navigation when later clicking on the pages. Fixed by adding a check for this in movePageAndWait(), and by removing the i variable and just using currentPage.
3. If the diary has an even number of entries, the "to be continued" page gets put on the right-side page. Clicking that page breaks navigation because movePage() expects it to always be on the left side. Fixed by disabling its navigation when it is on the right side (the user can still click the left-side page to go back).