### PR TITLE
Add enum to google connector structured output

### DIFF
--- a/connector/google_openaijson.php
+++ b/connector/google_openaijson.php
@@ -134,10 +134,11 @@ class connector
         
 
 
-        
+         $action_array=[];
          if (isset($GLOBALS["FUNCTIONS_ARE_ENABLED"]) && $GLOBALS["FUNCTIONS_ARE_ENABLED"]) {
             foreach ($GLOBALS["FUNCTIONS"] as $function) {
                 //$data["tools"][]=["type"=>"function","function"=>$function];
+                $action_array[]=$function["name"];
                 
                 if (strpos($function["name"],"Attack")!==false) {   // Every command starting with Attack
                     $contextData[0]["content"].="\nAVAILABLE ACTION: {$function["name"]} : {$function["description"]} ";
@@ -152,6 +153,7 @@ class connector
                     $contextData[0]["content"].="\nAVAILABLE ACTION: {$function["name"]} : {$function["description"]}";
             }
             $contextData[0]["content"].="\nAVAILABLE ACTION: Talk";
+            $action_array[]="Talk";
              
 
         }
@@ -310,31 +312,49 @@ class connector
                     "type" => "object",
                     "properties" => array(
                         "character" => array(
-                            "type" => "string"
+                            "type" => "string",
+                            "description" => $GLOBALS["HERIKA_NAME"]
                         ),
                         "listener" => array(
-                            "type" => "string"
-                        ),
-                        "mood" => array(
-                            "type" => "string"
-                        ),
-                        "action" => array(
-                            "type" => "string"
-                        ),
-                        "target" => array(
-                            "type" => "string"
+                            "type" => "string",
+                            "description" => "specify who {$GLOBALS["HERIKA_NAME"]} is talking to"
                         ),
                         "message" => array(
-                            "type" => "string"
+                            "type" => "string",
+                            "description" => "lines of dialogue"
+                        ),
+                        "mood" => empty($moods) ?
+                            array(
+                                "type" => "string",
+                                "description" => "mood to use while speaking"
+                            ) :
+                            array(
+                                "type" => "string",
+                                "description" => "mood to use while speaking",
+                                "enum" => !empty($moods) ? $moods : null
+                            ),
+                        "action" => empty($action_array) ? 
+                            array(
+                                "type" => "string",
+                                "description" => "a valid action (refer to available actions list)"
+                            ) :
+                            array(
+                                "type" => "string",
+                                "description" => "a valid action (refer to available actions list)",
+                                "enum" => $action_array
+                            ),
+                        "target" => array(
+                            "type" => "string",
+                            "description" => "action's target"
                         )
                     ),
                     "required" => [
                         "character",
                         "listener",
+                        "message",
                         "mood",
                         "action",
-                        "target",
-                        "message"
+                        "target"
                     ],
                     "additionalProperties" => false
                 ),

--- a/connector/google_openaijson.php
+++ b/connector/google_openaijson.php
@@ -331,7 +331,7 @@ class connector
                             array(
                                 "type" => "string",
                                 "description" => "mood to use while speaking",
-                                "enum" => !empty($moods) ? $moods : null
+                                "enum" => $moods
                             ),
                         "action" => empty($action_array) ? 
                             array(

--- a/connector/openaijson.php
+++ b/connector/openaijson.php
@@ -322,16 +322,26 @@ class connector
                             "type" => "string",
                             "description" => "lines of dialogue"
                         ),
-                        "mood" => array(
-                            "type" => "string",
-                            "description" => "mood to use while speaking",
-                            "enum" => $moods
-                        ),
-                        "action" => array(
-                            "type" => "string",
-                            "description" => "a valid action (refer to available actions list)",
-                            "enum" => $action_array
-                        ),
+                        "mood" => empty($moods) ?
+                            array(
+                                "type" => "string",
+                                "description" => "mood to use while speaking"
+                            ) :
+                            array(
+                                "type" => "string",
+                                "description" => "mood to use while speaking",
+                                "enum" => !empty($moods) ? $moods : null
+                            ),
+                        "action" => empty($action_array) ? 
+                            array(
+                                "type" => "string",
+                                "description" => "a valid action (refer to available actions list)"
+                            ) :
+                            array(
+                                "type" => "string",
+                                "description" => "a valid action (refer to available actions list)",
+                                "enum" => $action_array
+                            ),
                         "target" => array(
                             "type" => "string",
                             "description" => "action's target"

--- a/connector/openaijson.php
+++ b/connector/openaijson.php
@@ -330,7 +330,7 @@ class connector
                             array(
                                 "type" => "string",
                                 "description" => "mood to use while speaking",
-                                "enum" => !empty($moods) ? $moods : null
+                                "enum" => $moods
                             ),
                         "action" => empty($action_array) ? 
                             array(

--- a/connector/openrouterjson.php
+++ b/connector/openrouterjson.php
@@ -400,16 +400,26 @@ class connector
                                     "type" => "string",
                                     "description" => "lines of dialogue"
                                 ),
-                                "mood" => array(
-                                    "type" => "string",
-                                    "description" => "mood to use while speaking",
-                                    "enum" => $moods
-                                ),
-                                "action" => array(
-                                    "type" => "string",
-                                    "description" => "a valid action (refer to available actions list)",
-                                    "enum" => $action_array
-                                ),
+                                "mood" => empty($moods) ?
+                                    array(
+                                        "type" => "string",
+                                        "description" => "mood to use while speaking"
+                                    ) :
+                                    array(
+                                        "type" => "string",
+                                        "description" => "mood to use while speaking",
+                                        "enum" => !empty($moods) ? $moods : null
+                                    ),
+                                "action" => empty($action_array) ? 
+                                    array(
+                                        "type" => "string",
+                                        "description" => "a valid action (refer to available actions list)"
+                                    ) :
+                                    array(
+                                        "type" => "string",
+                                        "description" => "a valid action (refer to available actions list)",
+                                        "enum" => $action_array
+                                    ),
                                 "target" => array(
                                     "type" => "string",
                                     "description" => "action's target"

--- a/connector/openrouterjson.php
+++ b/connector/openrouterjson.php
@@ -408,7 +408,7 @@ class connector
                                     array(
                                         "type" => "string",
                                         "description" => "mood to use while speaking",
-                                        "enum" => !empty($moods) ? $moods : null
+                                        "enum" => $moods
                                     ),
                                 "action" => empty($action_array) ? 
                                     array(


### PR DESCRIPTION
1. add an enum for moods and actions to the google json connector, like with openai and openrouter
2. fixed a bug where an empty enum would cause errors in the case actions are turned off