### PR TITLE
Trim empty content from openrouter non-json connector

### DIFF
--- a/connector/openrouter.php
+++ b/connector/openrouter.php
@@ -44,7 +44,16 @@ class openrouter
                 }
             }
         }
+
+        // Remove context elements with empty content
+        $contextDataCopy=[];
+        foreach ($contextData as $n=>$element) {
+            if (!empty($element["content"])) {
+                $contextDataCopy[]=$element;
+            }
+        }
         
+        $contextData=$contextDataCopy;
 
         $data = array(
             'model' => (isset($GLOBALS["CONNECTOR"][$this->name]["model"])) ? $GLOBALS["CONNECTOR"][$this->name]["model"] : 'gpt-3.5-turbo-0613',

--- a/main.php
+++ b/main.php
@@ -862,7 +862,7 @@ if (php_sapi_name()=="cli" && !getenv('PHPUNIT_TEST')) {
 
 
 // POST PROCESS TASKS
-if ($semaphore) 
+if (isset($semaphore) && $semaphore)
     sem_release($semaphore);
 
 while(!getenv("PHPUNIT_TEST") && @ob_end_clean());

--- a/unittests/tests/DiaryTest.php
+++ b/unittests/tests/DiaryTest.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+
+require_once 'DatabaseTestCase.php';
+require_once 'CallableMock.php';
+
+// setUp and tearDown for the test database are in DatabaseTestCase.php
+final class DiaryTest extends DatabaseTestCase
+{
+    public function testDiary_EmptyContentInContext_ShouldBeStrippedFromDiaryPrompt(): void
+    {
+        // default test config
+        require("conf.php");
+        $GLOBALS["HERIKA_NAME"]="Unit Test";
+        $GLOBALS["HERIKA_PERS"]="You are a Unit Test.";
+        $GLOBALS["CONNECTORS"]=["openrouter"];
+
+        // add dialogue history
+        $testDb = new sql();
+        $testDb->insert(
+            'eventlog',
+            array(
+                'ts' => "0",
+                'gamets' => "0",
+                'type' => "inputtext",
+                'data' => "Prisoner:Silence. (Talking to Unit Test)",
+                'sess' => 'pending',
+                'localts' => 0,
+                'people'=> "|Unit Test|",
+                'location'=> "",
+                'party'=> "[]"
+            )
+        );
+        $testDb->insert(
+            'eventlog',
+            array(
+                'ts' => "0",
+                'gamets' => "0",
+                'type' => "chat",
+                'data' => "", // empty content
+                'sess' => 'pending',
+                'localts' => 2,
+                'people'=> "|Unit Test|",
+                'location'=> "",
+                'party'=> "[]"
+            )
+        );
+        $testDb->close();
+
+        $GLOBALS["mockConnectorSend"]=$this->createMock(CallableMock::class);
+        $GLOBALS["mockConnectorSend"]->expects($this->once())
+        ->method('__invoke')
+        ->with(
+            $this->equalTo('https://openrouter.ai/api/v1/chat/completions'),
+            $this->callback(function ($streamContext) {
+                $expectedPrompt = ["role"=>"user", "content"=>""];
+                $this->expectPromptNotInContext($streamContext, $expectedPrompt);
+
+                $expectedPrompt = ["role"=>"user", "content"=>"Please write a short summary of Prisoner and Unit Tests last dialogues and events written above into Unit Tests diary . WRITE AS IF YOU WERE Unit Test."];
+                $this->expectPromptInContext($streamContext, $expectedPrompt);
+                return true;
+            })
+        )
+        ->willReturnCallback(function($url, $context) {
+            return $this->defaultConnectorResponse($url, $context);
+        });
+
+        // comm.php?data=diary|100|200|Unit Test (base64 encoded)
+        $encodedData = base64_encode("diary|100|200|Unit Test");
+        $_SERVER["QUERY_STRING"] = "data={$encodedData}";
+        $_GET["profile"] = md5($this->testNPCName);
+        require(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."comm.php");
+    }
+
+    private function expectPromptInContext($streamContext, $expectedPrompt) {
+        $options = stream_context_get_options($streamContext);
+        $content = json_decode($options['http']['content']);
+        $found=false;
+        foreach ($content->messages as $message) {
+            if (json_encode($message) === json_encode($expectedPrompt)) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($found);
+    }
+
+    private function expectPromptNotInContext($streamContext, $expectedPrompt) {
+        $options = stream_context_get_options($streamContext);
+        $content = json_decode($options['http']['content']);
+        $found=false;
+        foreach ($content->messages as $message) {
+            if (json_encode($message) === json_encode($expectedPrompt)) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertFalse($found);
+    }
+
+    private function defaultConnectorResponse($url, $context) {
+        $response = 'data: {"choices":[{"delta":{"content": "Diary content here"}}]}';
+        $resourceMock = fopen('php://temp', 'r+');
+        fwrite($resourceMock, $response);
+        rewind($resourceMock);
+        return $resourceMock;
+    }
+}


### PR DESCRIPTION
The openrouter non-json connector is missing logic to strip empty content elements from the context like all the other connectors have. This can cause LLM errors during diary prompts if the eventlog somehow has rows with empty data fields.

- Copies logic from openai.php to remove context elements with empty content
- Adds a regression test for the above
- Removes an annoying warning about $semaphore not being initialized (it isn't set during diary events)