### PR TITLE
Prevent api keys from being leaked in error log

### DIFF
--- a/ui/cmd/action_copy_value_to_all_profiles.php
+++ b/ui/cmd/action_copy_value_to_all_profiles.php
@@ -44,7 +44,7 @@ if ($method === 'POST') {
             }
 
             $value=$jsonDataInput["value"];
-            error_log(print_r($jsonDataInput,true));
+            error_log("copying {$jsonDataInput["name"]} to all profiles");
             $new_php_code="";
             if (!is_array($value))
                 if ($value=='false')


### PR DESCRIPTION
When using the "copy to all profiles" button on an api key, the key is printed to the error log.
Fixed by printing only the name of the key in the log and not its value.