### PR TITLE
Fix: escaped quotes in text fields in config. wizard

### DIFF
--- a/ui/tools/conf_writer.php
+++ b/ui/tools/conf_writer.php
@@ -36,6 +36,11 @@ if (isset($_GET["incomplete"])) {
 
 }
 
+function process_slashes($s_input)  {
+    $sx = str_replace("\\'", "'", $s_input);
+    return addcslashes($sx,"'"); 
+}
+
 foreach ($_POST as $k=>$v) {
     
     $fullNameHierch=explode("@",$k);
@@ -52,7 +57,7 @@ foreach ($_POST as $k=>$v) {
     else if ($confSchema[$plainNameHierch]["type"]=="boolean")
         $value=($v=="true")?"true":"false";
     else
-        $value="'".addcslashes($v,"'")."'";
+        $value="'".process_slashes($v)."'";
     
     
     


### PR DESCRIPTION
Already escaped quotes in text fields prevents rendering of pages in Web UI.