### PR TITLE
insert memory as second-to-last entry in context

### DIFF
--- a/main.php
+++ b/main.php
@@ -646,7 +646,10 @@ if ($gameRequest[0] == "funcret") {
     if (in_array($GLOBALS["CURRENT_CONNECTOR"],["koboldcpp","openai","google_openai","openrouter"])) {  // OLD SCHEMA
         if (!empty($request)) {
             if (sizeof($memoryInjectionCtx)>0) {
-                $prompt[] = $memoryInjectionCtx;
+                if (!isset($prompt)) {
+                    $prompt=[];
+                }
+                array_splice($prompt, -1, 0, $memoryInjectionCtx); // add memory as second-to-last entry
                 error_log("Injected memory");
             }
             $FUNCTIONS_ARE_ENABLED=false;
@@ -667,7 +670,7 @@ if ($gameRequest[0] == "funcret") {
         if (!empty($request)) {
             $prompt[] = array('role' => $LAST_ROLE, 'content' => $request);
             if (sizeof($memoryInjectionCtx)>0) {
-                $prompt[] = $memoryInjectionCtx;
+                array_splice($prompt, -1, 0, $memoryInjectionCtx); // add memory as second-to-last entry
                 error_log("Injected memory");
             }
             


### PR DESCRIPTION
Inserts memories as the second-to-last entry in context rather than as the last entry.
This is to avoid koboldcpp making the memory the instruction in its prompt template (llama3, etc) files, since those look for the last entry in context to be the instruction.