### PR TITLE
make memoryInjectionCtx an array of arrays

### DIFF
--- a/main.php
+++ b/main.php
@@ -556,7 +556,7 @@ if (in_array($gameRequest[0],["inputtext","inputtext_s","ginputtext","ginputtext
     if (!empty($memoryInjection)) {
         
         //$memoryInjectionCtx[]= array('role' => 'user', 'content' => $gameRequest[3]);
-        $memoryInjectionCtx= array('role' => 'user', 'content' => "#MEMORY: {$GLOBALS["HERIKA_NAME"]} remembers this: [$memoryInjection]");
+        $memoryInjectionCtx[]= array('role' => 'user', 'content' => "#MEMORY: {$GLOBALS["HERIKA_NAME"]} remembers this: [$memoryInjection]");
         //$GLOBALS["COMMAND_PROMPT"].="'{$gameRequest[3]}'\n{$GLOBALS["HERIKA_NAME"]}):$memoryInjection\n";
         
     } else {
@@ -619,7 +619,7 @@ if (sizeof($memoryInjectionCtx)>0) {
     // Persist memory injetction
     $gameRequestCopy=$gameRequest;
     $gameRequestCopy[0]="infoaction";
-    $gameRequestCopy[3]=$memoryInjectionCtx["content"];
+    $gameRequestCopy[3]=$memoryInjectionCtx[0]["content"];
     logEvent($gameRequestCopy);
 }
 


### PR DESCRIPTION
Memories need to be an array of arrays in order to work properly with the array_splice when adding it to the prompt.
Fixes memories on koboldcpp (would cause error) and missing content entries on other connectors.