### PR TITLE
Use diary connector for background generator

### DIFF
--- a/ui/addons/background/index.php
+++ b/ui/addons/background/index.php
@@ -23,19 +23,19 @@ echo file_get_contents('template.html');
 $db = new sql();
 
 if ($_POST["doit"]) {
-  
+
   
   $head[] = array('role' => 'system', 'content' => stripslashes($_POST["prompt"]));
-  $prompt[] = array('role' => 'user', 'content' => "Generate a background story for $HERIKA_NAME, in first person, and how she ended in Whiterun, as she would write it into her diary");
+  $prompt[] = array('role' => 'user', 'content' => stripslashes($_POST["intro"]));
   
 
   $parms=array_merge($head,$prompt);
   
-   require($enginePath.DIRECTORY_SEPARATOR."connector".DIRECTORY_SEPARATOR."{$GLOBALS["CURRENT_CONNECTOR"]}.php");
+	require_once $enginePath . "connector" . DIRECTORY_SEPARATOR . "{$GLOBALS["CONNECTORS_DIARY"]}.php";
   
     $connectionHandler=new connector();
     $GLOBALS["gameRequest"][0]="diary"; // HAck to force diary grammar
-    $connectionHandler->open($parms,["MAX_TOKENS"=>$_POST["OPENAI_MAX_TOKENS_MEMORY"]]);
+    $connectionHandler->open($parms,["MAX_TOKENS"=>$_POST["MAX_TOKENS"]]);
 
     $buffer="";
     $totalBuffer="";
@@ -67,7 +67,7 @@ if ($_POST["doit"]) {
   $db->insert(
 			'diarylog',
 			array(
-				'ts' => $finalParsedData[1],
+				'ts' => time(),
 				'gamets' => 0,
 				'topic' => SQLite3::escapeString("$HERIKA_NAME's background story"),
 				'content' => SQLite3::escapeString($_POST["bgstory"]),
@@ -104,8 +104,8 @@ $rawResponse
 <input type='text' value='".(($_POST["intro"])?:"Generate a background story for $HERIKA_NAME, telling birthplace, childhood, family , writen in first person, and how she ended in Whiterun, as she would write it into her diary in a summarized way")."' name='intro' size='200'/>
 <br/>
 <p>Token limit</p>
-<input type='range' min='100' max='1024' value='".(($_POST["OPENAI_MAX_TOKENS_MEMORY"])?:200)."'  name='OPENAI_MAX_TOKENS_MEMORY' oninput='this.nextElementSibling.value = this.value'>
-<output>".(($_POST["OPENAI_MAX_TOKENS_MEMORY"])?:200)."</output>
+<input type='range' min='100' max='1024' value='".(($_POST["MAX_TOKENS"])?:500)."'  name='MAX_TOKENS' oninput='this.nextElementSibling.value = this.value'>
+<output>".(($_POST["MAX_TOKENS"])?:500)."</output>
 <br/>
 <input type='submit' name='doit' value='Generate background story' />
 <input type='submit' name='store' value='Store background story' onclick='return confirm(\"Are you sure?\")'/>


### PR DESCRIPTION
This PR is to get the background generator screen into working condition.

1. Clicking the "generate background story" button redirects to a blank screen and fails to send a request to the LLM. Fixed by using the CONNECTORS_DIARY.
2. User-entered text in the "prompt" input is ignored and the default is always sent to the LLM. Fixed changing how the $prompt variable is set.
3. The OPENAI_MAX_TOKENS_MEMORY name seems confusing since we might be using a non-openai connector. I changed it to just MAX_TOKENS. I also increased the default from 200 to 500, since 200 didn't feel like enough to me.
4. Clicking the "store background story" button failed to insert the data into the diarylog table. Fixed by setting the timestamp column with time(), since the currently used finalParsedData isn't initialized.

It's not obvious to me exactly what the expected flow is for uploading background data. It looks like you can only upload one row as the existing row gets deleted whenever you store a new one. But I don't want to mess with that, so I tried to stick just to bugfixes.