### PR TITLE
fixed codename regex to include "-" symbol

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -1,6 +1,6 @@
 <?php
 
-
+require_once("utils.php");
 
 // used for openai_token_count table
 
@@ -1804,10 +1804,8 @@ function createProfile($npcname,$FORCE_PARMS=[],$overwrite=false) {
     $path = dirname((__FILE__)) . DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR;
     $newConfFile=md5($npcname);
 
-    $codename=mb_convert_encoding($npcname, 'UTF-8', mb_detect_encoding($npcname));
-    $codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-    $codename=preg_replace('/[^\w+]/u', '', $codename);
-
+    $codename = npcNameToCodename($npcname);
+    
     $cn=$db->escape("Voicetype/$codename");
     $vtype=$db->fetchAll("select value from conf_opts where id='$cn'");
     $voicetypeString=(isOk($vtype))?$vtype[0]["value"]:null;

--- a/lib/utils.php
+++ b/lib/utils.php
@@ -1,0 +1,10 @@
+<?php
+
+function npcNameToCodename($npcName) {
+    $codename=mb_convert_encoding($npcName, 'UTF-8', mb_detect_encoding($npcName));
+    $codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
+    $codename=preg_replace('/[^\w+-]/u', '', $codename);
+    return $codename;
+}
+
+?>

--- a/vsx.php
+++ b/vsx.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once("lib/utils.php");
 
 /* Voice Sample Extractor */
 
@@ -13,9 +14,7 @@ require_once($path . "lib" .DIRECTORY_SEPARATOR."auditing.php");
 
 // Put info into DB asap
 $db=new sql();
-$codename=mb_convert_encoding($_GET["codename"], 'UTF-8', mb_detect_encoding($_GET["codename"]));
-$codename=strtr(strtolower(trim($codename)),[" "=>"_","'"=>"+"]);
-$codename=preg_replace('/[^\w+]/u', '', $codename);
+$codename = npcNameToCodename($_GET["codename"]);
 
     
 $db->delete("conf_opts", "id='".$db->escape("Voicetype/$codename")."'");


### PR DESCRIPTION
Everywhere in tables `npc_name` includes dashes `-`. After recent changes it was skipping dashes from npc name. For example `Lynly Star-Sung` -> `lynly_starsung`, when in it should be `lynly_star-sung`
![Screenshot 2025-01-11 195352](https://github.com/user-attachments/assets/0d16d304-f043-45a2-b3c2-bb256efcfe04)

I fixed regex and now it will work properly for new profiles. Not sure if we need any kind of fix for people who already got `HERIKA_PERS` "empty", like `Roleplay as Lynly Star-Sung` and that's it(because it couldn't pull correct personality from db).

I also added new utils file for some smaller re-usable functionality like codename, so it's easy to fix in one place.