### PR TITLE
use var_export instead of print_r

### DIFF
--- a/connector/google_openaijson.php
+++ b/connector/google_openaijson.php
@@ -269,7 +269,7 @@ class connector
 
         $GLOBALS["DEBUG_DATA"]["full"]=($data);
 
-        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".print_r($data,true)."=\n", FILE_APPEND);
+        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".var_export($data,true)."\n=\n", FILE_APPEND);
 
         $headers = array(
             'Content-Type: application/json',

--- a/connector/koboldcppjson.php
+++ b/connector/koboldcppjson.php
@@ -260,7 +260,7 @@ class connector
         $request .= $dataJson;
 
         // Open a TCP connection
-        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".print_r($postData,true)."=\n", FILE_APPEND);
+        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".var_export($postData,true)."\n=\n", FILE_APPEND);
 
                 
         //$this->primary_handler = fsockopen('tcp://' . $host, $port, $errno, $errstr, 30);

--- a/connector/openai.php
+++ b/connector/openai.php
@@ -231,7 +231,7 @@ class connector
 
         $context = stream_context_create($options);
 
-        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".print_r($data,true)."=\n", FILE_APPEND);
+        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".var_export($data,true)."\n=\n", FILE_APPEND);
 
                 
         $this->primary_handler = fopen($url, 'r', false, $context);

--- a/connector/openaijson.php
+++ b/connector/openaijson.php
@@ -278,7 +278,7 @@ class connector
 
         $GLOBALS["DEBUG_DATA"]["full"]=($data);
 
-        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".print_r($data,true)."=\n", FILE_APPEND);
+        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".var_export($data,true)."\n=\n", FILE_APPEND);
 
         $headers = array(
             'Content-Type: application/json',

--- a/connector/openrouter.php
+++ b/connector/openrouter.php
@@ -125,7 +125,7 @@ class connector
 
         $context = stream_context_create($options);
         
-        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".print_r($data,true)."=\n", FILE_APPEND);
+        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".var_export($data,true)."\n=\n", FILE_APPEND);
 
         $this->primary_handler = fopen($url, 'r', false, $context);
 

--- a/connector/openrouterjson.php
+++ b/connector/openrouterjson.php
@@ -335,7 +335,7 @@ class connector
 
         $GLOBALS["DEBUG_DATA"]["full"]=($data);
 
-        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".print_r($data,true)."=\n", FILE_APPEND);
+        file_put_contents(__DIR__."/../log/context_sent_to_llm.log",date(DATE_ATOM)."\n=\n".var_export($data,true)."\n=\n", FILE_APPEND);
 
         $headers = array(
             'Content-Type: application/json',

--- a/connector/web_connector.php
+++ b/connector/web_connector.php
@@ -103,7 +103,7 @@ class connector
         $GLOBALS["DEBUG_DATA"]["full"] = ($data);
 
         file_put_contents(__DIR__."/../log/context_sent_to_llm.log",
-            date(DATE_ATOM)."\n=\n".print_r($data,true)."=\n",
+            date(DATE_ATOM)."\n=\n".var_export($data,true)."\n=\n",
             FILE_APPEND
         );
 

--- a/debug/convert_log_to_csv.php
+++ b/debug/convert_log_to_csv.php
@@ -28,7 +28,6 @@ function parse_log_to_csv($log_file, $csv_file) {
                 if (is_array($object)) {
                     $json_string = json_encode($object, JSON_PRETTY_PRINT);
                     if ($json_string === false) {
-                        error_log("JSON encoding error for object: " . var_export($object, true));
                         $json_string = "JSON Encoding Error"; // Or handle the error differently
                     }
                     $csv_data[] = ["prompt" => $json_string];

--- a/debug/convert_log_to_csv.php
+++ b/debug/convert_log_to_csv.php
@@ -1,0 +1,64 @@
+<?php
+
+function parse_log_to_csv($log_file, $csv_file) {
+    $log_content = file_get_contents($log_file);
+    if ($log_content === false) {
+        die("Error reading log file: " . $log_file);
+    }
+
+    $entries = preg_split("/\n(?=\d{4}-\d{2}-\d{2}T)/", $log_content); // Split by timestamps
+    $csv_data = [];
+
+    foreach ($entries as $entry) {
+        $lines = explode("\n", trim($entry));
+        if (count($lines) > 1 && strpos($lines[1], "=") === 0) { // Check if it's an object entry
+            array_shift($lines); // Remove the timestamp line
+            array_shift($lines); // Remove the first "=" line
+
+			// remove last "=" line
+            if (end($lines) === "=") {
+                array_pop($lines);
+            }
+
+            $object_string = implode("\n", $lines);
+
+            // Attempt to parse the object.
+            try {
+                $object = eval("return " . $object_string . ";");
+                if (is_array($object)) {
+                    $json_string = json_encode($object, JSON_PRETTY_PRINT);
+                    if ($json_string === false) {
+                        error_log("JSON encoding error for object: " . var_export($object, true));
+                        $json_string = "JSON Encoding Error"; // Or handle the error differently
+                    }
+                    $csv_data[] = ["prompt" => $json_string];
+                }
+            } catch (ParseError $e) {
+                // fail silently to avoid spamming the error log
+            } catch (Error $e) {
+                // fail silently to avoid spamming the error log
+            }
+
+        }
+    }
+
+    $fp = fopen($csv_file, 'w');
+    if ($fp === false) {
+        die("Error opening CSV file for writing: " . $csv_file);
+    }
+
+    fputcsv($fp, array_keys($csv_data[0])); // Header row
+    foreach ($csv_data as $row) {
+        fputcsv($fp, $row);
+    }
+
+    fclose($fp);
+    echo "Successfully parsed log and created CSV file: " . $csv_file . "\n";
+}
+
+// Example usage:
+$log_file = __DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."log".DIRECTORY_SEPARATOR.'context_sent_to_llm.log';
+$csv_file = __DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."log".DIRECTORY_SEPARATOR.'context_sent_to_llm.csv';
+parse_log_to_csv($log_file, $csv_file);
+
+?>

--- a/debug/convert_log_to_csv.php
+++ b/debug/convert_log_to_csv.php
@@ -5,6 +5,8 @@ function parse_log_to_csv($log_file, $csv_file) {
     if ($log_content === false) {
         die("Error reading log file: " . $log_file);
     }
+	// Replace incorrectly escaped single quotes with properly escaped ones
+	$log_content = str_replace("\\\\\'", "\\'", $log_content);
 
     $entries = preg_split("/\n(?=\d{4}-\d{2}-\d{2}T)/", $log_content); // Split by timestamps
     $csv_data = [];
@@ -25,8 +27,8 @@ function parse_log_to_csv($log_file, $csv_file) {
             // Attempt to parse the object.
             try {
                 $object = eval("return " . $object_string . ";");
-                if (is_array($object)) {
-                    $json_string = json_encode($object, JSON_PRETTY_PRINT);
+                if (is_array($object) && $object["messages"]) {
+                    $json_string = json_encode($object["messages"], JSON_PRETTY_PRINT);
                     if ($json_string === false) {
                         $json_string = "JSON Encoding Error"; // Or handle the error differently
                     }
@@ -48,7 +50,7 @@ function parse_log_to_csv($log_file, $csv_file) {
 
     fputcsv($fp, array_keys($csv_data[0])); // Header row
     foreach ($csv_data as $row) {
-        fputcsv($fp, $row);
+        fputcsv($fp, $row, ",", "'"); // enclosing with single quotes to avoid problems with json inside json
     }
 
     fclose($fp);


### PR DESCRIPTION
Use var_export instead of print_r when writing to context_sent_to_llm.log
The purpose of this change is to better support sharing log files and converting them back into php objects so the prompt can be reused.
var_export writes text that can be read with eval() back into a valid php object.
print_r text is not quoted correctly and so can't be easily read back.

before:
```
2025-01-20T12:52:24+00:00
=
Array
(
    [model] => baezel-8b-linear
    ...
```

after:
```
2025-01-20T12:36:59+00:00
=
array (
  'model' => 'baezel-8b-linear',
  ...
```

My end goal here is to let people share their prompts that produce strange results, and to help build a dataset of CHIM prompts that I can use in LLM scoring tests.