### PR TITLE
Fix: default profile current connector

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -3414,8 +3414,8 @@ function createProfile($npcname,$FORCE_PARMS=[],$overwrite=false,$baseprofile=''
         file_put_contents($newFile, '?>'.PHP_EOL, FILE_APPEND | LOCK_EX);
 
         $currentModelFilePath = $path."data/CurrentModel_".md5($npcname).".json";
-        Logger::info(DMgetCurrentModelFile()." ".$currentModelFilePath);
-        copy(DMgetCurrentModelFile(),$currentModelFilePath);
+        Logger::info(DMgetDefaultModelFile()." ".$currentModelFilePath);
+        copy(DMgetDefaultModelFile(),$currentModelFilePath);
         shell_exec("chmod 0775 {$currentModelFilePath}");
         
          // Character Map file

--- a/lib/model_dynmodel.php
+++ b/lib/model_dynmodel.php
@@ -18,22 +18,22 @@ function removeAndReturnNext(&$array, $value) {
 
 function DMgetCurrentModel() {
     
-    $lprof=isset($GLOBALS["active_profile"])?$GLOBALS["active_profile"]:"";
-    
+    $lprof=$GLOBALS["active_profile"] ?? "72dc4b1c501563d149fec99eb45b45f1"; // default profile: 72dc4b1c501563d149fec99eb45b45f1 = md5("The Narrator")
     $file=__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."data".DIRECTORY_SEPARATOR."CurrentModel_{$lprof}.json";
     if (!file_exists($file) || getenv("PHPUNIT_TEST")) {
         DMsetCurrentModel($GLOBALS["CONNECTORS"][0]);
     }
 
     $cmj=file_get_contents($file);
-    
-    return json_decode($cmj,true);
+
+    $s_res = json_decode($cmj,true);
+    return $s_res;
 
 }
 
 function DMgetCurrentModelFile() {
     
-    $lprof=isset($GLOBALS["active_profile"])?$GLOBALS["active_profile"]:"";
+    $lprof=$GLOBALS["active_profile"] ?? "72dc4b1c501563d149fec99eb45b45f1"; 
     
     $file=__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."data".DIRECTORY_SEPARATOR."CurrentModel_{$lprof}.json";
     if (!file_exists($file)) {
@@ -44,14 +44,35 @@ function DMgetCurrentModelFile() {
 
 }
 
-function DMsetCurrentModel($model) {
+function DMgetDefaultModelFile() {
+    
+    $lprof="72dc4b1c501563d149fec99eb45b45f1";
+    
+    $file=__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."data".DIRECTORY_SEPARATOR."CurrentModel_{$lprof}.json";
+    if (!file_exists($file)) {
+        $file_def=$file;
+        $file=__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."data".DIRECTORY_SEPARATOR."CurrentModel_.json";
+        if (!file_exists($file)) {
+            Logger::warn("DMgetDefaultModelFile: no default model file found!");
+            $model="openrouterjson";
+            $file=$file_def;
+            $cmj=file_put_contents($file,json_encode($model));
+            shell_exec("chmod 0777 {$file}");
+        }
+    }
+    
+    return $file;
+}
 
-    $lprof=isset($GLOBALS["active_profile"])?$GLOBALS["active_profile"]:"";
+function DMsetCurrentModel($model='') {
 
-        
+    $lprof=$GLOBALS["active_profile"] ?? "72dc4b1c501563d149fec99eb45b45f1"; 
+    
     $file=__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."data".DIRECTORY_SEPARATOR."CurrentModel_{$lprof}.json";
 
-    shell_exec("chmod 775 $file");
+    shell_exec("chmod 0777 {$file}");
+    if (empty($model))
+        $model="openrouterjson";
     $cmj=file_put_contents($file,json_encode($model));
 
 }


### PR DESCRIPTION
The current connector of the default profile is sometimes stored in the 'CurrentModel_.json' file and read from 'CurrentModel_72dc4b1c501563d149fec99eb45b45f1.json'. The content of the two files is only synchronized after 'Copy to all profiles'. This change aims to always use the 'CurrentModel_72dc4b1c501563d149fec99eb45b45f1.json' file.