### PR TITLE
fix location regex for multibyte characters

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -525,15 +525,15 @@ function DataLastDataExpandedFor($actor, $lastNelements = -10,$sqlfilter="")
         $printLocation=false;
         
         $string = $row["location"];
-        preg_match('/Context\s*(new\s*)?location:\s*([^$,]+?)/', $string, $locationMatch);
-        preg_match('/Hold:\s*([^$,\)]+?)/', $string, $holdMatch);
+        preg_match('/Context\s*(?:new\s*)?location:\s*([^,]+?)(?:,|$)/u', $string, $locationMatch);
+        preg_match('/Hold:\s*([^,\)]+?)(?:,|\)|$)/u', $string, $holdMatch);
         
         if (!isset($holdMatch[1])) {
             //error_log(print_r($string,true));
             $locationFinal=$lastlocation;
         } else {
             $hold = trim($holdMatch[1]);
-            $location = trim($locationMatch[2]);
+            $location = trim($locationMatch[1]);
             $locationFinal="$location, hold: $hold";
         }
         


### PR DESCRIPTION
The current location regex is broken for multibyte characters such as `Świątynia Kynaret`, returning only a partial byte from the first character. This partial byte breaks the POST to the LLM and causes an error.
Fixed the regex to match on unicode characters and to correctly match on the end of the line rather than a literal dollar sign.