### PR TITLE
add 11labs style property

### DIFF
--- a/tts/tts-11labs.php
+++ b/tts/tts-11labs.php
@@ -41,7 +41,8 @@ $GLOBALS["TTS_IN_USE"]=function($textString, $mood = "default", $stringforhash) 
 			'model_id' => $GLOBALS["TTS"]["ELEVEN_LABS"]["model_id"],
 			'voice_settings' => array(
 				'stability' => $GLOBALS["TTS"]["ELEVEN_LABS"]["stability"]+0.0,
-				'similarity_boost' => $GLOBALS["TTS"]["ELEVEN_LABS"]["similarity_boost"]+0.0
+				'similarity_boost' => $GLOBALS["TTS"]["ELEVEN_LABS"]["similarity_boost"]+0.0,
+				'style' => $GLOBALS["TTS"]["ELEVEN_LABS"]["style"]+0.0
 			)
 		);
 


### PR DESCRIPTION
For 11labs tts, the `style` parameter is supported in CHIM's config but not actually sent with the POST request.
This PR adds style to the voice_settings.
Thanks to to telord in discord for pointing this out.