### PR TITLE
add support for JP lip sync

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -550,9 +550,12 @@ function returnLines($lines,$writeOutput=true)
                     error_log("Applying listenerFix2");
                     $GLOBALS["SCRIPTLINE_LISTENER"]=trim($listenerFix2[0]);
                 }
+
+                // convert Japanese to Latin characters for use with lip sync
+                $responseTextPhonetic = containsJapanese($responseTextUnmooded) ? convertJapaneseTextToLatin($responseTextUnmooded) : "";
                 
-                echo "{$outBuffer["actor"]}|ScriptQueue|$responseTextUnmooded/{$GLOBALS["SCRIPTLINE_EXPRESSION"]}/{$GLOBALS["SCRIPTLINE_LISTENER"]}/{$GLOBALS["SCRIPTLINE_ANIMATION"]}\r\n";
-                $GLOBALS["DEBUG_DATA"]["OUTPUT_LOG"]="{$outBuffer["actor"]}|ScriptQueue|$responseTextUnmooded/{$GLOBALS["SCRIPTLINE_EXPRESSION"]}/{$GLOBALS["SCRIPTLINE_LISTENER"]}/{$GLOBALS["SCRIPTLINE_ANIMATION"]}\r\n";
+                echo "{$outBuffer["actor"]}|ScriptQueue|$responseTextUnmooded/{$GLOBALS["SCRIPTLINE_EXPRESSION"]}/{$GLOBALS["SCRIPTLINE_LISTENER"]}/{$GLOBALS["SCRIPTLINE_ANIMATION"]}/$responseTextPhonetic\r\n";
+                $GLOBALS["DEBUG_DATA"]["OUTPUT_LOG"]="{$outBuffer["actor"]}|ScriptQueue|$responseTextUnmooded/{$GLOBALS["SCRIPTLINE_EXPRESSION"]}/{$GLOBALS["SCRIPTLINE_LISTENER"]}/{$GLOBALS["SCRIPTLINE_ANIMATION"]}/$responseTextPhonetic\r\n";
                 file_put_contents(__DIR__."/../log/output_to_plugin.log",$GLOBALS["DEBUG_DATA"]["OUTPUT_LOG"], FILE_APPEND | LOCK_EX);
             }
             else
@@ -1431,3 +1434,25 @@ function startsWithUppercase($string) {
     return preg_match('/^[A-Z]/', $string);
 }
 
+function containsJapanese($string) {
+    $pattern = '/[\p{Hiragana}\p{Katakana}\p{Han}]/u';
+    return preg_match($pattern, $string);
+}
+
+function convertJapaneseTextToLatin($jpText) {
+    if (!file_exists("/home/dwemer/kakasi/")) {
+        error_log("Error: could not convert Japanese to Romaji because Kakasi is not installed. Lip sync will not work.");
+        return "";
+    }
+    $venvPath = "/home/dwemer/kakasi/kakasi_env/bin/python3";
+    $scriptPath = "/home/dwemer/kakasi/convert_to_romaji.py";
+
+    // Escape the Japanese text to avoid issues with special characters
+    $escapedText = escapeshellarg($jpText);
+
+    // Run the Python script using the virtual environment
+    $command = "$venvPath $scriptPath $escapedText";
+    $output = shell_exec($command);
+    $romaji = trim($output);
+    return $romaji;
+}

--- a/unittests/tests/CommTest.php
+++ b/unittests/tests/CommTest.php
@@ -374,7 +374,7 @@ final class CommTest extends DatabaseTestCase
         // default test config
         require("conf.php");
 
-        // add chat history in order to create assistant role
+        // add chat history
         $testDb = new sql();
         $testDb->insert(
             'eventlog',
@@ -410,7 +410,7 @@ final class CommTest extends DatabaseTestCase
         $_SERVER["QUERY_STRING"] = "data={$encodedData}";
         require(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."comm.php");
 
-        // confirm LLM response added to eventlog as chat
+        // confirm events after the 150 timestamp were purged
         $rows=$testDb->fetchAll("SELECT * FROM eventlog ORDER BY rowid ASC;");
         $testDb->close();
         $this->assertSame(3, sizeof($rows));
@@ -425,7 +425,7 @@ final class CommTest extends DatabaseTestCase
         // default test config
         require("conf.php");
 
-        // add chat history in order to create assistant role
+        // add chat history
         $testDb = new sql();
         $testDb->insert(
             'eventlog',
@@ -461,7 +461,7 @@ final class CommTest extends DatabaseTestCase
         $_SERVER["QUERY_STRING"] = "data={$encodedData}";
         require(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."comm.php");
 
-        // confirm LLM response added to eventlog as chat
+        // confirm events were not purged
         $rows=$testDb->fetchAll("SELECT * FROM eventlog ORDER BY rowid ASC;");
         $testDb->close();
         $this->assertSame(3, sizeof($rows));
@@ -469,6 +469,58 @@ final class CommTest extends DatabaseTestCase
         $this->assertSame("Lydia: Very well my Thane, I'll take a look around. (talking to Prisoner)", $rows[1]["data"]);
         $this->assertSame("user_input", $rows[2]["type"]);
         $this->assertSame("init", $rows[2]["data"]);
+    }
+
+    public function testComm_WhenLinesAreNotJapanese_PhoneticTextShouldBeNotSentToScriptQueue(): void
+    {
+        // default test config
+        require("conf.php");
+        $GLOBALS["HERIKA_NAME"] = "Lydia";
+        $GLOBALS["HERIKA_PERS"] = "Roleplay as Lydia.";
+
+        $GLOBALS["mockConnectorSend"]=$this->createMock(CallableMock::class);
+        $GLOBALS["mockConnectorSend"]->expects($this->once())
+        ->method('__invoke')
+        ->willReturnCallback(function($url, $context) {
+            $response = 'data: {"choices":[{"delta":{"content": "{\"character\": \"The Narrator\", \"listener\": \"Prisoner\", \"message\": \"Of course I do.\", \"mood\": \"default\", \"action\": \"Talk\", \"target\": \"Prisoner\"}"}}]}';
+            $resourceMock = fopen('php://temp', 'r+');
+            fwrite($resourceMock, $response);
+            rewind($resourceMock);
+            return $resourceMock;
+        });
+
+        // comm.php?data=inputtext|100|200|Do you speak Japanese? (base64 encoded)
+        $encodedData = base64_encode("inputtext|100|200|Do you speak Japanese?");
+        $_SERVER["QUERY_STRING"] = "data={$encodedData}";
+        require(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."comm.php");
+
+        $this->assertMatchesRegularExpression('/Lydia|ScriptQueue|Of course I do\.\/\/Prisoner\/(IdleDialogueExpressiveStart)?\/\r\n/', $GLOBALS["DEBUG_DATA"]["OUTPUT_LOG"]);
+    }
+
+    public function testComm_WhenLinesAreJapanese_PhoneticTextShouldBeSentToScriptQueue(): void
+    {
+        // default test config
+        require("conf.php");
+        $GLOBALS["HERIKA_NAME"] = "Lydia";
+        $GLOBALS["HERIKA_PERS"] = "Roleplay as Lydia.";
+
+        $GLOBALS["mockConnectorSend"]=$this->createMock(CallableMock::class);
+        $GLOBALS["mockConnectorSend"]->expects($this->once())
+        ->method('__invoke')
+        ->willReturnCallback(function($url, $context) {
+            $response = 'data: {"choices":[{"delta":{"content": "{\"character\": \"The Narrator\", \"listener\": \"Prisoner\", \"message\": \"当たり前でしょう。\", \"mood\": \"default\", \"action\": \"Talk\", \"target\": \"Prisoner\"}"}}]}';
+            $resourceMock = fopen('php://temp', 'r+');
+            fwrite($resourceMock, $response);
+            rewind($resourceMock);
+            return $resourceMock;
+        });
+
+        // comm.php?data=inputtext|100|200|日本語が分かりますか？ (base64 encoded)
+        $encodedData = base64_encode("inputtext|100|200|日本語が分かりますか？");
+        $_SERVER["QUERY_STRING"] = "data={$encodedData}";
+        require(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."comm.php");
+
+        $this->assertMatchesRegularExpression('/Lydia|ScriptQueue|当たり前でしょう。\/\/Prisoner\/(IdleDialogueExpressiveStart)?\/atarimae deshou\.\r\n/', $GLOBALS["DEBUG_DATA"]["OUTPUT_LOG"]);
     }
 
     private function expectPromptInContext($streamContext, $expectedPrompt) {


### PR DESCRIPTION
Checks if the line to be spoken contains Japanese text, and if so, converts it to the Latin alphabet and also sends that in the ScriptQueue.
Requires a python library to be installed in /home/dwemer/kakasi (pykakasi)