### PR TITLE
fix diary being set back to Diary after loading extensions

### DIFF
--- a/main.php
+++ b/main.php
@@ -387,11 +387,11 @@ if ($MUST_END) {  // Shorthand for non LLM processing
 
 // Include prompts, command prompts and functions.
 require(__DIR__.DIRECTORY_SEPARATOR."prompt.includes.php");
+$gameRequest[0] = strtolower($gameRequest[0]); // one more time in case it was changed by an extension
 
 // Take care of override request if needed..
 require(__DIR__.DIRECTORY_SEPARATOR."processor".DIRECTORY_SEPARATOR."request.php");
 
-$gameRequest[0] = strtolower($gameRequest[0]); // one more time in case it was changed by an extension
 
 /*
  Safe stop

--- a/main.php
+++ b/main.php
@@ -391,6 +391,7 @@ require(__DIR__.DIRECTORY_SEPARATOR."prompt.includes.php");
 // Take care of override request if needed..
 require(__DIR__.DIRECTORY_SEPARATOR."processor".DIRECTORY_SEPARATOR."request.php");
 
+$gameRequest[0] = strtolower($gameRequest[0]); // one more time in case it was changed by an extension
 
 /*
  Safe stop

--- a/prompts/command_prompt.php
+++ b/prompts/command_prompt.php
@@ -13,7 +13,7 @@ Only perform actions and tool calling if your character would find it necessary 
 ";
 */
 
-$COMMAND_PROMPT_ENFORCE_ACTIONS="Choose coherent ACTION to obbey {$GLOBALS["PLAYER_NAME"]}.";
+$COMMAND_PROMPT_ENFORCE_ACTIONS="Choose coherent ACTION to obey {$GLOBALS["PLAYER_NAME"]}.";
 
 $DIALOGUE_TARGET="(Talking to {$GLOBALS["HERIKA_NAME"]})";
 $MEMORY_OFFERING="";


### PR DESCRIPTION
In main.php, gamerequest[0] starts as Diary and is set to diary at the start of the file. But after loading the custom prompts (ie MinAI), it might be set back to Diary again.
And fixed a random spelling error.