### PR TITLE
Replace php syntax in `DIARY_PROMPT` with placeholder-based syntax

### DIFF
--- a/conf/conf.sample.php
+++ b/conf/conf.sample.php
@@ -113,7 +113,7 @@ $DYNAMIC_PROMPT_GOALS = "Based on story developments and achievements, update th
     . "Focus on new aspirations that emerged, modified existing goals due to circumstances, and updated long-term objectives. "
     . "Return ONLY a bulleted list using * Goal description as actionable aspiration format. Do not include any introductory text, meta-commentary, or phrases like 'Here are the updated goals' or 'The character's goals are'. "
     . "Start directly with the first bullet point.";
-$DIARY_PROMPT = "Please write a short summary of {\$GLOBALS[\"PLAYER_NAME\"]} and {\$GLOBALS[\"HERIKA_NAME\"]}s last dialogues and events written above into {\$GLOBALS[\"HERIKA_NAME\"]}s diary . WRITE AS IF YOU WERE {\$GLOBALS[\"HERIKA_NAME\"]}. Start the diary entry with the current date and time.";
+$DIARY_PROMPT = "Please write a short summary of #PLAYER_NAME# and #HERIKA_NAME#s last dialogues and events written above into #HERIKA_NAME#s diary . WRITE AS IF YOU WERE #HERIKA_NAME#. Start the diary entry with the current date and time.";
 
 // Dynamic profile utility button
 $dynamic_profile_b1 = false; // Utility button for updating all dynamic profile fields

--- a/lib/dynamic_update_util.php
+++ b/lib/dynamic_update_util.php
@@ -104,7 +104,7 @@ function generateNearbyDiary($npcName, $gameRequest, $eventType) {
             $prompt[] = ["role" => "user", "content" => "Recent context: " . $historyData];
         }
 
-        $diaryPrompt = strtr($GLOBALS["DIARY_PROMPT"], ['#HERIKA_NAME#'=>$npcName,'#PLAYER_NAME"#'=>$NPC_CONF["PLAYER_NAME"]]);
+        $diaryPrompt = strtr($GLOBALS["DIARY_PROMPT"], ['#HERIKA_NAME#'=>$npcName,'#PLAYER_NAME#'=>$NPC_CONF["PLAYER_NAME"]]);
         $prompt[] = ["role" => "user", "content" => $diaryPrompt];
 
         $contextData = array_merge($head, $prompt);

--- a/lib/dynamic_update_util.php
+++ b/lib/dynamic_update_util.php
@@ -104,7 +104,7 @@ function generateNearbyDiary($npcName, $gameRequest, $eventType) {
             $prompt[] = ["role" => "user", "content" => "Recent context: " . $historyData];
         }
 
-        $diaryPrompt = strtr($GLOBALS["DIARY_PROMPT"], ['{$GLOBALS["HERIKA_NAME"]}'=>$npcName,'{$GLOBALS["PLAYER_NAME"]}'=>$NPC_CONF["PLAYER_NAME"]]);
+        $diaryPrompt = strtr($GLOBALS["DIARY_PROMPT"], ['#HERIKA_NAME#'=>$npcName,'#PLAYER_NAME"#'=>$NPC_CONF["PLAYER_NAME"]]);
         $prompt[] = ["role" => "user", "content" => $diaryPrompt];
 
         $contextData = array_merge($head, $prompt);
@@ -562,7 +562,7 @@ function generateFollowerDiary($followerName, $gameRequest, $eventType) {
             $prompt[] = ["role" => "user", "content" => "Recent context: " . $historyData];
         }
 
-        $diaryPrompt=strtr($GLOBALS["DIARY_PROMPT"],['{$GLOBALS["HERIKA_NAME"]}'=>$followerName,'{$GLOBALS["PLAYER_NAME"]}'=>$FOLLOWER_CONF["PLAYER_NAME"]]);
+        $diaryPrompt=strtr($GLOBALS["DIARY_PROMPT"],['#HERIKA_NAME#'=>$followerName,'#PLAYER_NAME#'=>$FOLLOWER_CONF["PLAYER_NAME"]]);
 
         $prompt[] = 
             ["role" => "user", "content" => $diaryPrompt

--- a/processor/request.php
+++ b/processor/request.php
@@ -117,7 +117,7 @@ if ($gameRequest[0] == "funcret") { // Take out the functions part
 } else if ($gameRequest[0] == "diary") {
 	// Use configurable DIARY_PROMPT or fallback to default
 	$diaryPrompt = isset($GLOBALS["DIARY_PROMPT"]) && !empty($GLOBALS["DIARY_PROMPT"]) 
-		? strtr($GLOBALS["DIARY_PROMPT"],['{$GLOBALS["HERIKA_NAME"]}'=>$GLOBALS["HERIKA_NAME"],'{$GLOBALS["PLAYER_NAME"]}'=>$GLOBALS["PLAYER_NAME"]])
+		? strtr($GLOBALS["DIARY_PROMPT"],['#HERIKA_NAME#'=>$GLOBALS["HERIKA_NAME"],'#PLAYER_NAME#'=>$GLOBALS["PLAYER_NAME"]])
 		: "Please write a short summary of {$GLOBALS["PLAYER_NAME"]} and {$GLOBALS["HERIKA_NAME"]}s last dialogues and events written above into {$GLOBALS["HERIKA_NAME"]}s diary . WRITE AS IF YOU WERE {$GLOBALS["HERIKA_NAME"]}.";
 	
 	// Add current game date/time context to the prompt


### PR DESCRIPTION
when doing stuff with DIARY_PROMPT there was a change made where the placeholder replacement is like this: `strtr($GLOBALS["DIARY_PROMPT"],['{$GLOBALS["HERIKA_NAME"]}'=>$GLOBALS["HERIKA_NAME"],'{$GLOBALS["PLAYER_NAME"]}'=>$GLOBALS["PLAYER_NAME"]])`

This implies the user needs to put php looking interpolation text inside the prompt rather than the "human readable" `#var#` style. Why was this changed from `#HERIKA_NAME#` and `#PLAYER_NAME#`. This is on both aiagent and dev branches. This patch restores it in case it wasnt intentional - or you agree its better to be consistent in the profile prompts.