### PR TITLE
prevent halt from being triggered by npc rechat

### DIFF
--- a/main.php
+++ b/main.php
@@ -442,7 +442,7 @@ require(__DIR__.DIRECTORY_SEPARATOR."processor".DIRECTORY_SEPARATOR."request.php
 /*
  Safe stop
 */
-if (preg_match(STOPALL_MAGIC_WORD, $gameRequest[3]) === 1) {  
+if (in_array($gameRequest[0],["inputtext","inputtext_s","ginputtext","ginputtext_s","instruction"]) && preg_match(STOPALL_MAGIC_WORD, $gameRequest[3]) === 1) {
     echo "{$GLOBALS["HERIKA_NAME"]}|command|Halt@\r\n";
     @ob_flush();
     $alreadysent[md5("{$GLOBALS["HERIKA_NAME"]}|command|Halt@\r\n")] = "{$GLOBALS["HERIKA_NAME"]}|command|Halt@\r\n";


### PR DESCRIPTION
The halt magic word may be triggered by NPCs during rechat events.
`rechat|386746178988600|57691220|Halted Stream Camp ,Hold: Whiterun Farkas has something to say in 4.1260001659393 secs`
This PR limits halt to explicit instructions from the player (inputtext, inputtext_s, ginputtext, ginputtext_s, instruction)