### PR TITLE
use bored_event for non-es language

### DIFF
--- a/prompts/prompts.php
+++ b/prompts/prompts.php
@@ -90,8 +90,7 @@ $PROMPTS=array(
 
         ]
         //,"extra"=>["dontuse"=>true]   //DEACTIVATED WHILE BETA STAGE
-        ,"extra" => ["dontuse" => false]   //50% chance
-        //,"extra"=>["dontuse"=>true]   //50% chance
+        ,"extra"=>["dontuse"=>(time()%($GLOBALS["BORED_EVENT"]+1)==0)]   // ignore 1/x+1 events
     ],
 
     "goodmorning"=>[


### PR DESCRIPTION
The BORED_EVENT setting is currently ignored except when using the es language prompts file.
This copies the es logic into the main prompts.php file so bored events may be disabled.