### PR TITLE
fix copy/paste error with response template descriptions

### DIFF
--- a/functions/json_response.php
+++ b/functions/json_response.php
@@ -77,9 +77,9 @@
                     "listener"=>"specify who {$GLOBALS["HERIKA_NAME"]} is talking to",
                     "mood"=>implode("|",$moods),
                     "action"=>implode("|",$GLOBALS["FUNC_LIST"]),
-                    "target"=>"action's target",
+                    "target"=>"action's target|destination name",
                     "lang"=>"en|es",
-                    "message"=>"action's target|destination name",
+                    "message"=>"lines of dialogue",
                 ];
             } else {
                 $GLOBALS["responseTemplate"] = [
@@ -87,8 +87,8 @@
                     "listener"=>"specify who {$GLOBALS["HERIKA_NAME"]} is talking to",
                     "mood"=>implode("|",$moods),
                     "action"=>implode("|",$GLOBALS["FUNC_LIST"]),
-                    "target"=>"action's target",
-                    "message"=>"action's target|destination name",
+                    "target"=>"action's target|destination name",
+                    "message"=>"lines of dialogue",
                 ];
             }
         }


### PR DESCRIPTION
in one branch of json_response.php, the message json has the wrong description (copy/paste error). Fixed it to use the correct "lines of dialogue" description instead.