### PR TITLE
Unmood variable scoping (using original code intent)

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -293,48 +293,59 @@ function getEndOfSentencePunctuation() {
 
 function unmoodSentence($sentence) {
     global $forceMood;
-    
-    if (isset($GLOBALS["strip_emotes_from_output"]) && $GLOBALS["strip_emotes_from_output"] == true) {
-        $GLOBALS["REMOVE_ASTERISKS_FROM_OUTPUT"]=true;
+
+    $output = $sentence;
+
+    // Determine whether to process asterisks:
+    // - strip_emotes_from_output (if set) overrides
+    // - otherwise fall back to REMOVE_ASTERISKS_FROM_OUTPUT
+    if (array_key_exists('strip_emotes_from_output', $GLOBALS)) {
+        $processAsterisks = (bool)$GLOBALS['strip_emotes_from_output'];
+    } else {
+        $processAsterisks = !empty($GLOBALS['REMOVE_ASTERISKS_FROM_OUTPUT']);
     }
 
-    if (isset($GLOBALS["REMOVE_ASTERISKS_FROM_OUTPUT"]) && $GLOBALS["REMOVE_ASTERISKS_FROM_OUTPUT"] == true) {
-        // Check to see if the LLM responded with the entire message in **'s.
-        if (str_starts_with($sentence, "*") && str_ends_with($sentence, "*")) {
-            $output = ltrim($sentence, "*");
-            $output = rtrim($sentence, "*");
-        }
-        else {
-            $output = preg_replace('/\*([^*]+)\*/', '', $sentence); // Remove text bewteen * *
+    if ($processAsterisks) {
+        // If the entire message is wrapped in asterisks, strip them from both ends
+        if (str_starts_with($output, '*') && str_ends_with($output, '*')) {
+            $output = trim($output, '*'); // correct trimming of leading/trailing asterisks
+        } else {
+            // Remove text between single-pair asterisks
+            $output = preg_replace('/\*([^*]+)\*/', '', $output);
         }
     }
+    // is this the users intention if they set REMOVE_ASTERISKS false?
     else {
-        $output = preg_replace('/\*(\w+\s+\w+.*?)\*/', '', $sentence); // Remove text bewteen * * if two or more words inside
+        // Remove text bewteen * * if two or more words inside
+        $output = preg_replace('/\*(\w+\s+\w+.*?)\*/', '', $sentence);
     }
-    $sentence=$output;
-    $output = strtr($sentence,[
-                    "*Smirks*"=>"","*smirks*"=>"",
-                    "*winks*"=>"","*wink*"=>"","*smirk*"=>"","*gasps*"=>"","*chuckles*"=>"","*giggles*"=>"","*Giggles*"=>"","*laughs*"=>"",
-                    "*gasp*"=>"","*moans*"=>"","*whispers*"=>"","*moan*"=>"","#SpeechStyle"=>"","#SpeechStyle:"=>"",
-                    "*pant*"=>"",
-                    "*cough*"=>"",
-                    "*hiccup*"=>"",
-                    "*whimper*"=>""
-                    ]
-                    ); // Manual cases
 
-    
-    $cleaned = preg_replace('/\s*# ?ACTIONS.*/', '', $output);  // Remove #ACTIONS .... (Gemini seems prone to doing this)
-    $output = preg_replace('/#[A-Za-z]+/', '', $cleaned);       // Remove #<text> .... (Gemini seems prone to doing this)
+    // Remove common emote tokens wrapped in asterisks (user intention?)
+    $output = strtr($output, [
+        "*Smirks*" => "", "*smirks*" => "",
+        "*winks*" => "", "*wink*" => "", "*smirk*" => "", "*gasps*" => "", "*chuckles*" => "", "*giggles*" => "", "*Giggles*" => "", "*laughs*" => "",
+        "*gasp*" => "", "*moans*" => "", "*whispers*" => "", "*moan*" => "",
+        "*pant*" => "", "*cough*" => "", "*hiccup*" => "", "*whimper*" => ""
+    ]);
 
-    $cleaned=$output;
-    $sentence = preg_replace('/"/', '', $cleaned); // Remove "
+    // Non-asterisk-related cleanup always applies
+    $output = strtr($output, [
+        "#SpeechStyle" => "",
+        "#SpeechStyle:" => ""
+    ]);
 
-    preg_match_all('/\((.*?)\)/', $sentence, $matches); // Unused?
+    $output = preg_replace('/\s*# ?ACTIONS.*/', '', $output);  // Remove "#ACTIONS ..."
+    $output = preg_replace('/#[A-Za-z]+/', '', $output);       // Remove "#<text>"
 
-    $responseTextUnmooded = trim(preg_replace('/\((.*?)\)/', '', $sentence));
+    // Remove quotes
+    $output = preg_replace('/"/', '', $output);
 
-    if (stripos($responseTextUnmooded, "whispering:") !== false) { // Very very nasty, but solves lots of isses. We must keep log clean.
+    // Remove parenthesized content and trim the result
+    $output = preg_replace('/\((.*?)\)/i', '', $output);
+    $responseTextUnmooded = trim($output);
+
+    // Handle whispering mood marker
+    if (stripos($responseTextUnmooded, "whispering:") !== false) {
         $responseTextUnmooded = str_ireplace("whispering:", "", $responseTextUnmooded);
         $forceMood = "whispering";
     }


### PR DESCRIPTION
I question that if the user has said not to remove asterisk by setting that in the profile, should we be removing `*two or more word*` examples