### PR TITLE
Replace placeholder in player bios with actual player name. Fix llm generating excessive non unique tags

### DIFF
--- a/debug/util_memory_subsystem.php
+++ b/debug/util_memory_subsystem.php
@@ -229,6 +229,30 @@ Here are additional instructions: {$GLOBALS["SUMMARY_PROMPT"]}
                     }
                     $connectionHandler->close();
                     $TEST_TEXT=strtr($buffer,["**"=>""]); // Use the final buffer
+
+                    // if the llm repeats tags we tidy them up
+                    $pattern = '/(.+)#Tags:(.+)/';
+                    preg_match($pattern, $TEST_TEXT, $matches);
+                    $tagsCol=''; // Initialize tagsCol
+                    if (isset($matches[2])) {
+                        // make data consistent (copied from tagsCol creation below)
+                        $tagsString = strtr($matches[2],["*"=>""]);
+                        $tagsArray = array_map('trim', explode(',', $tagsString));
+                        $tagsCol=implode(" ",$tagsArray);
+                        $tagsArray = array_map('trim', explode(' ', $tagsCol));
+
+                        // Remove duplicates and last tag if duplicates found
+                        $uniqueTagsArray = array_unique($tagsArray);
+                        if (count($uniqueTagsArray) < count($tagsArray)) {
+                            // Duplicates found - remove last tag as it may be truncated
+                            array_pop($uniqueTagsArray);
+                            Logger::debug("Corrected duplicate tags:\nOriginal tags: [" . implode(' ', $tagsArray) . "]\nUnique tags: [" . implode(' ', $uniqueTagsArray) . "]");
+                            $tagsCol = implode(" ", array_values($uniqueTagsArray));
+                            // Reconstruct TEST_TEXT with corrected tags
+                            $TEST_TEXT = trim($matches[1]) . "\n#Tags: " . $tagsCol;
+                        }
+                    }
+
                     $toUpdate[]=["rowid"=>$row["rowid"],"summary"=>$TEST_TEXT];
                 }
                 // Summarization logic ends, $TEST_TEXT contains the summary or packed_message

--- a/player_rewrite.php
+++ b/player_rewrite.php
@@ -84,7 +84,8 @@ if (!isset($GLOBALS["CURRENT_CONNECTOR"]) || (!file_exists($enginePath."connecto
         }
         
         if (!empty($GLOBALS["PLAYER_BIOS"])) {
-            $playerContext .= "Player Character Background: " . $GLOBALS["PLAYER_BIOS"] . "\n";
+            $bio = strtr($GLOBALS["PLAYER_BIOS"],["#PLAYER_NAME#"=>$GLOBALS["PLAYER_NAME"]]);
+            $playerContext .= "Player Character Background: " . $bio . "\n";
         }
         if (!empty($GLOBALS["PLAYER_SPEECH_STYLE"])) {
             $playerContext .= "Player Speech Style: " . $GLOBALS["PLAYER_SPEECH_STYLE"] . "\n";


### PR DESCRIPTION
Player rewrite should replace placeholder for player name

Fixes when llm spews duplicate tags in memory summary