### PR TITLE
Dynamic profile fixes

### DIFF
--- a/connector/openrouter.php
+++ b/connector/openrouter.php
@@ -1,5 +1,6 @@
 <?php
 
+$enginePath = dirname((__FILE__)) . DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR;
 
 class connector
 {

--- a/processor/comm.php
+++ b/processor/comm.php
@@ -575,10 +575,10 @@ if ($gameRequest[0] == "init") { // Reset responses if init sent (Think about th
             }
 
             file_put_contents($newFile, implode('', $file_lines));
-			$escapedDynamic = var_export($responseParsed["HERIKA_DYNAMIC"], true);
-			if (!is_string($responseParsed["HERIKA_DYNAMIC"]) || !$escapedDynamic) {
-				$escapedDynamic = '';
-			}
+            $escapedDynamic = var_export($responseParsed["HERIKA_DYNAMIC"], true);
+            if (!is_string($responseParsed["HERIKA_DYNAMIC"]) || !$escapedDynamic) {
+                $escapedDynamic = '';
+            }
             file_put_contents($newFile, PHP_EOL.'$HERIKA_DYNAMIC='.$escapedDynamic.';'.PHP_EOL, FILE_APPEND | LOCK_EX);
             file_put_contents($newFile, '?>'.PHP_EOL, FILE_APPEND | LOCK_EX);
             

--- a/processor/comm.php
+++ b/processor/comm.php
@@ -458,11 +458,11 @@ if ($gameRequest[0] == "init") { // Reset responses if init sent (Think about th
     }
     
     
-    if (!isset($GLOBALS["CONNECTORS_DIARY"]) || !file_exists($enginePath . "connector" . DIRECTORY_SEPARATOR . "{$GLOBALS["CONNECTORS_DIARY"]}.php")) {
+    if (!isset($GLOBALS["CONNECTORS_DIARY"]) || !file_exists(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."connector".DIRECTORY_SEPARATOR."{$GLOBALS["CONNECTORS_DIARY"]}.php")) {
             ;
 	}
 	 else {
-		require_once $enginePath . "connector" . DIRECTORY_SEPARATOR . "{$GLOBALS["CONNECTORS_DIARY"]}.php";
+		require_once(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."connector".DIRECTORY_SEPARATOR."{$GLOBALS["CONNECTORS_DIARY"]}.php");
         
         $historyData="";
         $lastPlace="";
@@ -498,7 +498,7 @@ if ($gameRequest[0] == "init") { // Reset responses if init sent (Think about th
 
 		$head[]   = ["role"	=> "system", "content"	=> "You are an assistant. Analyze this dialogue and then update the dynamic character profile based on the information provided. ", ];
 		$prompt[] = ["role"	=> "user", "content"	=> "* Dialogue history:\n" .$historyData ];
-		$prompt[] = ["role" => "user", "content" => "Current character profile you are updating:\n" . "Character name:\n"  . $jsonDataInput["HERIKA_NAME"] . "Character static biography:\n" . $jsonDataInput["HERIKA_PERS"] . "\n" ."Character dynamic biography (this is what you are updating):\n" . $jsonDataInput["HERIKA_DYNAMIC"]];
+		$prompt[] = ["role" => "user", "content" => "Current character profile you are updating:\n" . "Character name:\n"  . $GLOBALS["HERIKA_NAME"] . "Character static biography:\n" . $GLOBALS["HERIKA_PERS"] . "\n" ."Character dynamic biography (this is what you are updating):\n" . $GLOBALS["HERIKA_DYNAMIC"]];
 		$prompt[] = ["role"=> "user", "content"	=> $updateProfilePrompt, ];
 		$contextData       = array_merge($head, $prompt);
 		$connectionHandler = new connector();
@@ -575,7 +575,11 @@ if ($gameRequest[0] == "init") { // Reset responses if init sent (Think about th
             }
 
             file_put_contents($newFile, implode('', $file_lines));
-            file_put_contents($newFile, PHP_EOL.'$HERIKA_DYNAMIC=\''.addslashes($responseParsed["HERIKA_DYNAMIC"]).'\';'.PHP_EOL, FILE_APPEND | LOCK_EX);
+			$escapedDynamic = var_export($responseParsed["HERIKA_DYNAMIC"], true);
+			if (!is_string($responseParsed["HERIKA_DYNAMIC"]) || !$escapedDynamic) {
+				$escapedDynamic = '';
+			}
+            file_put_contents($newFile, PHP_EOL.'$HERIKA_DYNAMIC='.$escapedDynamic.';'.PHP_EOL, FILE_APPEND | LOCK_EX);
             file_put_contents($newFile, '?>'.PHP_EOL, FILE_APPEND | LOCK_EX);
             
         }


### PR DESCRIPTION
Fixes a few issues with the new dynamic profiles.

1. The non-json openrouter connector doesn't set $enginePath like all the other connectors do. I don't think it really causes any problems, but I'm adding it now to prevent warnings in the log.
2. processor/comm.php version of dynamic profile update was looking at $enginePath, which isn't initialized yet because this is before a database call. Changed to relative path from the processor/comm.php file.
3. $jsonDataInput was being used in processor/comm.php even though it isn't initialized there. This meant that the NPC name and existing bios were not being added to context. Changed to use $GLOBALS instead.
4. When writing to the conf_(md5).php file, double quotes are being unnecessarily escaped. Switched to using var_export which will give a properly escaped string. Tested in game with an LLM response that includes single quotes and double quotes, and looks good.