### PR TITLE
add an upsert function

### DIFF
--- a/lib/phpunit.class.php
+++ b/lib/phpunit.class.php
@@ -28,15 +28,15 @@ class sql
 
     public function insert($table, $data)
     {
-		$i=0;
+        $i=0;
         $columns = implode(', ', array_keys($data));
-		foreach (array_keys($data) as $d) {
-			$values[]='$'.(++$i);
-		}
+        foreach (array_keys($data) as $d) {
+            $values[]='$'.(++$i);
+        }
         $values = implode(', ', $values);
 
         $query = "INSERT INTO $table ($columns) VALUES ($values)";
-		//error_log($query);
+        //error_log($query);
         $params = array_values($data);
         //error_log(print_r($params,true));
         $result = pg_query_params(self::$link, $query, $params);
@@ -188,8 +188,124 @@ class sql
         }
 
         return true;
-}
+    }
 
+    public function upsertRowTrx($table, $data, $whereCondition) {
+        // Start a transaction
+        pg_query(self::$link, "BEGIN");
+    
+        try {
+            // Extract WHERE condition keys and values
+            $whereClauses = [];
+            $whereParams = [];
+            $i = 0;
+    
+            foreach ($whereCondition as $column => $value) {
+                $whereClauses[] = "$column = $" . (++$i); // Explicitly cast as TEXT
+                $whereParams[] = (string) $value; // Convert value to string
+            }
+    
+            
+            $whereSql = implode(" AND ", $whereClauses);
+    
+            // Check if the row exists and lock it
+            $checkQuery = "SELECT 1 FROM $table WHERE $whereSql FOR UPDATE";
+            $checkResult = pg_query_params(self::$link, $checkQuery, $whereParams);
+    
+            if (!$checkResult) {
+                throw new Exception(pg_last_error(self::$link));
+            }
+    
+            if (pg_num_rows($checkResult) > 0) {
+                // Row exists, perform an UPDATE (excluding WHERE fields)
+                $setClauses = [];
+                $params = [];
+                foreach ($data as $column => $value) {
+                    if (!array_key_exists($column, $whereCondition)) { // Exclude WHERE fields
+                        $setClauses[] = "$column = $" . (++$i); // Explicitly cast as TEXT
+                        $params[] = (string) $value; // Convert value to string
+                    }
+                }
+    
+                if (empty($setClauses)) {
+                    throw new Exception("No updatable fields provided.");
+                }
+    
+                $setSql = implode(', ', $setClauses);
+                $query = "UPDATE $table SET $setSql WHERE $whereSql";
+    
+                // Merge params: first the update values, then the WHERE values
+                $params = array_merge($params, $whereParams);
+            } else {
+                // Row does not exist, perform an INSERT
+                $i = 0;
+                $columns = array_keys($data);
+                $placeholders = [];
+                $params = [];
+    
+                foreach ($data as $index => $value) {
+                    $placeholders[] = '$' . (++$i) ; // Explicitly cast as TEXT
+                    $params[] = (string) $value; // Convert value to string
+                }
+    
+                $columnList = implode(', ', $columns);
+                $placeholderList = implode(', ', $placeholders);
+                $query = "INSERT INTO $table ($columnList) VALUES ($placeholderList)";
+            }
+    
+            // error_log($query . " " . print_r($params, true));
+    
+            // Execute the query
+            $result = pg_query_params(self::$link, $query, $params);
+            if (!$result) {
+                throw new Exception(pg_last_error(self::$link));
+            }
+    
+            // Commit transaction
+            pg_query(self::$link, "COMMIT");
+    
+            return true;
+        } catch (Exception $e) {
+            // Rollback on error
+            pg_query(self::$link, "ROLLBACK");
+            error_log($e->getMessage() . print_r(debug_backtrace(), true));
+            return false;
+        }
+    }
+
+    // an upsert that completes in one query. Good for simple cases when a constraint can be used
+    public function upsertRowOnConflict($tableName, $data, $conflictTarget) {
+        // Prepare the column names for the INSERT statement.
+        $columns = implode(', ', array_keys($data));
+    
+        // Take care of escaping here instead of requiring it before every upsert call
+        $values = array_map(function($value) {
+            return pg_escape_literal(self::$link, $value);
+        }, array_values($data));
+        $valuesString = implode(', ', $values);
+    
+        // EXCLUDED refers to the row that was attempted to be inserted.
+        // This loop constructs "column = EXCLUDED.column" for each column in the data.
+        $updateStatements = [];
+        foreach ($data as $column => $value) {
+            $updateStatements[] = "$column = EXCLUDED.$column";
+        }
+        $updateString = implode(', ', $updateStatements);
+    
+        // ON CONFLICT ... DO UPDATE is effectively an upsert
+        // If the constraint in $conflictTarget is violated during the insert, an update will be done instead
+        $sqlquery = "INSERT INTO $tableName ($columns) VALUES ($valuesString) " .
+                    "ON CONFLICT ($conflictTarget) DO UPDATE SET $updateString;";
+    
+        $result = pg_query(self::$link, $sqlquery);
+    
+        if (!$result) {
+            error_log(pg_last_error(self::$link) . print_r(debug_backtrace(), true));
+            return false; // Indicate failure
+        }
+    
+        return true; // Indicate success
+    }
 
 }
 

--- a/lib/postgresql.class.php
+++ b/lib/postgresql.class.php
@@ -28,15 +28,15 @@ class sql
 
     public function insert($table, $data)
     {
-		$i=0;
+        $i=0;
         $columns = implode(', ', array_keys($data));
-		foreach (array_keys($data) as $d) {
-			$values[]='$'.(++$i);
-		}
+        foreach (array_keys($data) as $d) {
+            $values[]='$'.(++$i);
+        }
         $values = implode(', ', $values);
 
         $query = "INSERT INTO $table ($columns) VALUES ($values)";
-		//error_log($query);
+        //error_log($query);
         $params = array_values($data);
         //error_log(print_r($params,true));
         $result = pg_query_params(self::$link, $query, $params);
@@ -271,6 +271,40 @@ class sql
             error_log($e->getMessage() . print_r(debug_backtrace(), true));
             return false;
         }
+    }
+
+    // an upsert that completes in one query. Good for simple cases when a constraint can be used
+    public function upsertRowOnConflict($tableName, $data, $conflictTarget) {
+        // Prepare the column names for the INSERT statement.
+        $columns = implode(', ', array_keys($data));
+    
+        // Take care of escaping here instead of requiring it before every upsert call
+        $values = array_map(function($value) {
+            return pg_escape_literal(self::$link, $value);
+        }, array_values($data));
+        $valuesString = implode(', ', $values);
+    
+        // EXCLUDED refers to the row that was attempted to be inserted.
+        // This loop constructs "column = EXCLUDED.column" for each column in the data.
+        $updateStatements = [];
+        foreach ($data as $column => $value) {
+            $updateStatements[] = "$column = EXCLUDED.$column";
+        }
+        $updateString = implode(', ', $updateStatements);
+    
+        // ON CONFLICT ... DO UPDATE is effectively an upsert
+        // If the constraint in $conflictTarget is violated during the insert, an update will be done instead
+        $sqlquery = "INSERT INTO $tableName ($columns) VALUES ($valuesString) " .
+                    "ON CONFLICT ($conflictTarget) DO UPDATE SET $updateString;";
+    
+        $result = pg_query(self::$link, $sqlquery);
+    
+        if (!$result) {
+            error_log(pg_last_error(self::$link) . print_r(debug_backtrace(), true));
+            return false; // Indicate failure
+        }
+    
+        return true; // Indicate success
     }
 
 }

--- a/tts/tts-openai.php
+++ b/tts/tts-openai.php
@@ -32,7 +32,7 @@ $GLOBALS["TTS_IN_USE"]=function($textString, $mood , $stringforhash) {
 		
 		// add instructions if using gpt-4o-mini-tts
 		if ($GLOBALS["TTS"]["openai"]["model_id"] == "gpt-4o-mini-tts") {
-			if ($mood) {
+			if ($mood && $mood != "default") {
 				$data["instructions"] = "Emotion: $mood\n";
 			}
 


### PR DESCRIPTION
Adds upsertRowOnConflict() for simple upserts when the table has a constraint. This completes in one sql query, so it should be fast and avoid any race conditions.
Will avoid actually calling this function in CHIM until after the next release, but I'd like to add the function now for testing in Min AI.