### PR TITLE
fix: after last update QUEST_COMMENT setting is ignored

### DIFF
--- a/processor/comm.php
+++ b/processor/comm.php
@@ -330,9 +330,13 @@ if ($gameRequest[0] == "init") { // Reset responses if init sent (Think about th
         }
     } else
         $MUST_END=true;
-    
+    /*
     if (isset($GLOBALS["FEATURES"]["MISC"]["QUEST_COMMENT"]))
         if ($GLOBALS["FEATURES"]["MISC"]["QUEST_COMMENT"]===false)
+            $MUST_END=true;
+    */
+    if (isset($GLOBALS["QUEST_COMMENT"])) 
+        if ($GLOBALS["QUEST_COMMENT"]===false)
             $MUST_END=true;
 
 } elseif ($gameRequest[0] == "location") {


### PR DESCRIPTION
file: comm.php
QUEST_COMMENT was moved from FEATURES MISC on last update. Code modified to reflect last update on web interface, QUEST_COMMENT is now accessible trough $GLOBALS["QUEST_COMMENT"]. Left the old code in comment if the change is not final.