### PR TITLE
Multilingual support

### DIFF
--- a/debug/sentence_split_test.php
+++ b/debug/sentence_split_test.php
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Sentence Splitter Test</title>
+    <meta charset="UTF-8">
+    <style>
+		.code-block {
+			background-color: #f0f0f0;
+			border: 1px solid #ccc;
+			padding: 10px;
+			margin-bottom: 15px;
+		}
+		.code-block .content {
+			overflow: hidden; /* Hide content initially */
+			transition: max-height 0.3s ease-out; /* Smooth transition for expanding/collapsing */
+			max-height: 0; /* Initially collapsed */
+		}
+		.code-block.expanded .content {
+			max-height: 500px; /* Adjust as needed */
+		}
+		.code-block .toggle {
+			cursor: pointer;
+			font-weight: bold;
+			margin-bottom: 5px;
+		}
+		.pass { color: green; }
+		.fail { color: red; }
+    </style>
+
+	<script>
+		function toggleCodeBlock(element) {
+			element.classList.toggle("expanded");
+		}
+	</script>
+</head>
+<body>
+
+<h1>Sentence Splitter Test</h1>
+
+<?php
+
+$GLOBALS["HERIKA_NAME"]="Ysolda";
+
+require_once(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."lib".DIRECTORY_SEPARATOR."chat_helper_functions.php");
+
+// reduce the default values to make testing easier
+define("MAXIMUM_SENTENCE_SIZE", 60);
+define("MINIMUM_SENTENCE_SIZE", 25);
+
+// approximately copies the logic in main.php
+function mainFunction($inputText) {
+    $buffer="";
+	$returnSentences=[];
+
+	// looping over each character of the input string to simulate a buffer from the LLM
+    foreach (mb_str_split($inputText) as $char) {
+        $buffer.=$char;
+
+        $buffer=strtr($buffer, array("\""=>"",".)"=>")."));
+
+        if (strlen($buffer)<MINIMUM_SENTENCE_SIZE) {
+            continue;
+        }
+
+        $position = findDotPosition($buffer);
+
+        if ($position !== false && $position>MINIMUM_SENTENCE_SIZE ) {
+            $extractedData = substr($buffer, 0, $position + 1);
+            $remainingData = substr($buffer, $position + 1);
+            $returnSentences=array_merge($returnSentences, split_sentences_stream(cleanResponse($extractedData)));
+            $buffer=$remainingData;
+        }
+    }
+    
+    
+    if (trim($buffer)) {
+        $returnSentences=array_merge($returnSentences, split_sentences_stream(cleanResponse(trim($buffer))));
+    }
+
+	return $returnSentences;
+}
+
+// Array of strings to be tested along with their expected outputs
+$testStrings = [
+	// regular paragraph
+    "Upon the realm of Tamriel, an empire stands. With Iron will and disciplined hands. United under Mede, they strive to keep."
+		=> ["Upon the realm of Tamriel, an empire stands.", "With Iron will and disciplined hands.", "United under Mede, they strive to keep."],
+	// zero punctuation
+	"Upon the realm of Tamriel an empire stands With Iron will and disciplined hands United under Mede they strive to keep"
+		=> ["Upon the realm of Tamriel an empire stands With Iron will and disciplined hands United under Mede they strive to keep"],
+	// incomplete ending
+    "Upon the realm of Tamriel, an empire stands. With Iron will and disciplined hands. United under Mede, they strive to keep. And it will"
+		=> ["Upon the realm of Tamriel, an empire stands.", "With Iron will and disciplined hands.", "United under Mede, they strive to keep.", "And it will"],
+	// incomplete ending with no periods
+	"Upon the realm of Tamriel, an empire stands! With Iron will and disciplined hands! United under Mede, they strive to keep! And it will"
+		=> ["Upon the realm of Tamriel, an empire stands!", "With Iron will and disciplined hands!", "United under Mede, they strive to keep!", "And it will"],
+	// incomplete ending (short)
+	"Okay. And"
+		=> ["Okay. And"],
+	// double punctuation
+	"Upon the realm of Tamriel, an empire stands?! With Iron will and disciplined hands!! United under Mede, they strive to keep!!"
+		=> ["Upon the realm of Tamriel, an empire stands?", "With Iron will and disciplined hands!", "United under Mede, they strive to keep!"],
+	// abbreviations - currently FAILS
+	"I've been to Daggerfall, Morrowind, Cyrodiil, and Skyrim. But I've never been to the U.S. Is it as exciting as Nirn?"
+		=> ["I've been to Daggerfall, Morrowind, Cyrodiil, and Skyrim.", "But I've never been to the U.S.", "Is it as exciting as Nirn?"],
+	// ellipsis 
+	"Upon the realm of Tamriel, an empire stands... With Iron will and disciplined hands... United under Mede, they strive to keep..."
+		=> ["Upon the realm of Tamriel, an empire stands...", "With Iron will and disciplined hands...", "United under Mede, they strive to keep..."],
+
+	// regular paragraph
+    "ああ、カスティル。飲み物ならここにあるよ。何がいい？エールか、ミードか？それとも他に何か欲しいものがあるかい？食事もいかがですか？"
+		=> ["ああ、カスティル。", "飲み物ならここにあるよ。", "何がいい？ エールか、ミードか？", "それとも他に何か欲しいものがあるかい？", "食事もいかがですか？"],
+	// incomplete ending
+    "ああ、カスティル。飲み物ならここにあるよ。何がいい？エールか、ミードか？それとも他に何か欲しいものがあるかい？食事もいかがですか？何でも"
+		=> ["ああ、カスティル。", "飲み物ならここにあるよ。", "何がいい？ エールか、ミードか？", "それとも他に何か欲しいものがあるかい？", "食事もいかがですか？", "何でも"],
+	// incomplete ending (short)
+	"あ。それで"
+		=> ["あ。それで"],
+];
+
+foreach ($testStrings as $input => $expected) {
+    $pass = true;
+    $sentences = mainFunction($input);
+
+    if ($sentences !== $expected) {
+        $pass = false;
+    }
+
+    $blockClass = "code-block";
+    if (!$pass) {
+        $blockClass .= " expanded"; // Expand if test fails
+    }
+
+    echo "<div class='" . $blockClass . "'>";
+    echo "<div class='toggle' onclick='toggleCodeBlock(this.parentNode)'><span class='" . ($pass ? "pass" : "fail") . "'>#INPUT: </span>" . htmlspecialchars($input) . "</div>";
+    echo "<div class='content'>"; // Content to be toggled
+
+    echo "<p>#OUTPUTS:</p>";
+    foreach ($sentences as $sentence) {
+        echo "<p>" . htmlspecialchars($sentence) . "</p>";
+    }
+
+    if (!$pass) {
+        // Show expected output on failure
+        echo "<p>#EXPECTED:</p>";
+		foreach ($expected as $sentence) {
+			echo "<p>" . htmlspecialchars($sentence) . "</p>";
+		}
+    }
+
+    echo "</div>"; // Close content div
+    echo "</div>"; // Close code-block div
+}
+?>
+
+</body>
+</html>

--- a/debug/sentence_split_test.php
+++ b/debug/sentence_split_test.php
@@ -4,34 +4,34 @@
     <title>Sentence Splitter Test</title>
     <meta charset="UTF-8">
     <style>
-		.code-block {
-			background-color: #f0f0f0;
-			border: 1px solid #ccc;
-			padding: 10px;
-			margin-bottom: 15px;
-		}
-		.code-block .content {
-			overflow: hidden; /* Hide content initially */
-			transition: max-height 0.3s ease-out; /* Smooth transition for expanding/collapsing */
-			max-height: 0; /* Initially collapsed */
-		}
-		.code-block.expanded .content {
-			max-height: 500px; /* Adjust as needed */
-		}
-		.code-block .toggle {
-			cursor: pointer;
-			font-weight: bold;
-			margin-bottom: 5px;
-		}
-		.pass { color: green; }
-		.fail { color: red; }
+        .code-block {
+            background-color: #f0f0f0;
+            border: 1px solid #ccc;
+            padding: 10px;
+            margin-bottom: 15px;
+        }
+        .code-block .content {
+            overflow: hidden; /* Hide content initially */
+            transition: max-height 0.3s ease-out; /* Smooth transition for expanding/collapsing */
+            max-height: 0; /* Initially collapsed */
+        }
+        .code-block.expanded .content {
+            max-height: 500px; /* Adjust as needed */
+        }
+        .code-block .toggle {
+            cursor: pointer;
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+        .pass { color: green; }
+        .fail { color: red; }
     </style>
 
-	<script>
-		function toggleCodeBlock(element) {
-			element.classList.toggle("expanded");
-		}
-	</script>
+    <script>
+        function toggleCodeBlock(element) {
+            element.classList.toggle("expanded");
+        }
+    </script>
 </head>
 <body>
 
@@ -50,9 +50,9 @@ define("MINIMUM_SENTENCE_SIZE", 25);
 // approximately copies the logic in main.php
 function mainFunction($inputText) {
     $buffer="";
-	$returnSentences=[];
+    $returnSentences=[];
 
-	// looping over each character of the input string to simulate a buffer from the LLM
+    // looping over each character of the input string to simulate a buffer from the LLM
     foreach (mb_str_split($inputText) as $char) {
         $buffer.=$char;
 
@@ -77,45 +77,45 @@ function mainFunction($inputText) {
         $returnSentences=array_merge($returnSentences, split_sentences_stream(cleanResponse(trim($buffer))));
     }
 
-	return $returnSentences;
+    return $returnSentences;
 }
 
 // Array of strings to be tested along with their expected outputs
 $testStrings = [
-	// regular paragraph
+    // regular paragraph
     "Upon the realm of Tamriel, an empire stands. With Iron will and disciplined hands. United under Mede, they strive to keep."
-		=> ["Upon the realm of Tamriel, an empire stands.", "With Iron will and disciplined hands.", "United under Mede, they strive to keep."],
-	// zero punctuation
-	"Upon the realm of Tamriel an empire stands With Iron will and disciplined hands United under Mede they strive to keep"
-		=> ["Upon the realm of Tamriel an empire stands With Iron will and disciplined hands United under Mede they strive to keep"],
-	// incomplete ending
+        => ["Upon the realm of Tamriel, an empire stands.", "With Iron will and disciplined hands.", "United under Mede, they strive to keep."],
+    // zero punctuation
+    "Upon the realm of Tamriel an empire stands With Iron will and disciplined hands United under Mede they strive to keep"
+        => ["Upon the realm of Tamriel an empire stands With Iron will and disciplined hands United under Mede they strive to keep"],
+    // incomplete ending
     "Upon the realm of Tamriel, an empire stands. With Iron will and disciplined hands. United under Mede, they strive to keep. And it will"
-		=> ["Upon the realm of Tamriel, an empire stands.", "With Iron will and disciplined hands.", "United under Mede, they strive to keep.", "And it will"],
-	// incomplete ending with no periods
-	"Upon the realm of Tamriel, an empire stands! With Iron will and disciplined hands! United under Mede, they strive to keep! And it will"
-		=> ["Upon the realm of Tamriel, an empire stands!", "With Iron will and disciplined hands!", "United under Mede, they strive to keep!", "And it will"],
-	// incomplete ending (short)
-	"Okay. And"
-		=> ["Okay. And"],
-	// double punctuation
-	"Upon the realm of Tamriel, an empire stands?! With Iron will and disciplined hands!! United under Mede, they strive to keep!!"
-		=> ["Upon the realm of Tamriel, an empire stands?", "With Iron will and disciplined hands!", "United under Mede, they strive to keep!"],
-	// abbreviations - currently FAILS
-	"I've been to Daggerfall, Morrowind, Cyrodiil, and Skyrim. But I've never been to the U.S. Is it as exciting as Nirn?"
-		=> ["I've been to Daggerfall, Morrowind, Cyrodiil, and Skyrim.", "But I've never been to the U.S.", "Is it as exciting as Nirn?"],
-	// ellipsis 
-	"Upon the realm of Tamriel, an empire stands... With Iron will and disciplined hands... United under Mede, they strive to keep..."
-		=> ["Upon the realm of Tamriel, an empire stands...", "With Iron will and disciplined hands...", "United under Mede, they strive to keep..."],
+        => ["Upon the realm of Tamriel, an empire stands.", "With Iron will and disciplined hands.", "United under Mede, they strive to keep.", "And it will"],
+    // incomplete ending with no periods
+    "Upon the realm of Tamriel, an empire stands! With Iron will and disciplined hands! United under Mede, they strive to keep! And it will"
+        => ["Upon the realm of Tamriel, an empire stands!", "With Iron will and disciplined hands!", "United under Mede, they strive to keep!", "And it will"],
+    // incomplete ending (short)
+    "Okay. And"
+        => ["Okay. And"],
+    // double punctuation
+    "Upon the realm of Tamriel, an empire stands?! With Iron will and disciplined hands!! United under Mede, they strive to keep!!"
+        => ["Upon the realm of Tamriel, an empire stands?", "With Iron will and disciplined hands!", "United under Mede, they strive to keep!"],
+    // abbreviations - currently FAILS
+    "I've been to Daggerfall, Morrowind, Cyrodiil, and Skyrim. But I've never been to the U.S. Is it as exciting as Nirn?"
+        => ["I've been to Daggerfall, Morrowind, Cyrodiil, and Skyrim.", "But I've never been to the U.S.", "Is it as exciting as Nirn?"],
+    // ellipsis 
+    "Upon the realm of Tamriel, an empire stands... With Iron will and disciplined hands... United under Mede, they strive to keep..."
+        => ["Upon the realm of Tamriel, an empire stands...", "With Iron will and disciplined hands...", "United under Mede, they strive to keep..."],
 
-	// regular paragraph
+    // regular paragraph
     "ああ、カスティル。飲み物ならここにあるよ。何がいい？エールか、ミードか？それとも他に何か欲しいものがあるかい？食事もいかがですか？"
-		=> ["ああ、カスティル。", "飲み物ならここにあるよ。", "何がいい？ エールか、ミードか？", "それとも他に何か欲しいものがあるかい？", "食事もいかがですか？"],
-	// incomplete ending
+        => ["ああ、カスティル。", "飲み物ならここにあるよ。", "何がいい？ エールか、ミードか？", "それとも他に何か欲しいものがあるかい？", "食事もいかがですか？"],
+    // incomplete ending
     "ああ、カスティル。飲み物ならここにあるよ。何がいい？エールか、ミードか？それとも他に何か欲しいものがあるかい？食事もいかがですか？何でも"
-		=> ["ああ、カスティル。", "飲み物ならここにあるよ。", "何がいい？ エールか、ミードか？", "それとも他に何か欲しいものがあるかい？", "食事もいかがですか？", "何でも"],
-	// incomplete ending (short)
-	"あ。それで"
-		=> ["あ。それで"],
+        => ["ああ、カスティル。", "飲み物ならここにあるよ。", "何がいい？ エールか、ミードか？", "それとも他に何か欲しいものがあるかい？", "食事もいかがですか？", "何でも"],
+    // incomplete ending (short)
+    "あ。それで"
+        => ["あ。それで"],
 ];
 
 foreach ($testStrings as $input => $expected) {
@@ -143,9 +143,9 @@ foreach ($testStrings as $input => $expected) {
     if (!$pass) {
         // Show expected output on failure
         echo "<p>#EXPECTED:</p>";
-		foreach ($expected as $sentence) {
-			echo "<p>" . htmlspecialchars($sentence) . "</p>";
-		}
+        foreach ($expected as $sentence) {
+            echo "<p>" . htmlspecialchars($sentence) . "</p>";
+        }
     }
 
     echo "</div>"; // Close content div

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -99,6 +99,12 @@ function cleanResponse($rawResponse)
     );
     */
 
+	// convert to half-width numbers
+	$sentenceXX = str_replace(
+        array('１', '２', '３', '４', '５', '６', '７', '８', '９', '０'),
+        array('1', '2', '3', '4', '5', '6', '7', '8', '9', '0'),
+        $sentenceX
+    );
 
     return $sentenceX;
 }

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -99,8 +99,8 @@ function cleanResponse($rawResponse)
     );
     */
 
-	// convert to half-width numbers
-	$sentenceXX = str_replace(
+    // convert to half-width numbers (to avoid display issues with japanese font)
+    $sentenceXX = str_replace(
         array('１', '２', '３', '４', '５', '６', '７', '８', '９', '０'),
         array('1', '2', '3', '4', '5', '6', '7', '8', '9', '0'),
         $sentenceX
@@ -141,7 +141,8 @@ function split_sentences($paragraph)
     
     $paragraphNcr = br2nl($paragraph); // Some BR detected sometimes in response
     // Split the paragraph into an array of sentences using a regular expression
-    $splitSentenceRegex = "/[^\n" . preg_quote(getEndOfSentencePunctuation()) . "]+[" . preg_quote(getEndOfSentencePunctuation()) . "]/u";
+    $eosPunc = preg_quote(getEndOfSentencePunctuation());
+    $splitSentenceRegex = "/[^\n" . $eosPunc . "]+[" . $eosPunc . "]/u";
     preg_match_all($splitSentenceRegex, $paragraphNcr, $matches);
     //print_r($matches);
     $sentences = $matches[0];
@@ -239,7 +240,8 @@ function split_sentences_stream($paragraph)
         return [$paragraph];
     }
 
-    $splitSentenceRegex = "/(?<=[" . preg_quote(getEndOfSentencePunctuation()) . "])[\s+]?/u";
+    $eosPunc = preg_quote(getEndOfSentencePunctuation());
+    $splitSentenceRegex = "/(?<=[" . $eosPunc . "])[\s+]?/u";
     $sentences = preg_split($splitSentenceRegex, $paragraph, -1, PREG_SPLIT_NO_EMPTY);
 
     $splitSentences = [];

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -261,10 +261,6 @@ function split_sentences_stream($paragraph)
         $sentences[]=$paragraph;
     }
 
-    if ($paragraph) {
-        $sentences[]=$paragraph;
-    }
-
     $splitSentences = [];
     $currentSentence = '';
 

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -81,7 +81,7 @@ function cleanResponse($rawResponse)
 
     $sentences = split_sentences($toSplit);
 
-    $sentence = trim((implode(".", $sentences)));
+    $sentence = trim((implode("", $sentences)));
 
     $sentenceX = strtr(
         $sentence,
@@ -135,7 +135,8 @@ function split_sentences($paragraph)
     
     $paragraphNcr = br2nl($paragraph); // Some BR detected sometimes in response
     // Split the paragraph into an array of sentences using a regular expression
-    preg_match_all('/[^\n?.!]+[?.!]/', $paragraphNcr, $matches);
+    $splitSentenceRegex = "/[^\n" . preg_quote(getEndOfSentencePunctuation()) . "]+[" . preg_quote(getEndOfSentencePunctuation()) . "]/u";
+    preg_match_all($splitSentenceRegex, $paragraphNcr, $matches);
     //print_r($matches);
     $sentences = $matches[0];
     // Check if the last sentence is truncated (i.e., doesn't end with a period)
@@ -232,7 +233,8 @@ function split_sentences_stream($paragraph)
         return [$paragraph];
     }
 
-    $sentences = preg_split('/(?<=[.!?])\s+/', $paragraph, -1, PREG_SPLIT_NO_EMPTY);
+    $splitSentenceRegex = "/(?<=[" . preg_quote(getEndOfSentencePunctuation()) . "])[\s+]?/u";
+    $sentences = preg_split($splitSentenceRegex, $paragraph, -1, PREG_SPLIT_NO_EMPTY);
 
     $splitSentences = [];
     $currentSentence = '';
@@ -1390,5 +1392,12 @@ function prettyPrintJson($json )
     }
 
     return $result;
+}
+
+function getEndOfSentencePunctuation() {
+    $en='.?!';
+    $cjk='。？！';
+
+    return $en.$cjk;
 }
 

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -1806,7 +1806,7 @@ function createProfile($npcname,$FORCE_PARMS=[],$overwrite=false) {
 
     $codename=mb_convert_encoding($npcname, 'UTF-8', mb_detect_encoding($npcname));
     $codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-    $codename=preg_replace('/[^\w\p{L}\p{N}_+]/u', '', $codename);
+    $codename=preg_replace('/[^\w]/u', '', $codename);
 
     $cn=$db->escape("Voicetype/$codename");
     $vtype=$db->fetchAll("select value from conf_opts where id='$cn'");

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -519,8 +519,8 @@ function DataLastDataExpandedFor($actor, $lastNelements = -10,$sqlfilter="")
         $printLocation=false;
         
         $string = $row["location"];
-        preg_match('/Context\s*(new\s*)?location:\s*([^$|,]+)/', $string, $locationMatch);
-        preg_match('/Hold:\s*([^$|,]+)/', $string, $holdMatch);
+        preg_match('/Context\s*(new\s*)?location:\s*([^$,]+)/', $string, $locationMatch);
+        preg_match('/Hold:\s*([^$,]+)/', $string, $holdMatch);
         
         if (!isset($holdMatch[1])) {
             //error_log(print_r($string,true));

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -1806,7 +1806,7 @@ function createProfile($npcname,$FORCE_PARMS=[],$overwrite=false) {
 
     $codename=mb_convert_encoding($npcname, 'UTF-8', mb_detect_encoding($npcname));
     $codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-    $codename=preg_replace('/[^a-zA-Z0-9\p{Han}\p{Hiragana}\p{Katakana}\p{Cyrillic}\p{Greek}\p{Latin}\p{Arabic}_+]/u', '', $codename);
+    $codename=preg_replace('/[^\w\p{L}\p{N}_+]/u', '', $codename);
 
     $cn=$db->escape("Voicetype/$codename");
     $vtype=$db->fetchAll("select value from conf_opts where id='$cn'");

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -519,8 +519,8 @@ function DataLastDataExpandedFor($actor, $lastNelements = -10,$sqlfilter="")
         $printLocation=false;
         
         $string = $row["location"];
-        preg_match('/Context\s*(new\s*)?location:\s*([a-zA-Z\s\'\-]+)(\s*,|$)/', $string, $locationMatch);
-        preg_match('/Hold:\s*([a-zA-Z\s\'\-]+)(\s*|$)/', $string, $holdMatch);
+        preg_match('/Context\s*(new\s*)?location:\s*([^$|,]+)/', $string, $locationMatch);
+        preg_match('/Hold:\s*([^$|,]+)/', $string, $holdMatch);
         
         if (!isset($holdMatch[1])) {
             //error_log(print_r($string,true));
@@ -1804,8 +1804,9 @@ function createProfile($npcname,$FORCE_PARMS=[],$overwrite=false) {
     $path = dirname((__FILE__)) . DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR;
     $newConfFile=md5($npcname);
 
-    $codename=strtr(strtolower(trim($npcname)),[" "=>"_","'"=>"+"]);
-    $codename=preg_replace('/[^a-zA-Z0-9_+]/u', '', $codename);
+    $codename=mb_convert_encoding($npcname, 'UTF-8', mb_detect_encoding($npcname));
+    $codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
+    $codename=preg_replace('/[^a-zA-Z0-9\p{Han}\p{Hiragana}\p{Katakana}\p{Cyrillic}\p{Greek}\p{Latin}\p{Arabic}_+]/u', '', $codename);
 
     $cn=$db->escape("Voicetype/$codename");
     $vtype=$db->fetchAll("select value from conf_opts where id='$cn'");

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -122,7 +122,7 @@ function DataLastInfoFor($actor, $lastNelements = -2)
 
     foreach ($lastDialog as $n => $line) {
 
-        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\'\ ]+), 4E (\d+)/'; //extract also for months with apostrophe like Sun's Something
+        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:\w+)?(?:(?:st|nd|rd|th) of |\/)(.+), 4E (\d+)/u'; //extract also for months with apostrophe like Sun's Something
         $replacement = 'Day name: $1, Hour: $2, Day Number: $3, Month: $4, 4th Era, Year: $5';
         $result = preg_replace($pattern, $replacement, $line["content"]);
         $lastDialogFull[$n]["content"] = $result;

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -520,7 +520,7 @@ function DataLastDataExpandedFor($actor, $lastNelements = -10,$sqlfilter="")
         
         $string = $row["location"];
         preg_match('/Context\s*(new\s*)?location:\s*([^$,]+)/', $string, $locationMatch);
-        preg_match('/Hold:\s*([^$,]+)/', $string, $holdMatch);
+        preg_match('/Hold:\s*([^$,\)]+)/', $string, $holdMatch);
         
         if (!isset($holdMatch[1])) {
             //error_log(print_r($string,true));

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -1806,7 +1806,7 @@ function createProfile($npcname,$FORCE_PARMS=[],$overwrite=false) {
 
     $codename=mb_convert_encoding($npcname, 'UTF-8', mb_detect_encoding($npcname));
     $codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-    $codename=preg_replace('/[^\w]/u', '', $codename);
+    $codename=preg_replace('/[^\w+]/u', '', $codename);
 
     $cn=$db->escape("Voicetype/$codename");
     $vtype=$db->fetchAll("select value from conf_opts where id='$cn'");

--- a/main.php
+++ b/main.php
@@ -550,7 +550,7 @@ if ($GLOBALS["FUNCTIONS_ARE_ENABLED"]) {
 
         $TEST_TEXT=strtr($TEST_TEXT,["."=>" ","{$GLOBALS["PLAYER_NAME"]}:"=>""]);
         $command=file_get_contents("http://127.0.0.1:8082/command?text=".urlencode($TEST_TEXT));
-        if ($command) {
+        if ($command && is_valid_json($command)) {
             $preCommand=json_decode($command,true);
             if ($preCommand["is_command"]!="Talk") {
                 $GLOBALS["db"]->insert(

--- a/main.php
+++ b/main.php
@@ -550,7 +550,7 @@ if ($GLOBALS["FUNCTIONS_ARE_ENABLED"]) {
 
         $TEST_TEXT=strtr($TEST_TEXT,["."=>" ","{$GLOBALS["PLAYER_NAME"]}:"=>""]);
         $command=file_get_contents("http://127.0.0.1:8082/command?text=".urlencode($TEST_TEXT));
-        if ($command && is_valid_json($command)) {
+        if ($command && $command !== "null") {
             $preCommand=json_decode($command,true);
             if ($preCommand["is_command"]!="Talk") {
                 $GLOBALS["db"]->insert(

--- a/tts/tts-xtts-fastapi.php
+++ b/tts/tts-xtts-fastapi.php
@@ -140,9 +140,9 @@ $GLOBALS["TTS_IN_USE"]=function($textString, $mood , $stringforhash) {
 			error_log("Error occurred.".__FILE__);
 			
 			// Lets try to use standard scheme:
-			$codename = str_replace(" ", "_", mb_strtolower($GLOBALS["HERIKA_NAME"], 'UTF-8'));
-			$codename = str_replace("'", "+", $codename);
-			$codename=preg_replace('/[^a-zA-Z0-9_+]/u', '', $codename);
+            $codename=mb_convert_encoding($GLOBALS["HERIKA_NAME"], 'UTF-8', mb_detect_encoding($GLOBALS["HERIKA_NAME"]));
+            $codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
+            $codename=preg_replace('/[^a-zA-Z0-9\p{Han}\p{Hiragana}\p{Katakana}\p{Cyrillic}\p{Greek}\p{Latin}\p{Arabic}_+]/u', '', $codename);
 			
 			$data = array(
 				'text' => $newString,

--- a/tts/tts-xtts-fastapi.php
+++ b/tts/tts-xtts-fastapi.php
@@ -142,7 +142,7 @@ $GLOBALS["TTS_IN_USE"]=function($textString, $mood , $stringforhash) {
 			// Lets try to use standard scheme:
 			$codename=mb_convert_encoding($GLOBALS["HERIKA_NAME"], 'UTF-8', mb_detect_encoding($GLOBALS["HERIKA_NAME"]));
 			$codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-			$codename=preg_replace('/[^\w\p{L}\p{N}_+]/u', '', $codename);
+			$codename=preg_replace('/[^\w]/u', '', $codename);
 			
 			$data = array(
 				'text' => $newString,

--- a/tts/tts-xtts-fastapi.php
+++ b/tts/tts-xtts-fastapi.php
@@ -72,7 +72,43 @@ function xtts_fastapi_settings($settings) {
 	}
 }
 
+// convert numbers into Japanese kanji
+function num2kan_decimal($instr) {
+    // Check if the input is exactly 0. Return katakana zero in that case.
+    if ($instr === '0') {
+        return 'ゼロ';
+    }
 
+	static $kantbl1 = array(0=>'', 1=>'一', 2=>'二', 3=>'三', 4=>'四', 5=>'五', 6=>'六', 7=>'七', 8=>'八', 9=>'九', '.'=>'．', '-'=>'－');
+	static $kantbl2 = array(0=>'', 1=>'十', 2=>'百', 3=>'千');
+	static $kantbl3 = array(0=>'', 1=>'万', 2=>'億', 3=>'兆', 4=>'京');
+
+	$outstr = '';
+	$len = strlen($instr);
+	$m = (int)($len / 4);
+	//repeat for each grouping of numbers (single digits, ten thousands, etc)
+	for ($i = 0; $i <= $m; $i++) {
+		$s2 = '';
+		//repeat for each grouping of numbers inside a larger grouping (single digits, tens, hundreds, thousands)
+		for ($j = 0; $j < 4; $j++) {
+			$pos = $len - $i * 4 - $j - 1;
+			if ($pos >= 0) {
+				$ch  = substr($instr, $pos, 1);
+				if ($ch == ',') continue;       //ignore commas
+				$ch1 = isset($kantbl1[$ch]) ? $kantbl1[$ch] : '';
+				$ch2 = isset($kantbl2[$j])  ? $kantbl2[$j]  : '';
+				// handle case when leading one is present (10 should be 十 and not 一十)
+				if ($ch1 != '') {
+					if ($ch1 == '一' && $ch2 != '') $s2 = $ch2 . $s2;
+					else                                $s2 = $ch1 . $ch2 . $s2;
+				}
+			}
+		}
+		if ($s2 != '')  $outstr = $s2 . $kantbl3[$i] . $outstr;
+	}
+
+	return $outstr;
+}
 
 
 $GLOBALS["TTS_IN_USE"]=function($textString, $mood , $stringforhash) {
@@ -109,6 +145,18 @@ $GLOBALS["TTS_IN_USE"]=function($textString, $mood , $stringforhash) {
 
 		if (empty($lang))
 			$lang=$GLOBALS["TTS"]["XTTSFASTAPI"]["language"];
+
+		// xtts has trouble reading numbers when lang is Japanese
+		// PATCH it by converting numbers into kanji, which it can read
+		if ($lang == 'ja') {
+			$callback=function ($matches) {
+				return num2kan_decimal($matches[0]);
+			};
+			// remove commas between digits
+			$newString = preg_replace('/(?<=\d),(?=\d)/', '', $newString);
+			// replace numbers with kanji
+			$newString=preg_replace_callback('/\d+/', $callback, $newString);
+		}
 	
 	
 		$voice=isset($GLOBALS["TTS"]["FORCED_VOICE_DEV"])?$GLOBALS["TTS"]["FORCED_VOICE_DEV"]:$GLOBALS["TTS"]["XTTSFASTAPI"]["voiceid"];
@@ -140,9 +188,9 @@ $GLOBALS["TTS_IN_USE"]=function($textString, $mood , $stringforhash) {
 			error_log("Error occurred.".__FILE__);
 			
 			// Lets try to use standard scheme:
-			$codename=mb_convert_encoding($GLOBALS["HERIKA_NAME"], 'UTF-8', mb_detect_encoding($GLOBALS["HERIKA_NAME"]));
-			$codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-			$codename=preg_replace('/[^\w+]/u', '', $codename);
+			$codename = str_replace(" ", "_", mb_strtolower($GLOBALS["HERIKA_NAME"], 'UTF-8'));
+			$codename = str_replace("'", "+", $codename);
+			$codename=preg_replace('/[^a-zA-Z0-9_+]/u', '', $codename);
 			
 			$data = array(
 				'text' => $newString,

--- a/tts/tts-xtts-fastapi.php
+++ b/tts/tts-xtts-fastapi.php
@@ -142,7 +142,7 @@ $GLOBALS["TTS_IN_USE"]=function($textString, $mood , $stringforhash) {
 			// Lets try to use standard scheme:
 			$codename=mb_convert_encoding($GLOBALS["HERIKA_NAME"], 'UTF-8', mb_detect_encoding($GLOBALS["HERIKA_NAME"]));
 			$codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-			$codename=preg_replace('/[^a-zA-Z0-9\p{Han}\p{Hiragana}\p{Katakana}\p{Cyrillic}\p{Greek}\p{Latin}\p{Arabic}_+]/u', '', $codename);
+			$codename=preg_replace('/[^\w\p{L}\p{N}_+]/u', '', $codename);
 			
 			$data = array(
 				'text' => $newString,

--- a/tts/tts-xtts-fastapi.php
+++ b/tts/tts-xtts-fastapi.php
@@ -140,9 +140,9 @@ $GLOBALS["TTS_IN_USE"]=function($textString, $mood , $stringforhash) {
 			error_log("Error occurred.".__FILE__);
 			
 			// Lets try to use standard scheme:
-            $codename=mb_convert_encoding($GLOBALS["HERIKA_NAME"], 'UTF-8', mb_detect_encoding($GLOBALS["HERIKA_NAME"]));
-            $codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-            $codename=preg_replace('/[^a-zA-Z0-9\p{Han}\p{Hiragana}\p{Katakana}\p{Cyrillic}\p{Greek}\p{Latin}\p{Arabic}_+]/u', '', $codename);
+			$codename=mb_convert_encoding($GLOBALS["HERIKA_NAME"], 'UTF-8', mb_detect_encoding($GLOBALS["HERIKA_NAME"]));
+			$codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
+			$codename=preg_replace('/[^a-zA-Z0-9\p{Han}\p{Hiragana}\p{Katakana}\p{Cyrillic}\p{Greek}\p{Latin}\p{Arabic}_+]/u', '', $codename);
 			
 			$data = array(
 				'text' => $newString,

--- a/tts/tts-xtts-fastapi.php
+++ b/tts/tts-xtts-fastapi.php
@@ -142,7 +142,7 @@ $GLOBALS["TTS_IN_USE"]=function($textString, $mood , $stringforhash) {
 			// Lets try to use standard scheme:
 			$codename=mb_convert_encoding($GLOBALS["HERIKA_NAME"], 'UTF-8', mb_detect_encoding($GLOBALS["HERIKA_NAME"]));
 			$codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-			$codename=preg_replace('/[^\w]/u', '', $codename);
+			$codename=preg_replace('/[^\w+]/u', '', $codename);
 			
 			$data = array(
 				'text' => $newString,

--- a/ui/npc_upload.php
+++ b/ui/npc_upload.php
@@ -116,6 +116,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['submit_csv'])) {
         $fileExtension = pathinfo($fileName, PATHINFO_EXTENSION);
 
         if (in_array($fileExtension, $allowedfileExtensions)) {
+            // Get file encoding
+            $encoding = mb_detect_encoding(file_get_contents($fileTmpPath), 'UTF-8', true);
+
             // Open the file for reading
             if (($handle = fopen($fileTmpPath, 'r')) !== false) {
                 // Skip the header row
@@ -135,21 +138,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['submit_csv'])) {
                     $xtts_voiceid = (isset($data[4]) && trim($data[4]) !== '') ? trim($data[4]) : null;
                     $xvasynth_voiceid = (isset($data[5]) && trim($data[5]) !== '') ? trim($data[5]) : null;
 
-                    // Convert to UTF-8 to avoid invalid byte sequences
-                    $npc_name = iconv('Windows-1252', 'UTF-8//IGNORE', $npc_name);
-                    $npc_pers = iconv('Windows-1252', 'UTF-8//IGNORE', $npc_pers);
-                    $npc_misc = iconv('Windows-1252', 'UTF-8//IGNORE', $npc_misc);
+                    // Convert to UTF-8 to avoid invalid byte sequences, if not already UTF-8
+                    if ($encoding !== 'UTF-8') {
+                        $npc_name = iconv('Windows-1252', 'UTF-8//IGNORE', $npc_name);
+                        $npc_pers = iconv('Windows-1252', 'UTF-8//IGNORE', $npc_pers);
+                        $npc_misc = iconv('Windows-1252', 'UTF-8//IGNORE', $npc_misc);
 
-                    if ($melotts_voiceid !== null) {
-                        $melotts_voiceid = iconv('Windows-1252', 'UTF-8//IGNORE', $melotts_voiceid);
-                    }
+                        if ($melotts_voiceid !== null) {
+                            $melotts_voiceid = iconv('Windows-1252', 'UTF-8//IGNORE', $melotts_voiceid);
+                        }
 
-                    if ($xtts_voiceid !== null) {
-                        $xtts_voiceid = iconv('Windows-1252', 'UTF-8//IGNORE', $xtts_voiceid);
-                    }
+                        if ($xtts_voiceid !== null) {
+                            $xtts_voiceid = iconv('Windows-1252', 'UTF-8//IGNORE', $xtts_voiceid);
+                        }
 
-                    if ($xvasynth_voiceid !== null) {
-                        $xvasynth_voiceid = iconv('Windows-1252', 'UTF-8//IGNORE', $xvasynth_voiceid);
+                        if ($xvasynth_voiceid !== null) {
+                            $xvasynth_voiceid = iconv('Windows-1252', 'UTF-8//IGNORE', $xvasynth_voiceid);
+                        }
                     }
 
                     if (!empty($npc_name) && !empty($npc_pers)) {

--- a/ui/tests.php
+++ b/ui/tests.php
@@ -227,7 +227,9 @@ if (!isset($GLOBALS["CURRENT_CONNECTOR"]) || !file_exists($enginePath . "connect
     }
 
     print_r($GLOBALS["DEBUG_DATA"]);
-    print_r($GLOBALS["ALREADY_SENT_BUFFER"]); 
+    if (isset($GLOBALS["ALREADY_SENT_BUFFER"])) {
+        print_r($GLOBALS["ALREADY_SENT_BUFFER"]);
+    }
 }
 
 echo '</pre>';

--- a/vsx.php
+++ b/vsx.php
@@ -15,7 +15,7 @@ require_once($path . "lib" .DIRECTORY_SEPARATOR."auditing.php");
 $db=new sql();
 $codename=mb_convert_encoding($_GET["codename"], 'UTF-8', mb_detect_encoding($_GET["codename"]));
 $codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-$codename=preg_replace('/[^a-zA-Z0-9\p{Han}\p{Hiragana}\p{Katakana}\p{Cyrillic}\p{Greek}\p{Latin}\p{Arabic}_+]/u', '', $codename);
+$codename=preg_replace('/[^\w\p{L}\p{N}_+]/u', '', $codename);
 
     
 $db->delete("conf_opts", "id='".$db->escape("Voicetype/$codename")."'");

--- a/vsx.php
+++ b/vsx.php
@@ -15,7 +15,7 @@ require_once($path . "lib" .DIRECTORY_SEPARATOR."auditing.php");
 $db=new sql();
 $codename=mb_convert_encoding($_GET["codename"], 'UTF-8', mb_detect_encoding($_GET["codename"]));
 $codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-$codename=preg_replace('/[^\w\p{L}\p{N}_+]/u', '', $codename);
+$codename=preg_replace('/[^\w]/u', '', $codename);
 
     
 $db->delete("conf_opts", "id='".$db->escape("Voicetype/$codename")."'");

--- a/vsx.php
+++ b/vsx.php
@@ -13,9 +13,9 @@ require_once($path . "lib" .DIRECTORY_SEPARATOR."auditing.php");
 
 // Put info into DB asap
 $db=new sql();
-$codename = str_replace(" ", "_", mb_strtolower($_GET["codename"], 'UTF-8'));
-$codename = str_replace("'", "+", $codename);
-$codename=preg_replace('/[^a-zA-Z0-9_+]/u', '', $codename);
+$codename=mb_convert_encoding($_GET["codename"], 'UTF-8', mb_detect_encoding($_GET["codename"]));
+$codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
+$codename=preg_replace('/[^a-zA-Z0-9\p{Han}\p{Hiragana}\p{Katakana}\p{Cyrillic}\p{Greek}\p{Latin}\p{Arabic}_+]/u', '', $codename);
 
     
 $db->delete("conf_opts", "id='".$db->escape("Voicetype/$codename")."'");

--- a/vsx.php
+++ b/vsx.php
@@ -15,7 +15,7 @@ require_once($path . "lib" .DIRECTORY_SEPARATOR."auditing.php");
 $db=new sql();
 $codename=mb_convert_encoding($_GET["codename"], 'UTF-8', mb_detect_encoding($_GET["codename"]));
 $codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-$codename=preg_replace('/[^\w]/u', '', $codename);
+$codename=preg_replace('/[^\w+]/u', '', $codename);
 
     
 $db->delete("conf_opts", "id='".$db->escape("Voicetype/$codename")."'");


### PR DESCRIPTION
Adds several fixes for multilingual support (in particular Japanese).

1. Fixed activating NPCs with non-alphanumeric names. Their xtts voice id will be set properly, and a voice file of that name will be generated. Special characters are still removed.
2. conf_opts db will be populated correctly for non-alphanumeric names (it was blank before)
3. Works for player TTS as well.
4. Changes several regex statements in chat_helper_functions.php to match against UTF-8 \p{L} (non-special characters from all languages) rather than just a-z.
5. Fixed uploading npc bio csv files with multi-byte contents (it was previously uploading garbled text to the database).
6. Added a test file called debug\sentence_split_test.php to verify several patterns in English and Japanese. Only one pattern (abbreviations like U.S.) doesn't pass, but that doesn't work even without this PR. Some other patterns that were previously failing are now fixed.
7. Added a patch to xtts to get it to read numbers when the language is japanese