### PR TITLE
Split on commas in DataBeingsInCloseRange

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -1374,7 +1374,7 @@ function DataBeingsInRange()
         return "";
     }
     
-    $beings=strtr($lastLoc[0]["data"],["beings in range:"=>""]);
+    $beings=strtr($lastLoc[0]["data"],["(beings in range:"=>""]);
     $beingsArray=explode(",",$beings);
     $beingsArrayNew=[];
     foreach ($beingsArray as $k=>$v) {
@@ -1400,8 +1400,8 @@ function DataBeingsInCloseRange()
         return "";
     }
     
-    $beings=strtr($lastLoc[0]["data"],["beings in range:"=>""]);
-    $beingsArray=explode("/",$beings);
+    $beings=strtr($lastLoc[0]["data"],["(beings in range:"=>""]);
+    $beingsArray=explode(",",$beings);
     $beingsArrayNew=[];
     foreach ($beingsArray as $k=>$v) {
         if (strpos($v,")")===false) 


### PR DESCRIPTION
The new function DataBeingsInCloseRange is splitting the "beings in close range" eventlog entry on slashes, but it should be split on commas. This causes $people to be blank when inputtext is stored in eventlog, so the player's inputtext prompt doesn't get added to context.