### PR TITLE
Improve connector error handling

### DIFF
--- a/connector/google_openaijson.php
+++ b/connector/google_openaijson.php
@@ -281,7 +281,8 @@ class connector
                 'method' => 'POST',
                 'header' => implode("\r\n", $headers),
                 'content' => json_encode($data),
-                'timeout' => ($GLOBALS["HTTP_TIMEOUT"]) ?: 30
+                'timeout' => ($GLOBALS["HTTP_TIMEOUT"]) ?: 30,
+                "ignore_errors" => true
             )
         );
 
@@ -289,28 +290,52 @@ class connector
         
         $this->primary_handler = fopen($url, 'r', false, $context);
         if (!$this->primary_handler) {
-                $error=error_get_last();
-                error_log(print_r($error,true));
+            $error=error_get_last();
+            error_log(print_r($error,true));
+
+            if ($GLOBALS["db"]) {
+                $GLOBALS["db"]->insert(
+                'audit_request',
+                    array(
+                        'request' => json_encode($data),
+                        'result' => $error["message"]
+                    ));
+            }
+            return null;
+        } else {
+            // Get HTTP response code
+            $response_info = stream_get_meta_data($this->primary_handler);
+            $status_line = $response_info['wrapper_data'][0];
+            preg_match('/\d{3}/', $status_line, $matches); // get three digits (200, 300, 404, etc)
+            $status_code = isset($matches[0]) ? intval($matches[0]) : null;
+
+            if ($status_code >= 300) {
+                $response = stream_get_contents($this->primary_handler);
+                $error_message = "Request to google_openaijson connector failed: {$status_line}.\nResponse body: {$response}";
+                trigger_error($error_message, E_USER_WARNING);
 
                 if ($GLOBALS["db"]) {
                     $GLOBALS["db"]->insert(
                     'audit_request',
                         array(
                             'request' => json_encode($data),
-                            'result' => $error["message"]
+                            'result' => $error_message
                         ));
                 }
-                return null;
-        } else  {
-            if ($GLOBALS["db"]) {
-                $GLOBALS["db"]->insert(
-                 'audit_request',
-                 array(
-                    'request' => json_encode($data),
-                    'result' => "Ok"
-                ));
-            }
 
+                $this->close();
+                $this->primary_handler=false;
+                return null;
+            } else  {
+                if ($GLOBALS["db"]) {
+                    $GLOBALS["db"]->insert(
+                    'audit_request',
+                    array(
+                        'request' => json_encode($data),
+                        'result' => "Ok"
+                    ));
+                }
+            }
         }
 
 
@@ -329,7 +354,11 @@ class connector
 
         static $numOutputTokens=0;
 
-        $line = fgets($this->primary_handler);
+        if (!$this->primary_handler) {
+            $line = "";
+        } else {
+            $line = fgets($this->primary_handler);
+        }
         $buffer="";
         $totalBuffer="";
         $finalData="";
@@ -393,9 +422,9 @@ class connector
     // Method to close the data processing operation
     public function close()
     {
-
-        fclose($this->primary_handler);
-        
+        if ($this->primary_handler) {
+            fclose($this->primary_handler);
+        }
         
         //file_put_contents(__DIR__."/../log/ouput_from_llm.log",$this->_buffer, FILE_APPEND | LOCK_EX);
         file_put_contents(__DIR__."/../log/output_from_llm.log",date(DATE_ATOM)."\n=\n".$this->_buffer."\n=\n", FILE_APPEND);
@@ -470,7 +499,7 @@ class connector
 
     public function isDone()
     {
-        return feof($this->primary_handler);
+        return !$this->primary_handler || feof($this->primary_handler);
     }
 
 }

--- a/connector/openrouterjson.php
+++ b/connector/openrouterjson.php
@@ -349,7 +349,8 @@ class connector
                 'method' => 'POST',
                 'header' => implode("\r\n", $headers),
                 'content' => json_encode($data),
-                'timeout' => 30
+                'timeout' => 30,
+                "ignore_errors" => true
             )
         );
 
@@ -369,17 +370,40 @@ class connector
                     ));
             }
             return null;
-                
-        } else  {
-            if ($GLOBALS["db"]) {
-                $GLOBALS["db"]->insert(
-                 'audit_request',
-                 array(
-                    'request' => json_encode($data),
-                    'result' => "Ok"
-                ));
-            }
+        } else {
+            // Get HTTP response code
+            $response_info = stream_get_meta_data($this->primary_handler);
+            $status_line = $response_info['wrapper_data'][0];
+            preg_match('/\d{3}/', $status_line, $matches); // get three digits (200, 300, 404, etc)
+            $status_code = isset($matches[0]) ? intval($matches[0]) : null;
 
+            if ($status_code >= 300) {
+                $response = stream_get_contents($this->primary_handler);
+                $error_message = "Request to openrouterjson connector failed: {$status_line}.\nResponse body: {$response}";
+                trigger_error($error_message, E_USER_WARNING);
+
+                if ($GLOBALS["db"]) {
+                    $GLOBALS["db"]->insert(
+                    'audit_request',
+                        array(
+                            'request' => json_encode($data),
+                            'result' => $error_message
+                        ));
+                }
+
+                $this->close();
+                $this->primary_handler=false;
+                return null;
+            } else  {
+                if ($GLOBALS["db"]) {
+                    $GLOBALS["db"]->insert(
+                    'audit_request',
+                    array(
+                        'request' => json_encode($data),
+                        'result' => "Ok"
+                    ));
+                }
+            }
         }
 
         $this->_dataSent=json_encode($data);    // Will use this data in tokenizer.
@@ -496,8 +520,9 @@ class connector
     // Method to close the data processing operation
     public function close()
     {
-
-        fclose($this->primary_handler);
+        if ($this->primary_handler) {
+            fclose($this->primary_handler);
+        }
         
         if (($this->_buffer==null) || (empty(trim($this->_buffer))) ) {
 
@@ -598,7 +623,7 @@ class connector
     {
         if ($this->_forcedClose)
             return true;
-        return feof($this->primary_handler);
+        return !$this->primary_handler || feof($this->primary_handler);
     }
 
 }

--- a/connector/openrouterjson.php
+++ b/connector/openrouterjson.php
@@ -426,7 +426,7 @@ class connector
             $GLOBALS["patch_openrouter_timeout"]=time();
 
         if ($this->isDone()) {//  Didn't output anything?
-            if (empty(trim($this->_buffer))) {
+            if (!$this->_buffer || empty(trim($this->_buffer))) {
                 $line="";    
                 error_log("LLM didn't output anything");
             }


### PR DESCRIPTION
Improves error handling for the json connectors.

1. Use "ignore_errors" in the stream context to allow capturing a failed call's response body text.
2. Check for an error status code in the response. If found, log both the status header and the response body, since the AI providers usually give detailed error information in the body ("your api key has expired" etc).
3. Use trigger_error to throw a warning with the error. This allows it to be seen in the LLM Connection Test without halting execution, and it also adds the warning to the error log.
4. Closes the connection after an error and sets primary_handler to false. This is the trigger for main.php to reply with "didn't hear you, can you repeat."
5. Added checks in close(), process(), and isDone() for a null or false primary_handler to avoid errors.