### PR TITLE
Update conf_loader.php to allow plugins to add their own settings

### DIFF
--- a/conf/conf_loader.php
+++ b/conf/conf_loader.php
@@ -6,6 +6,23 @@ function conf_loader_load() {
 
 	$confSchema=json_decode(file_get_contents($localPath."conf_schema.json"),true);
 
+	// Load plugin schemas from ext/*/conf/*_conf.php
+	$pluginSchemas = [];
+	$extDir = $rootPath . "ext" . DIRECTORY_SEPARATOR;
+	$pluginFolders = glob($extDir . "*", GLOB_ONLYDIR);
+	foreach ($pluginFolders as $folder) {
+		$pluginName = basename($folder);
+		$confDir = $folder . DIRECTORY_SEPARATOR . "conf" . DIRECTORY_SEPARATOR;
+		$pluginConfigs = glob($confDir . "*_conf.php");
+		foreach ($pluginConfigs as $pluginConfig) {
+			include_once $pluginConfig;
+			$schemaFunc = "get_{$pluginName}_schema";
+			if (function_exists($schemaFunc)) {
+				$pluginSchemas[$pluginName] = $schemaFunc();
+			}
+		}
+	}
+
 	$langFolders=scandir($rootPath."lang".DIRECTORY_SEPARATOR);
 	foreach ($langFolders as $n=>$folder)
 		if (!is_dir($rootPath."lang".DIRECTORY_SEPARATOR.$folder))
@@ -45,6 +62,30 @@ function conf_loader_load() {
 		}
 	}
 
+	// Merge plugin schemas into confMap, pulling values from $GLOBALS
+	foreach ($pluginSchemas as $pluginName => $pluginSchema) {
+		foreach ($pluginSchema as $name => $definition) {
+			if (isset($definition["type"])) {
+				$definition["currentValue"] = $GLOBALS[$name] ?? null;
+				$confMap[$name] = $definition;
+			} else if (is_array($definition)) {
+				foreach ($definition as $name2 => $definition2) {
+					if (isset($definition2["type"])) {
+						$definition2["currentValue"] = $GLOBALS[$name][$name2] ?? null;
+						$confMap["$name $name2"] = $definition2;
+					} else if (is_array($definition2)) {
+						foreach ($definition2 as $name3 => $definition3) {
+							if (isset($definition3["type"])) {
+								$definition3["currentValue"] = $GLOBALS[$name][$name2][$name3] ?? null;
+								$confMap["$name $name2 $name3"] = $definition3;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return $confMap;
 }
 
@@ -54,6 +95,41 @@ function conf_loader_load_titles() {
 	$rootPath=__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR;
 
 	$confSchema=json_decode(file_get_contents($localPath."conf_schema.json"),true);
+
+	// Load plugin titles from ext/*/conf/*_conf.php
+	$extDir = $rootPath . "ext" . DIRECTORY_SEPARATOR;
+	$pluginFolders = glob($extDir . "*", GLOB_ONLYDIR);
+	foreach ($pluginFolders as $folder) {
+		$pluginName = basename($folder);
+		$confDir = $folder . DIRECTORY_SEPARATOR . "conf" . DIRECTORY_SEPARATOR;
+		$pluginConfigs = glob($confDir . "*_conf.php");
+		foreach ($pluginConfigs as $pluginConfig) {
+			include_once $pluginConfig;
+			$schemaFunc = "get_{$pluginName}_schema";
+			if (function_exists($schemaFunc)) {
+				$pluginSchema = $schemaFunc();
+				foreach ($pluginSchema as $name => $definition) {
+					if (isset($definition["_title"])) {
+						$titleMap[$name] = $definition["_title"];
+					}
+					if (is_array($definition)) {
+						foreach ($definition as $name2 => $definition2) {
+							if (isset($definition2["_title"])) {
+								$titleMap["$name $name2"] = $definition2["_title"];
+							}
+							if (is_array($definition2)) {
+								foreach ($definition2 as $name3 => $definition3) {
+									if (isset($definition3["_title"])) {
+										$titleMap["$name $name2 $name3"] = $definition3["_title"];
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 
 	foreach ($confSchema as $name=>$definition) {
 		if (isset($definition["_title"])) {
@@ -85,6 +161,39 @@ function conf_loader_load_schema() {
 	$rootPath=__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR;
 
 	$confSchema=json_decode(file_get_contents($localPath."conf_schema.json"),true);
+
+	// Load plugin schemas from ext/*/conf/*_conf.php
+	$extDir = $rootPath . "ext" . DIRECTORY_SEPARATOR;
+	$pluginFolders = glob($extDir . "*", GLOB_ONLYDIR);
+	foreach ($pluginFolders as $folder) {
+		$pluginName = basename($folder);
+		$confDir = $folder . DIRECTORY_SEPARATOR . "conf" . DIRECTORY_SEPARATOR;
+		$pluginConfigs = glob($confDir . "*_conf.php");
+		foreach ($pluginConfigs as $pluginConfig) {
+			include_once $pluginConfig;
+			$schemaFunc = "get_{$pluginName}_schema";
+			if (function_exists($schemaFunc)) {
+				$pluginSchema = $schemaFunc();
+				foreach ($pluginSchema as $name => $definition) {
+					if (isset($definition["type"])) {
+						$confMap[$name] = $definition;
+					} else if (is_array($definition)) {
+						foreach ($definition as $name2 => $definition2) {
+							if (isset($definition2["type"])) {
+								$confMap["$name $name2"] = $definition2;
+							} else if (is_array($definition2)) {
+								foreach ($definition2 as $name3 => $definition3) {
+									if (isset($definition3["type"])) {
+										$confMap["$name $name2 $name3"] = $definition3;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 
 	foreach ($confSchema as $name=>$definition) {
 		if (isset($definition["type"])) {

--- a/conf/conf_loader.php
+++ b/conf/conf_loader.php
@@ -16,9 +16,12 @@ function conf_loader_load() {
 		$pluginConfigs = glob($confDir . "*_conf.php");
 		foreach ($pluginConfigs as $pluginConfig) {
 			include_once $pluginConfig;
-			$schemaFunc = "get_{$pluginName}_schema";
+			$schemaFunc = "get_" . basename($pluginConfig, "_conf.php") . "_schema";
 			if (function_exists($schemaFunc)) {
-				$pluginSchemas[$pluginName] = $schemaFunc();
+				$pluginSchemas[$pluginName] = array_merge(
+					$pluginSchemas[$pluginName] ?? [],
+					$schemaFunc()
+				);
 			}
 		}
 	}
@@ -62,21 +65,21 @@ function conf_loader_load() {
 		}
 	}
 
-	// Merge plugin schemas into confMap, pulling values from $GLOBALS
+	// Merge plugin schemas into confMap, pulling values from $GLOBALS or defaults
 	foreach ($pluginSchemas as $pluginName => $pluginSchema) {
 		foreach ($pluginSchema as $name => $definition) {
 			if (isset($definition["type"])) {
-				$definition["currentValue"] = $GLOBALS[$name] ?? null;
+				$definition["currentValue"] = $GLOBALS[$name] ?? $definition["default"] ?? null;
 				$confMap[$name] = $definition;
 			} else if (is_array($definition)) {
 				foreach ($definition as $name2 => $definition2) {
 					if (isset($definition2["type"])) {
-						$definition2["currentValue"] = $GLOBALS[$name][$name2] ?? null;
+						$definition2["currentValue"] = $GLOBALS[$name][$name2] ?? $definition2["default"] ?? null;
 						$confMap["$name $name2"] = $definition2;
 					} else if (is_array($definition2)) {
 						foreach ($definition2 as $name3 => $definition3) {
 							if (isset($definition3["type"])) {
-								$definition3["currentValue"] = $GLOBALS[$name][$name2][$name3] ?? null;
+								$definition3["currentValue"] = $GLOBALS[$name][$name2][$name3] ?? $definition3["default"] ?? null;
 								$confMap["$name $name2 $name3"] = $definition3;
 							}
 						}
@@ -105,7 +108,7 @@ function conf_loader_load_titles() {
 		$pluginConfigs = glob($confDir . "*_conf.php");
 		foreach ($pluginConfigs as $pluginConfig) {
 			include_once $pluginConfig;
-			$schemaFunc = "get_{$pluginName}_schema";
+			$schemaFunc = "get_" . basename($pluginConfig, "_conf.php") . "_schema";
 			if (function_exists($schemaFunc)) {
 				$pluginSchema = $schemaFunc();
 				foreach ($pluginSchema as $name => $definition) {
@@ -171,7 +174,7 @@ function conf_loader_load_schema() {
 		$pluginConfigs = glob($confDir . "*_conf.php");
 		foreach ($pluginConfigs as $pluginConfig) {
 			include_once $pluginConfig;
-			$schemaFunc = "get_{$pluginName}_schema";
+			$schemaFunc = "get_" . basename($pluginConfig, "_conf.php") . "_schema";
 			if (function_exists($schemaFunc)) {
 				$pluginSchema = $schemaFunc();
 				foreach ($pluginSchema as $name => $definition) {


### PR DESCRIPTION
### Why?
Plugins need the ability to add settings specific to each profile to enable features or store data. I wanted to allow plugins to add their own schemas without having to add new fields to this repo. By hooking plugins into the configuration schema, we can centralize npc settings. 

### How It Works
The system will scan all plugins in the `ext` folder on the server. If a plugin wants to add its own schema, it must:

1. Create a `conf` folder in the plugin.
2. Add a PHP file named `<name>_conf.php` (e.g., `npcgroup_conf.php`).
3. Inside that file, create a function called `get_<filename>_schema()` (e.g., `get_npcgroup_schema()`).
4. Return the configuration properties you want in the schema function.
5. You can have multiple `conf.php` files for your plugin.

For an example plugin, check: [MyPlugin Example](https://github.com/vrpdont/myplugin/tree/main). Download the zip, add the `myplugin` folder to the `ext` folder, and open the configuration wizard.

Example configuration file: [myplugin_conf.php](https://github.com/vrpdont/myplugin/blob/main/myplugin/conf/myplugin_conf.php).

### Testing Checklist
- [ ] Ensure new settings show up in the configuration wizard.
- [ ] Verify new settings are saved correctly.
- [ ] Check if properties can be copied to all profiles (non-locked).
- [ ] Confirm default values populate properly, and non-default values work as expected.

### Next Steps for Future PRs
- Allow plugins to place themselves after specific settings (e.g., after "Roleplay Management").
  - Alternatively, make a section for all plugins in the configuration page and store them all there.
- Identify any issues with dynamically setting schemas (do we need extra data for schema control?).
- Consider adding the plugin name to the schema function to avoid collisions (unlikely, but possible).
