### PR TITLE
Add support for KoboldCPP TTS API

### DIFF
--- a/conf/conf.sample.php
+++ b/conf/conf.sample.php
@@ -240,6 +240,9 @@ $TTS["COQUI_AI"]["voice_id"]='f05c5b91-7540-4b26-b534-e820d43065d1'; //Voice ID.
 $TTS["COQUI_AI"]["speed"]=1; //Speech rate.
 $TTS["COQUI_AI"]["language"]='en'; //Language.
 $TTS["COQUI_AI"]["API_KEY"]='';	//Coqui.ai API key.
+//KoboldCPP TTS
+$TTS["koboldcpp"]["endpoint"]='http://127.0.0.1:5001/api/extra/tts'; //API endpoint.
+$TTS["koboldcpp"]["voice"]='kobo';
 
 // KOKORO
 

--- a/conf/conf_schema.json
+++ b/conf/conf_schema.json
@@ -150,7 +150,8 @@
       "template": {"type":"select","values":["vicuna-1","vicuna-1.1","alpaca","synthia","extended-alpaca","superHOT","chatml","chatml-c","zephyr","openchat","dreamgen","neuralchat","phi","llama3","gromenauer","gemma2","mistral-ins"],"description":"Prompt Format. Specified in the HuggingFace model card"}
     }
   },
-  "TTSFUNCTION": {"type":"select","values":["none","melotts","xtts-fastapi","mimic3","xvasynth","azure","11labs","gcp","openai","convai","kokoro"],"description":"Text-to-Speech service options. Used to generate AI NPC voice.","_title":"Text-to-Speech Service"},
+  "TTSFUNCTION": {"type":"select","values":["none","melotts","xtts-fastapi","mimic3","xvasynth","azure","11labs","gcp","openai","convai","kokoro","koboldcpp"],"description":"Text-to-Speech service options. Used to generate AI NPC voice.","_title":"Text-to-Speech Service"},
+
   "TTS": {
     "_title":"Text-to-Speech Service",
     "MELOTTS": {
@@ -233,8 +234,13 @@
       "endpoint":{"type":"url","description":"End point URL","helpurl":""},
       "voiceid":{"type":"string","description":"Voice id (check compatability with language)","helpurl":""},
       "speed":{"type":"number","description":"Speed"}
-      }
-  },
+    },
+    "koboldcpp": {
+      "_title": "KoboldCPP TTS",
+      "endpoint":{"type":"url","description":"Endpoint URL"},
+      "voice": {"type":"string","description":"Voice to use"}
+    }
+},
   "TTSFUNCTION_PLAYER": {"type":"select","userlvl":"basic","scope":"global","values":["none","melotts","xtts-fastapi","xvasynth","mimic3","azure","11labs","gcp","openai","convai"],"description":"Text-to-Speech service options. Used to generate your voice. Currently bugged for xVASynth.","_title":"Player TTS"},
   "TTSFUNCTION_PLAYER_VOICE": {"type":"string","userlvl":"basic","scope":"global","description":"VoiceID to use for the player character."},
   "STTFUNCTION": {

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -480,7 +480,11 @@ function returnLines($lines,$writeOutput=true)
                 require_once(__DIR__."/../tts/tts-stylettsv2-2.php");
                 $ttsOutput=$GLOBALS["TTS_IN_USE"]($responseTextUnmooded, $mood, $responseText);
 
-            } else {
+            } else if ($GLOBALS["TTSFUNCTION"] == "koboldcpp") {
+                require_once(__DIR__."/../tts/tts-koboldcpp.php");
+                $ttsOutput=$GLOBALS["TTS_IN_USE"]($responseTextUnmooded, $mood, $responseText);
+            } 
+            else {
                 if (file_exists(__DIR__."/../tts/tts-".$GLOBALS["TTSFUNCTION"].".php")) {
                     require_once(__DIR__."/../tts/tts-".$GLOBALS["TTSFUNCTION"].".php");
                     $ttsOutput=$GLOBALS["TTS_IN_USE"]($responseTextUnmooded, $mood, $responseText);

--- a/tts/tts-koboldcpp.php
+++ b/tts/tts-koboldcpp.php
@@ -1,0 +1,55 @@
+<?php
+
+
+$GLOBALS["TTS_IN_USE"]=function($textString, $mood , $stringforhash) {
+
+    // Cache 
+		if (!isset($GLOBALS["AVOID_TTS_CACHE"]))
+			if (file_exists(dirname((__FILE__)) . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "soundcache/" . md5(trim($stringforhash)) . ".wav"))
+				return dirname((__FILE__)) . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "soundcache/" . md5(trim($stringforhash)) . ".wav";
+	
+		$url = $GLOBALS["TTS"]["koboldcpp"]["endpoint"]; //http://127.0.0.1:5001/api/extra/tts
+
+		// Request headers
+		$headers = array(
+			"accept: audio/wav",
+			'Content-Type: application/json'
+		);
+		
+			
+		// Request data
+		$data = array(
+			'input' => "$textString",
+			'voice' => $GLOBALS["TTS"]["koboldcpp"]["voice"],
+			);
+
+
+		// Create stream context options
+		$options = array(
+			'http' => array(
+				'method' => 'POST',
+				'header' => implode("\r\n", $headers),
+				'content' => json_encode($data)
+			)
+		);
+
+		;
+		// Create stream context
+		$context = stream_context_create($options);
+
+		// Send the request
+		$response = file_get_contents($url, false, $context);
+
+		// Handle the response
+		if ($response !== false ) {
+			$wavName=dirname((__FILE__)) . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "soundcache/" . md5(trim($stringforhash)) . ".wav";
+			file_put_contents($wavName, trim($response));
+			return "soundcache/" . md5(trim($stringforhash)) . ".wav";
+		} else {
+			$textString.=print_r($http_response_header,true);
+			file_put_contents(dirname((__FILE__)) . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "soundcache/" . md5(trim($stringforhash)) . ".err", trim($textString));
+            return false;
+			
+		}
+
+};


### PR DESCRIPTION
As of the [most recent KoboldCPP release](https://github.com/LostRuins/koboldcpp/releases/tag/v1.82.2), you can run local TTS using [OuteTTS](https://huggingface.co/OuteAI/OuteTTS-0.3-500M-GGUF). This patch adds support for doing just that.