### PR TITLE
alter regex for repeated context location

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -510,7 +510,7 @@ function DataLastDataExpandedFor($actor, $lastNelements = -10,$sqlfilter="")
         if ($rowData==="The Narrator:") // Hunt empty rows
             continue;
         
-        $pattern = "/\(Context location: (.*?),(.*?)\)/";
+        $pattern = "/\(Context location: (.*)\)/";
         if ($rowData)
             $rowData = preg_replace($pattern, "", $rowData); // Remove context location if repeated
         


### PR DESCRIPTION
![repeated context](https://github.com/user-attachments/assets/a3cf4208-2077-4f4b-a59e-4f62c5f01c24)
When removing repeat (context location) lines, there might not be a comma in the location text, so it doesn't get picked up by the regex. The location in the image is from Keep it Clean mod, but I imagine other modded locations might have the same issue.
This PR adjusts the regex so it doesn't require a comma to be in the location text.