### PR TITLE
regex used to decode datetime in data_functions.php fail for specific months.

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -832,14 +832,24 @@ function selectRandomInArray($arraySource)
         return "";
     
     $n=sizeof($arraySource);
-    if ($n==1) {
-        return strtr($arraySource[0],["#HERIKA_NPC1#"=>$GLOBALS["HERIKA_NAME"]]);
-        //return $arraySource[0];
+
+    //$arraySource could be empty, could contain undefined element, could contain empty element, could contain array element
+    if ($n > 0) {   
+        if ($n > 1) {
+            $ix = rand(0, $n-1);
+        } else {
+            $ix = 0;
+        }
+        if (isset($arraySource[$ix])) {
+            if (is_array($arraySource[$ix])) {
+                error_log("selectRandomInArray: expecting string, received array " . print_r($arraySource[$ix], true) ); 
+            } else {
+                if (strlen($arraySource[$ix]) > 0) {
+                    return strtr($arraySource[$ix],["#HERIKA_NPC1#"=>$GLOBALS["HERIKA_NAME"]]);
+                }
+            }
+        }
     }
-    
-    return strtr($arraySource[rand(0, $n-1)],["#HERIKA_NPC1#"=>$GLOBALS["HERIKA_NAME"]]);
-    //return $arraySource[rand(0, $n-1)];
-
-
+    return "";
 
 }

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -69,7 +69,7 @@ function DataLastDataFor($actor, $lastNelements = -10)
 
     foreach ($lastDialogFull as $n => $line) {
 
-        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\ ]+), 4E (\d+)/';
+        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\'\ ]+), 4E (\d+)/'; //extract also for months with apostrophe like Sun's Something
         $replacement = 'Day name: $1, Hour: $2, Day Number: $3, Month: $4, 4th Era, Year: $5';
         $result = preg_replace($pattern, $replacement, $line["content"]);
         $lastDialogFull[$n]["content"] = $result;
@@ -121,7 +121,7 @@ function DataLastInfoFor($actor, $lastNelements = -2)
 
     foreach ($lastDialog as $n => $line) {
 
-        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\ ]+), 4E (\d+)/';
+        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\'\ ]+), 4E (\d+)/'; //extract also for months with apostrophe like Sun's Something
         $replacement = 'Day name: $1, Hour: $2, Day Number: $3, Month: $4, 4th Era, Year: $5';
         $result = preg_replace($pattern, $replacement, $line["content"]);
         $lastDialogFull[$n]["content"] = $result;
@@ -442,7 +442,7 @@ function DataLastDataExpandedFor($actor, $lastNelements = -10)
 
     foreach ($lastDialogFull as $n => $line) {
 
-        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\ ]+), 4E (\d+)/';
+        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\'\ ]+), 4E (\d+)/'; //extract also for months with apostrophe like Sun's Something
         $replacement = 'Day name: $1, Hour: $2, Day Number: $3, Month: $4, 4th Era, Year: $5';
         $result = preg_replace($pattern, $replacement, $line["content"]);
         $lastDialogFull[$n]["content"] = $result;
@@ -653,14 +653,17 @@ function DataLastKnowDate()
 
     global $db;
 
-    $lastLoc=$db->fetchAll("select  a.data  as data  FROM  eventlog a  WHERE type in ('infoloc')  order by gamets desc,ts desc LIMIT 0,1");
+    $lastLoc=$db->fetchAll("select  a.data  as data  FROM  eventlog a  WHERE (type in ('infoloc')) and (data like '%Current Date%')  order by gamets desc, ts desc LIMIT 1"); //make sure record has datetime
     if (!is_array($lastLoc) || sizeof($lastLoc)==0) {
         return "";
     }
-    $re = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\ ]+), 4E (\d+)/';
-    preg_match($re, $lastLoc[0]["data"], $matches, PREG_OFFSET_CAPTURE, 0);
-    return $matches[0][0];
-
+    $re = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\'\ ]+), 4E (\d+)/'; //extract also for months with apostrophe like Sun's Something
+    if (preg_match($re, $lastLoc[0]["data"], $matches, PREG_OFFSET_CAPTURE, 0)) {
+        return $matches[0][0];
+    } else {
+        error_log("DataLastKnowDate: NO match found");
+        return "";
+    }
 }
 
 function DataLastKnownLocation()


### PR DESCRIPTION
data_functions.php
An issue occurring when calendar in Skyrim reach Sun's Dawn, Sun's Height or Sun's Dusk. The regex fail to decode date on months with apostrophe.

function DataLastKnowDate()
Also, probably related to same type of error with month names with apostrophe, occurring in another place, sometime 'infoloc' record would not have a valid date and the SQL query will return wrong record. SQL should retrieve only records with 'Current Date'.