### PR TITLE
prevent error when listeners is an array

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -539,7 +539,11 @@ function returnLines($lines,$writeOutput=true)
                     $GLOBALS["SCRIPTLINE_ANIMATION"]="";
                     $GLOBALS["SCRIPTLINE_ANIMATION_SENT"]=true;
                 }
-                
+
+                if (is_array($GLOBALS["SCRIPTLINE_LISTENER"]) && sizeof($GLOBALS["SCRIPTLINE_LISTENER"]) > 0 && is_string($GLOBALS["SCRIPTLINE_LISTENER"][0])) {
+                    $GLOBALS["SCRIPTLINE_LISTENER"]=$GLOBALS["SCRIPTLINE_LISTENER"][0];
+                }
+
                 $listenerFix=explode(" and ",$GLOBALS["SCRIPTLINE_LISTENER"]);
                 if (is_array($listenerFix) && (sizeof($listenerFix)>1)) {
                     $GLOBALS["SCRIPTLINE_LISTENER"]=$listenerFix[0];


### PR DESCRIPTION
If the LLM gives listeners as an array, eg ["Prisoner", "Lydia"] then the explode statement will throw an error and stop execution.
`$listenerFix=explode(" and ",$GLOBALS["SCRIPTLINE_LISTENER"]);`