### PR TITLE
Fix unit tests after change to db functions

### DIFF
--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -1,6 +1,6 @@
 <?php 
 
-function checkVersion($tablename) {
+$checkVersion = function($tablename) {
     global $db;
     $query = "
     SELECT version 
@@ -14,14 +14,14 @@ function checkVersion($tablename) {
         return -1;
     else
         return $existsColumn[0]["version"]+0;
-}
+};
 
-function updateVersion($tablename,$version) {
+$updateVersion = function($tablename,$version) {
     global $db;
     $db->execQuery("INSERT INTO public.database_versioning SELECT '$tablename',$version where not exists (SELECT 1 from public.database_versioning where tablename='$tablename')");
     $db->execQuery("UPDATE public.database_versioning set version=$version WHERE tablename='$tablename'");
     error_log("TABLE $tablename updated to version $version");
-}
+};
 
 /////////////////////////
 
@@ -422,7 +422,7 @@ if (!$existsColumn[0]["version"] || $existsColumn[0]["version"]<20250120001) {
 // Oghma npc table 20250129
 
 
-if (checkVersion("npc_templates")<20250129001) {
+if ($checkVersion("npc_templates")<20250129001) {
     $query = "
     ALTER TABLE npc_templates 
     ADD COLUMN IF NOT EXISTS npc_dynamic TEXT;
@@ -434,10 +434,10 @@ if (checkVersion("npc_templates")<20250129001) {
     ADD COLUMN IF NOT EXISTS xvasynth_voiceid TEXT;
     ";
     $db->execQuery($query);
-    updateVersion("npc_templates",20250129001);
+    $updateVersion("npc_templates",20250129001);
 }
 
-if (checkVersion("npc_templates_custom")<20250129001) {
+if ($checkVersion("npc_templates_custom")<20250129001) {
     $query = "
     ALTER TABLE npc_templates_custom 
     ADD COLUMN IF NOT EXISTS npc_dynamic TEXT;
@@ -449,10 +449,10 @@ if (checkVersion("npc_templates_custom")<20250129001) {
     ADD COLUMN IF NOT EXISTS xvasynth_voiceid TEXT;
     ";
     $db->execQuery($query);
-    updateVersion("npc_templates_custom",20250129001);
+    $updateVersion("npc_templates_custom",20250129001);
 }
 
-if (checkVersion("combined_npc_templates")<20250129001) {
+if ($checkVersion("combined_npc_templates")<20250129001) {
     $query="
     DROP VIEW public.combined_npc_templates;
     CREATE VIEW public.combined_npc_templates AS
@@ -477,10 +477,10 @@ if (checkVersion("combined_npc_templates")<20250129001) {
       WHERE (c.npc_name IS NULL);";
     
     $db->execQuery($query);
-    updateVersion("combined_npc_templates",20250129001);
+    $updateVersion("combined_npc_templates",20250129001);
 }
 
-if (checkVersion("oghma")<20250902001) {
+if ($checkVersion("oghma")<20250902001) {
     $query = "
     ALTER TABLE oghma ADD COLUMN IF NOT EXISTS knowledge_class TEXT;
     ALTER TABLE oghma ADD COLUMN IF NOT EXISTS topic_desc_basic TEXT;
@@ -490,13 +490,13 @@ if (checkVersion("oghma")<20250902001) {
    
     ";
     $db->execQuery($query);
-    updateVersion("oghma",20250902001);
+    $updateVersion("oghma",20250902001);
 }
 
 
 // Pfff
 
-if (checkVersion("npc_templates_custom")<20250211001) {
+if ($checkVersion("npc_templates_custom")<20250211001) {
     $query="DROP VIEW public.combined_npc_templates;";
    
     $db->execQuery($query);
@@ -537,8 +537,8 @@ if (checkVersion("npc_templates_custom")<20250211001) {
     
     $db->execQuery($query);
 
-    updateVersion("npc_templates_custom",20250211001);
-    updateVersion("combined_npc_templates",20250211001);
+    $updateVersion("npc_templates_custom",20250211001);
+    $updateVersion("combined_npc_templates",20250211001);
     error_log("Applied patch 20250211001");
 }
 
@@ -547,7 +547,7 @@ if (checkVersion("npc_templates_custom")<20250211001) {
 //  sql_gamets_convert_functions 20250218001
 //----------------------------------------------------
 
-if (checkVersion("sql_gamets_convert_functions")<20250218001) {
+if ($checkVersion("sql_gamets_convert_functions")<20250218001) {
     error_log(" try patch: sql_gamets_convert_functions 20250218001 - dbg -");
 
     $db->execQuery("DROP VIEW IF EXISTS public.speech_view;");
@@ -709,8 +709,8 @@ if (checkVersion("sql_gamets_convert_functions")<20250218001) {
             public.convert_gamets2gregorian_date(s.gamets) AS gregorian_date
           FROM public.speech s; ");
     
-    updateVersion("sql_gamets_convert_functions",20250218001);
-    updateVersion("sql_gamets_convert_functions",20250218001);
+    $updateVersion("sql_gamets_convert_functions",20250218001);
+    $updateVersion("sql_gamets_convert_functions",20250218001);
     error_log("Applied patch: sql_gamets_convert_functions 20250218001 - dbg -");
 }
 

--- a/unittests/tests/DatabaseTestCase.php
+++ b/unittests/tests/DatabaseTestCase.php
@@ -61,6 +61,13 @@ abstract class DatabaseTestCase extends TestCase
         $returnVar = 0;
         exec($psqlCommand, $output, $returnVar);
 
+		// apply database updates
+		$db = new sql();
+		$GLOBALS["db"]=$db;
+		require(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."debug".DIRECTORY_SEPARATOR."db_updates.php");
+		$db->close();
+		unset($db);
+		unset($GLOBALS["db"]);
 
         // if minAI is installed then create its database tables as well, to avoid errors
         if (file_exists($path.DIRECTORY_SEPARATOR."ext".DIRECTORY_SEPARATOR."minai_plugin")) {

--- a/unittests/tests/DatabaseTestCase.php
+++ b/unittests/tests/DatabaseTestCase.php
@@ -61,13 +61,13 @@ abstract class DatabaseTestCase extends TestCase
         $returnVar = 0;
         exec($psqlCommand, $output, $returnVar);
 
-		// apply database updates
-		$db = new sql();
-		$GLOBALS["db"]=$db;
-		require(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."debug".DIRECTORY_SEPARATOR."db_updates.php");
-		$db->close();
-		unset($db);
-		unset($GLOBALS["db"]);
+        // apply database updates
+        $db = new sql();
+        $GLOBALS["db"]=$db;
+        require(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."debug".DIRECTORY_SEPARATOR."db_updates.php");
+        $db->close();
+        unset($db);
+        unset($GLOBALS["db"]);
 
         // if minAI is installed then create its database tables as well, to avoid errors
         if (file_exists($path.DIRECTORY_SEPARATOR."ext".DIRECTORY_SEPARATOR."minai_plugin")) {

--- a/unittests/tests/OghmaTest.php
+++ b/unittests/tests/OghmaTest.php
@@ -321,7 +321,6 @@ final class OghmaTest extends DatabaseTestCase
         $content = json_decode($options['http']['content']);
         $found=false;
         foreach ($content->messages as $message) {
-            print_r($message);
             if (json_encode($message) === json_encode($expectedPrompt)) {
                 $found = true;
                 break;

--- a/unittests/tests/conf.php
+++ b/unittests/tests/conf.php
@@ -21,6 +21,7 @@ $GLOBALS["BORED_EVENT"]=100; //Bored Event Probability. Chance of an NPC startin
 $GLOBALS["CONTEXT_HISTORY"]="50"; //Amount of context history (dialogue and events) that will be sent to LLM.
 $GLOBALS["HTTP_TIMEOUT"]=15; //Timeout for AI requests.
 $GLOBALS["CORE_LANG"]=""; //Custom languages. - language folder
+$GLOBALS["CURRENT_TASK"]=true; //Sends current plan/quest to the AI
 $GLOBALS["NEWQUEUE"]=true; //Leave as is - read only
 $GLOBALS["MAX_WORDS_LIMIT"]=0; //Enforce a word limit for AI's responses. 0 = unlimited.
 $GLOBALS["BOOK_EVENT_FULL"]=true; //Sends full contents of books to the AI


### PR DESCRIPTION
PR #86 caused some of the unit tests to break because I wasn't running the db_updates.php file when setting up the test database, and it became necessary to do so. I've enabled the db_updates to get the tests working again.