### PR TITLE
Refactor summary splitting to avoid failing regexp

### DIFF
--- a/debug/util_memory_subsystem.php
+++ b/debug/util_memory_subsystem.php
@@ -231,11 +231,11 @@ Here are additional instructions: {$GLOBALS["SUMMARY_PROMPT"]}
                     $TEST_TEXT=strtr($buffer,["**"=>""]); // Use the final buffer
 
                     // if the llm repeats tags we tidy them up
-                    $pattern = '/(.+)#Tags:(.+)/';
-                    preg_match($pattern, $TEST_TEXT, $matches);
-                    if (isset($matches[2])) {
+                    $pattern = '/#Tags:/';
+                    $split = preg_split($pattern, $TEST_TEXT, 2);
+                    if (isset($split[1])) {
                         // make data consistent (copied from tagsCol creation below)
-                        $tagsString = strtr($matches[2],["*"=>""]);
+                        $tagsString = strtr($split[1],["*"=>""]);
                         $tagsArray = array_map('trim', explode(',', $tagsString));
                         $tagsCol=implode(" ",$tagsArray);
                         $tagsArray = array_map('trim', explode(' ', $tagsCol));
@@ -248,7 +248,7 @@ Here are additional instructions: {$GLOBALS["SUMMARY_PROMPT"]}
                             Logger::debug("Corrected duplicate tags:\nOriginal tags: [" . implode(' ', $tagsArray) . "]\nUnique tags: [" . implode(' ', $uniqueTagsArray) . "]");
                             $tagsCol = implode(" ", array_values($uniqueTagsArray));
                             // Reconstruct TEST_TEXT with corrected tags
-                            $TEST_TEXT = trim($matches[1]) . "\n#Tags: " . $tagsCol;
+                            $TEST_TEXT = trim($split[0]) . "\n#Tags: " . $tagsCol;
                         }
                     }
 


### PR DESCRIPTION
This is a more lazy match to split the summary into content and tags. Should work for all edge cases as long as `#Tags:` is in the content (there was issues with new lines and leading spaces)