### PR TITLE
Add capability for LLM retries

### DIFF
--- a/connector/openrouterjson.php
+++ b/connector/openrouterjson.php
@@ -455,10 +455,15 @@ class connector
             if (strlen(($data["choices"][0]["delta"]["content"]))>0) {
                 $buffer.=$data["choices"][0]["delta"]["content"];
                 $this->_buffer.=$data["choices"][0]["delta"]["content"];
-                $this->_numOutputTokens += 1;
+                // Check to see if we've received something that looks like it starts with a JSON object
+                if (strlen($this->_buffer)>10 && strpos($this->_buffer, '{') === false) {
+                    return -1;
+                }
 
             }
+
             $totalBuffer.=$data["choices"][0]["delta"]["content"];
+
 
         }
         

--- a/main.php
+++ b/main.php
@@ -725,169 +725,194 @@ if ($gameRequest[0] == "funcret") {
 CALL INITIALIZATION
 ***********************/
 
-if (!isset($GLOBALS["CURRENT_CONNECTOR"]) || (!file_exists(__DIR__.DIRECTORY_SEPARATOR."connector".DIRECTORY_SEPARATOR."{$GLOBALS["CURRENT_CONNECTOR"]}.php"))) {
-    die("{$GLOBALS["HERIKA_NAME"]}|AASPGQuestDialogue2Topic1B1Topic|I'm mindless. Choose a LLM model and connector.".PHP_EOL);
+    if (!isset($GLOBALS["CURRENT_CONNECTOR"]) || (!file_exists(__DIR__.DIRECTORY_SEPARATOR."connector".DIRECTORY_SEPARATOR."{$GLOBALS["CURRENT_CONNECTOR"]}.php"))) {
+        die("{$GLOBALS["HERIKA_NAME"]}|AASPGQuestDialogue2Topic1B1Topic|I'm mindless. Choose a LLM model and connector.".PHP_EOL);
 
-} else {
+    } else {
 
-    require(__DIR__.DIRECTORY_SEPARATOR."connector".DIRECTORY_SEPARATOR."{$GLOBALS["CURRENT_CONNECTOR"]}.php");
+        require(__DIR__.DIRECTORY_SEPARATOR."connector".DIRECTORY_SEPARATOR."{$GLOBALS["CURRENT_CONNECTOR"]}.php");
+    }
+    function call_llm() {
+        $outputWasValid = true;
+        $connectionHandler=new connector();
+        $connectionHandler->open($contextData,$overrideParameters);
+    ///// PATCH. STORE FUNCTION RESULT ONCE RESULT PROMPT HAS BEEN BUILT.
 
-    $connectionHandler=new connector();
-    $connectionHandler->open($contextData,$overrideParameters);
-    
+    if (isset($GLOBALS["PATCH_STORE_FUNC_RES"])) {
+        $gameRequestCopy=$gameRequest;
+        $gameRequestCopy[0]="infoaction";
+        $gameRequestCopy[3]=$GLOBALS["PATCH_STORE_FUNC_RES"];
+        logEvent($gameRequestCopy);
+    }
 
-}
+    ///// PATCH
 
-///// PATCH. STORE FUNCTION RESULT ONCE RESULT PROMPT HAS BEEN BUILT.
+    if ($connectionHandler->primary_handler === false) {
 
-if (isset($GLOBALS["PATCH_STORE_FUNC_RES"])) {
-    $gameRequestCopy=$gameRequest;
-    $gameRequestCopy[0]="infoaction";
-    $gameRequestCopy[3]=$GLOBALS["PATCH_STORE_FUNC_RES"];
-    logEvent($gameRequestCopy);
-}
-
-///// PATCH
-
-if ($connectionHandler->primary_handler === false) {
-
-    $db->insert(
-        'log',
-        array(
-            'localts' => time(),
-            'prompt' => nl2br((json_encode($GLOBALS["DEBUG_DATA"], JSON_PRETTY_PRINT))),
-            'response' => ((print_r(error_get_last(), true))),
-            'url' => nl2br(("$receivedData in " . (microtime(true) - $startTime) . " secs "))
+        $db->insert(
+            'log',
+            array(
+                'localts' => time(),
+                'prompt' => nl2br((json_encode($GLOBALS["DEBUG_DATA"], JSON_PRETTY_PRINT))),
+                'response' => ((print_r(error_get_last(), true))),
+                'url' => nl2br(("$receivedData in " . (microtime(true) - $startTime) . " secs "))
 
 
-        )
-    );
-    returnLines([$GLOBALS["ERROR_OPENAI"]]);
-    
-    $ERROR_TRIGGERED=true;
-    @ob_end_flush();
+            )
+        );
+        returnLines([$GLOBALS["ERROR_OPENAI"]]);
+        
+        $ERROR_TRIGGERED=true;
+        @ob_end_flush();
 
-    error_log(print_r(error_get_last(), true));
+        error_log(print_r(error_get_last(), true));
+        $outputWasValid = false;
 
-} else {
+    } else {
 
-    // Read and process the response line by line
-    $buffer="";
-    $totalBuffer="";
-    $breakFlag=false;
-    $lineCounter=0;
-    $fullContent="";
-    $totalProcessedData="";
-    $numOutputTokens = 0;
+        // Read and process the response line by line
+        $buffer="";
+        $totalBuffer="";
+        $breakFlag=false;
+        $lineCounter=0;
+        $fullContent="";
+        $totalProcessedData="";
+        $numOutputTokens = 0;
 
-    while (true) {
+        while (true) {
 
-        if ($breakFlag) {
-            break;
+            if ($breakFlag) {
+                break;
+            }
+
+            $tmpData=$connectionHandler->process();
+            if ($tmpData==-1) {
+                error_log("Invalid JSON Output.");
+                $outputWasValid=false;
+                $breakFlag=true;
+            }
+            else {
+                $buffer.= $tmpData;
+                $totalBuffer.=$buffer; 
+            }
+
+
+
+
+            if ($connectionHandler->isDone()) {
+                $breakFlag=true;
+            }
+
+            $buffer=strtr($buffer, array("\""=>"",".)"=>")."));
+
+            if (strlen($buffer)<MINIMUM_SENTENCE_SIZE) {	// Avoid too short buffers
+                continue;
+            }
+
+            $position = findDotPosition($buffer);
+
+            //echo "<$buffer>".PHP_EOL;
+            if ($position !== false && $position>MINIMUM_SENTENCE_SIZE ) {
+                $extractedData = substr($buffer, 0, $position + 1);
+                $remainingData = substr($buffer, $position + 1);
+                $sentences=split_sentences_stream(cleanResponse($extractedData));
+                $GLOBALS["DEBUG_DATA"]["response"][]=["raw"=>$buffer,"processed"=>implode("|", $sentences)];
+                $GLOBALS["DEBUG_DATA"]["perf"][]=(microtime(true) - $startTime)." secs in openai stream";
+
+                if ($gameRequest[0] != "diary") {
+                    returnLines($sentences);
+                } else {
+                    $talkedSoFar[md5(implode(" ", $sentences))]=implode(" ", $sentences);
+                }
+
+                //echo "$extractedData  # ".(microtime(true)-$startTime)."\t".strlen($finalData)."\t".PHP_EOL;  // Output
+                $totalProcessedData.=$extractedData;
+                $extractedData="";
+                $buffer=$remainingData;
+                $db = new sql();
+                $user_input_after=$db->fetchAll("select count(*) as N from eventlog where type='user_input' and ts>$gameRequest[1]");
+                if (isset($user_input_after[0]))
+                    if (isset($user_input_after[0]["N"]))
+                        if ($user_input_after[0]["N"]>0) {
+                            die('X-CUSTOM-CLOSE');
+                            error_log("Generation stopped because user_input. ".__LINE__);
+                            // Abort , user input detected
+                        }
+
+            }
+
         }
-
-
-        $buffer.=$connectionHandler->process();
-        $totalBuffer.=$buffer;
-
-
-        if ($connectionHandler->isDone()) {
-            $breakFlag=true;
-        }
-
-        $buffer=strtr($buffer, array("\""=>"",".)"=>")."));
-
-        if (strlen($buffer)<MINIMUM_SENTENCE_SIZE) {	// Avoid too short buffers
-            continue;
-        }
-
-        $position = findDotPosition($buffer);
-
-        //echo "<$buffer>".PHP_EOL;
-        if ($position !== false && $position>MINIMUM_SENTENCE_SIZE ) {
-            $extractedData = substr($buffer, 0, $position + 1);
-            $remainingData = substr($buffer, $position + 1);
-            $sentences=split_sentences_stream(cleanResponse($extractedData));
+        
+        
+        if (trim($buffer)) {
+            error_log("REMAINING DATA <$buffer>");
+            $sentences=split_sentences_stream(cleanResponse(trim($buffer)));
             $GLOBALS["DEBUG_DATA"]["response"][]=["raw"=>$buffer,"processed"=>implode("|", $sentences)];
             $GLOBALS["DEBUG_DATA"]["perf"][]=(microtime(true) - $startTime)." secs in openai stream";
-
             if ($gameRequest[0] != "diary") {
                 returnLines($sentences);
             } else {
                 $talkedSoFar[md5(implode(" ", $sentences))]=implode(" ", $sentences);
             }
-
-            //echo "$extractedData  # ".(microtime(true)-$startTime)."\t".strlen($finalData)."\t".PHP_EOL;  // Output
-            $totalProcessedData.=$extractedData;
-            $extractedData="";
-            $buffer=$remainingData;
-
-            $user_input_after=$db->fetchAll("select count(*) as N from eventlog where type='user_input' and ts>$gameRequest[1]");
-            if (isset($user_input_after[0]))
-                if (isset($user_input_after[0]["N"]))
-                    if ($user_input_after[0]["N"]>0) {
-                        die('X-CUSTOM-CLOSE');
-                        error_log("Generation stopped because user_input. ".__LINE__);
-                        // Abort , user input detected
-                    }
-
+            $totalBuffer.=trim($buffer);
+            $totalProcessedData.=trim($buffer);
         }
 
-    }
-    
-    
-    if (trim($buffer)) {
-        // error_log("REMAINING DATA <$buffer>");
-        $sentences=split_sentences_stream(cleanResponse(trim($buffer)));
-        $GLOBALS["DEBUG_DATA"]["response"][]=["raw"=>$buffer,"processed"=>implode("|", $sentences)];
-        $GLOBALS["DEBUG_DATA"]["perf"][]=(microtime(true) - $startTime)." secs in openai stream";
-        if ($gameRequest[0] != "diary") {
-            returnLines($sentences);
-        } else {
-            $talkedSoFar[md5(implode(" ", $sentences))]=implode(" ", $sentences);
-        }
-        $totalBuffer.=trim($buffer);
-        $totalProcessedData.=trim($buffer);
-    }
+        if ($GLOBALS["FUNCTIONS_ARE_ENABLED"])  {
+            $actions=$connectionHandler->processActions();
 
-    if ($GLOBALS["FUNCTIONS_ARE_ENABLED"])  {
-        $actions=$connectionHandler->processActions();
-
-        if (is_array($actions) && (sizeof($actions)>0)) {
-            
-            // ACTION POST-FILTER
-            
-            if ($GLOBALS["FUNCTIONS_ARE_ENABLED"]) {
+            if (is_array($actions) && (sizeof($actions)>0)) {
                 
-                foreach ($actions as $n=>$action) {
-                    $actionParts=explode("|",$action);
-                    $actionParts2=explode("@",$actionParts[2]);
+                // ACTION POST-FILTER
+                
+                if ($GLOBALS["FUNCTIONS_ARE_ENABLED"]) {
                     
-                    if (isset($actionParts2[1])) {
-                        // Parameter part 
-                        if ($actionParts2[0]=="Attack") {
-                            // Lets polish the parammeters
-                            $localtarget=$actionParts2[1];
-                            $mang1=explode(",",$localtarget);
-                            $mang2=explode(" and ",$mang1[0]);
-                            $mang3=explode("(",$mang2[0]);
-                            $actions[$n]="{$actionParts[0]}|{$actionParts[1]}|Attack@{$mang3[0]}";
+                    foreach ($actions as $n=>$action) {
+                        $actionParts=explode("|",$action);
+                        $actionParts2=explode("@",$actionParts[2]);
+                        
+                        if (isset($actionParts2[1])) {
+                            // Parameter part 
+                            if ($actionParts2[0]=="Attack") {
+                                // Lets polish the parammeters
+                                $localtarget=$actionParts2[1];
+                                $mang1=explode(",",$localtarget);
+                                $mang2=explode(" and ",$mang1[0]);
+                                $mang3=explode("(",$mang2[0]);
+                                $actions[$n]="{$actionParts[0]}|{$actionParts[1]}|Attack@{$mang3[0]}";
+                            }
                         }
                     }
                 }
+
+                $GLOBALS["DEBUG_DATA"]["response"][]=$actions;
+                echo implode("\r\n", $actions).PHP_EOL;
+                file_put_contents(__DIR__."/log/ouput_to_plugin.log",implode("\r\n", $actions), FILE_APPEND | LOCK_EX);
+
             }
-
-            $GLOBALS["DEBUG_DATA"]["response"][]=$actions;
-            echo implode("\r\n", $actions).PHP_EOL;
-            file_put_contents(__DIR__."/log/ouput_to_plugin.log",implode("\r\n", $actions), FILE_APPEND | LOCK_EX);
-
         }
+        $connectionHandler->close();
+        //fwrite($fileLog, $totalBuffer . PHP_EOL); // Write the line to the file with a line break // DEBUG CODE
+
+
     }
-    $connectionHandler->close();
-    //fwrite($fileLog, $totalBuffer . PHP_EOL); // Write the line to the file with a line break // DEBUG CODE
-
-
+    return $outputWasValid;
 }
+
+$outputWasValid = call_llm();
+if (!$outputWasValid) {
+    error_log("Warning: LLM returned invalid output.");
+    if (isset($GLOBALS["LLM_RETRY_FNCT"])) {
+        $GLOBALS["LLM_RETRY_FNCT"]();
+    }
+}
+
+
+
+
+
+
+
 
 if (sizeof($talkedSoFar) == 0) {
     if (sizeof($alreadysent) > 0) { // AI only issued commands

--- a/main.php
+++ b/main.php
@@ -732,10 +732,11 @@ CALL INITIALIZATION
 
         require(__DIR__.DIRECTORY_SEPARATOR."connector".DIRECTORY_SEPARATOR."{$GLOBALS["CURRENT_CONNECTOR"]}.php");
     }
-    function call_llm() {
-        $outputWasValid = true;
-        $connectionHandler=new connector();
-        $connectionHandler->open($contextData,$overrideParameters);
+function call_llm() {
+    global $contextData;
+    $outputWasValid = true;
+    $connectionHandler=new connector();
+    $connectionHandler->open($contextData,$overrideParameters);
     ///// PATCH. STORE FUNCTION RESULT ONCE RESULT PROMPT HAS BEEN BUILT.
 
     if (isset($GLOBALS["PATCH_STORE_FUNC_RES"])) {

--- a/main.php
+++ b/main.php
@@ -733,11 +733,15 @@ CALL INITIALIZATION
         require(__DIR__.DIRECTORY_SEPARATOR."connector".DIRECTORY_SEPARATOR."{$GLOBALS["CURRENT_CONNECTOR"]}.php");
     }
 function call_llm() {
-    global $contextData;
+    global $contextData, $gameRequest, $receivedData, $startTime, $db;
+    global $ERROR_TRIGGERED, $talkedSoFar, $alreadysent, $FUNCTIONS_ARE_ENABLED;
+    global $overrideParameters, $request;
+    
     $outputWasValid = true;
     $connectionHandler=new connector();
     $connectionHandler->open($contextData,$overrideParameters);
     ///// PATCH. STORE FUNCTION RESULT ONCE RESULT PROMPT HAS BEEN BUILT.
+
 
     if (isset($GLOBALS["PATCH_STORE_FUNC_RES"])) {
         $gameRequestCopy=$gameRequest;
@@ -830,10 +834,10 @@ function call_llm() {
                 $totalProcessedData.=$extractedData;
                 $extractedData="";
                 $buffer=$remainingData;
-                $db = new sql();
-                $user_input_after=$db->fetchAll("select count(*) as N from eventlog where type='user_input' and ts>$gameRequest[1]");
+                $user_input_after=$GLOBALS["db"]->fetchAll("select count(*) as N from eventlog where type='user_input' and ts>$gameRequest[1]");
                 if (isset($user_input_after[0]))
                     if (isset($user_input_after[0]["N"]))
+
                         if ($user_input_after[0]["N"]>0) {
                             die('X-CUSTOM-CLOSE');
                             error_log("Generation stopped because user_input. ".__LINE__);


### PR DESCRIPTION
Add functionality to call a defined "LLM Retry Function" if the LLM returns a non-JSON response. Currently leveraging this from MinAI, no reason we can't add this functionality in CHIM proper as well if you like.

Changes are pretty minor - Wrapped most of the call logic in a function (Which is why the diff is so large), and added a check to openrouterjson to see if the response contains at a minimum a '{' token in the first 10 characters.

## Testing Done
Tested to make sure the LLM troubleshooter still works. Also, validated manually via the chat test. Tested in-game, and is working as expected.
```
==> output_from_llm.log <==
I apologize, but I

2025-02-07T17:32:14+01:00 END
```
```
 MinAI: Retrying LLM...
```
```
==> output_from_llm.log <==
{
  "character": "Hafseta [hunter]",
  "listener": "Min",
  "mood": "sarcastic",
  "action": "Talk",
  "target": "Min",
  "message": "Oh, great, another thrilling day in paradise. What's on your agenda, Min? More exciting adventures or just the usual?"
}```