### PR TITLE
Move memory compaction to background

### DIFF
--- a/processor/postrequest.php
+++ b/processor/postrequest.php
@@ -56,7 +56,7 @@ if ($GLOBALS["FEATURES"]["MEMORY_EMBEDDING"]["AUTO_CREATE_SUMMARYS"]) {
 
     if (($gameRequest[2]-$maxRow)>($pfi)) {
         
-        error_log(shell_exec("php ".__DIR__."/../debug/util_memory_subsystem.php compact noembed 2"));
+        error_log(shell_exec("php ".__DIR__."/../debug/util_memory_subsystem.php compact noembed 2 &"));
         
     } else {
         


### PR DESCRIPTION
Two character change to move the execution of the memory compaction subsystem to the background. 

shell_exec appears to be causing apache to hang and wait for a response, which is blocking subsequent player inputs. 