### PR TITLE
fix undefined llamacpp vision cue in prompts.php

### DIFF
--- a/conf/conf.sample.php
+++ b/conf/conf.sample.php
@@ -289,10 +289,10 @@ $ITT["google_openai"]["AI_PROMPT"]='#HERIKA_NPC1# describes what they are seeing
 $ITT["AZURE"]["ENDPOINT"]=""; //API endpoint.
 $ITT["AZURE"]["API_KEY"]=""; //API key.
 //Llama
-$ITT["LLAMACPP"]["URL"]="http://127.0.0.1:8007"; //Server endpoint.		
-$ITT["LLAMACPP"]["AI_VISION_PROMPT"]="USER:Context, roleplay In Skyrim universe, #HERIKA_NPC1# watchs this scene:[img-1]. "
+$ITT["llamacpp"]["URL"]="http://127.0.0.1:8007"; //Server endpoint.		
+$ITT["llamacpp"]["AI_VISION_PROMPT"]="USER:Context, roleplay In Skyrim universe, #HERIKA_NPC1# watchs this scene:[img-1]. "
     . "Describe the vision while keeping roleplay. Describe COLORS and SHAPES";	//Prompt to sent to the Vision AI.
-$ITT["LLAMACPP"]["AI_PROMPT"]=''; //Prompt sent to the LLM.
+$ITT["llamacpp"]["AI_PROMPT"]=''; //Prompt sent to the LLM.
 
 //[Memory Configuration]
 //Memory Settings

--- a/conf/conf_schema.json
+++ b/conf/conf_schema.json
@@ -286,7 +286,7 @@
       "AI_VISION_PROMPT": {"type":"longstring","description":"Prompt to send to the OpenAI vision model.","scope":"global"},
       "AI_PROMPT": {"type":"longstring","description":"Prompt for the AI NPC to follow when describing the scene."}
     },
-    "LLAMACPP": {
+    "llamacpp": {
       "_title":"LLama Server (Installed in DwemerDistro)",
       "URL": {"type":"url","description":"URL of the llama.cpp server","helpurl":"https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md","scope":"global"},
       "AI_VISION_PROMPT": {"type":"longstring","description":"Prompt to send to the llama vision model.","scope":"global"},

--- a/itt/itt-llamacpp.php
+++ b/itt/itt-llamacpp.php
@@ -14,7 +14,7 @@ function itt($file,$hints)
 
     // Define the POST data as an associative array
     $postData = [
-        'prompt' => strtr("{$GLOBALS["ITT"]["LLAMACPP"]["AI_VISION_PROMPT"]}.Hints: $hints. \nASSISTANT:",["#HERIKA_NPC1#"=>$GLOBALS["HERIKA_NAME"]]),
+        'prompt' => strtr("{$GLOBALS["ITT"]["llamacpp"]["AI_VISION_PROMPT"]}.Hints: $hints. \nASSISTANT:",["#HERIKA_NPC1#"=>$GLOBALS["HERIKA_NAME"]]),
         'n_predict' => 256,
         'image_data' => [["data"=>$base64Encoded,"id"=>1]],
         'ignore_eos' => false,
@@ -42,7 +42,7 @@ function itt($file,$hints)
     ]);
 
     // Specify the URL
-    $url = $GLOBALS["ITT"]["LLAMACPP"]["URL"]."/completion";
+    $url = $GLOBALS["ITT"]["llamacpp"]["URL"]."/completion";
 
     // Perform the HTTP POST request
     $responseRaw = file_get_contents($url, false, $context);


### PR DESCRIPTION
closes #60 

Fixes llamacpp vision cue in prompts.php by changing ITT["LLAMACPP"] to the lowercase ITT["llamacpp"].
This change requires players using llamacpp for vision to save their config once; that should reflect the change to their conf.php.