### PR TITLE
Command prompt tidy

### DIFF
--- a/functions/json_response.php
+++ b/functions/json_response.php
@@ -27,7 +27,8 @@
     // specify the available actions which will be made available in the context
     Function setActions() {
         if (isset($GLOBALS["FUNCTIONS_ARE_ENABLED"]) && $GLOBALS["FUNCTIONS_ARE_ENABLED"]) {
-            //$GLOBALS["COMMAND_PROMPT"].=$GLOBALS["COMMAND_PROMPT_FUNCTIONS"];
+            //inject the prompt here with the actions (moved from minime block in main)
+            $GLOBALS["COMMAND_PROMPT"].=$GLOBALS["COMMAND_PROMPT_FUNCTIONS"];
             foreach ($GLOBALS["FUNCTIONS"] as $function) {
                 //$data["tools"][]=["type"=>"function","function"=>$function];
                 if (!$function)

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -1375,76 +1375,50 @@ function DataGetCurrentTask()
     $results = $db->fetchAll("SElECT  distinct description as description,gamets FROM currentmission where sess='ephemeral' and gamets>$hourThreshold order by gamets desc");
     error_log("SElECT  distinct description as description,gamets FROM currentmission where sess='ephemeral' and gamets>$hourThreshold order by gamets desc");
 
-    if (!$results) {
-        $results=[];
-    } else {
-        return $results[0]["description"];
-
+    if (!empty($results)) {
+        // couldnt find usages of ephemeral quests so didnt modify this apart from new lines
+        return "\n{$results[0]["description"]}\n";
     }
 
     $data = "";
-
-    $n = 0;
-    foreach ($results as $row) {
-
-        if ($n == 0) {
-            $data = "Current plan: {$row["description"]}.";
-        } elseif ($n == 1) {
-            $data .= "Previous plan: {$row["description"]}.";
-        } else {
-            break;
+    $results = $db->fetchAll("SElECT distinct description as description,gamets FROM currentmission where sess<>'ephemeral' order by gamets desc");
+    if (!empty($results)) {
+        $data = "\n#PLANS\n";
+        $n = 0;
+        foreach ($results as $row) {
+            if ($n == 0) {
+                $data .= "Current plan: {$row["description"]}.\n";
+            } elseif ($n == 1) {
+                $data .= "Previous plan: {$row["description"]}.\n";
+            } else {
+                break;
+            }
+            $n++;
         }
-        $n++;
     }
 
-    $results = $db->fetchAll("SElECT  distinct description as description,gamets FROM currentmission where sess<>'ephemeral' order by gamets desc");
-    if (!$results) {
-        $results=[];
-    }
-
-    $data = "";
-
-    $n = 0;
-    foreach ($results as $row) {
-
-        if ($n == 0) {
-            $data = "Current plan: {$row["description"]}.";
-        } elseif ($n == 1) {
-            $data .= "Previous plan: {$row["description"]}.";
-        } else {
-            break;
-        }
-        $n++;
-    }
-
+    // quests are an unordered list (because of how the aiagent plugin works - delete current, bulk update)
+    // we would need to get clever with ignoring _questreset or expiring untouched quests, and using upserts on _quest
+    // quests, and making "current" if _questdata updates after initial insert
+    // for now lets just list all active quests rather than saying Current: xxx Previous: yyy
     $results = $db->fetchAll("SElECT  distinct name,briefing as description,gamets FROM quests order by gamets desc");
     if (!$results) {
         Logger::info("No quests ".__FILE__);
         return $data;
     }
-    
-    if (sizeof($results)>2) {
-        Logger::info("Too much quests ".__FILE__);
-        return $data;
-    }
 
-    //$data = "";
+    // dont think we need to limit it now since we dont require exactly two to format Current: xxx Previous: yyy
+//    if (sizeof($results)>2) {
+//        Logger::info("Too much quests ".__FILE__);
+//        return $data;
+//    }
 
-    $n = 0;
+    $data .= "\n#ACTIVE QUESTS\n";
     foreach ($results as $row) {
-
-        if ($n == 0) {
-            $data .= "Current quest: {$row["name"]}/{$row["description"]}.";
-        } elseif ($n == 1) {
-            $data .= "Previous quest: {$row["name"]}/{$row["description"]}.";
-        } else {
-            break;
-        }
-        $n++;
+        $data .= "* {$row["name"]}/".trim($row["description"])."\n";
     }
-    
-    return $data;
 
+    return $data;
 }
 
 

--- a/main.php
+++ b/main.php
@@ -995,7 +995,7 @@ if (isset($GLOBALS["CURRENT_TASK"]) && $GLOBALS["CURRENT_TASK"] && $gameRequest[
     if ((!$GLOBALS["IS_NPC"])||($GLOBALS["HERIKA_NAME"]=="The Narrator")) {
         $task=DataGetCurrentTask();
         if (empty($task)) {
-            $task="No active quests right now.";
+            $task="\n#QUESTS\nNo active quests right now.";
         }
         $GLOBALS["COMMAND_PROMPT"].=$task;
     } else {

--- a/main.php
+++ b/main.php
@@ -1183,11 +1183,9 @@ if ($GLOBALS["FUNCTIONS_ARE_ENABLED"]) {
                 } 
             }
         }
-
-       
     }
-
-    $GLOBALS["COMMAND_PROMPT"].=$GLOBALS["COMMAND_PROMPT_FUNCTIONS"];
+    //command prompt function now injected in json_response.php with actions
+    //$GLOBALS["COMMAND_PROMPT"].=$GLOBALS["COMMAND_PROMPT_FUNCTIONS"];
 }
 
 
@@ -1223,16 +1221,19 @@ if (isset($GLOBALS["ADD_PLAYER_BIOS"])&&($GLOBALS["ADD_PLAYER_BIOS"])) {
 $dynamicBiography = buildDynamicBiography($GLOBALS);
 
 if (isset($GLOBALS["OGHMA_HINT"]) && $GLOBALS["OGHMA_HINT"]) {
-
     $head[] = array('role' => 'system', 'content' =>  
-        strtr($GLOBALS["PROMPT_HEAD"] . "\n".$GLOBALS["HERIKA_PERS"] . $dynamicBiography . "\n" . $GLOBALS["OGHMA_HINT"]."\n". $GLOBALS["COMMAND_PROMPT"],
+        strtr($GLOBALS["PROMPT_HEAD"] . "\n".$GLOBALS["HERIKA_PERS"] . $dynamicBiography . "\n" . $GLOBALS["OGHMA_HINT"]."\n" . $GLOBALS["COMMAND_PROMPT"],
         ["#PLAYER_NAME#"=>$GLOBALS["PLAYER_NAME"]])
     );
+    //avoid reinjecting command prompt that we have already appended
+    $GLOBALS["COMMAND_PROMPT"] = "";
 } else {
     $head[] = array('role' => 'system', 'content' =>  
-        strtr($GLOBALS["PROMPT_HEAD"] . "\n".$GLOBALS["HERIKA_PERS"] . $dynamicBiography . "\n". $GLOBALS["COMMAND_PROMPT"],
+        strtr($GLOBALS["PROMPT_HEAD"] . "\n".$GLOBALS["HERIKA_PERS"] . $dynamicBiography . "\n" . $GLOBALS["COMMAND_PROMPT"],
         ["#PLAYER_NAME#"=>$GLOBALS["PLAYER_NAME"]])
     );
+    //avoid reinjecting command prompt that we have already appended
+    $GLOBALS["COMMAND_PROMPT"] = "";
 }
 
 

--- a/processor/oghma.php
+++ b/processor/oghma.php
@@ -188,7 +188,7 @@ if ($GLOBALS["MINIME_T5"]) {
 
                                 if ($advancedAllowed) {
                                     // The user can access advanced lore
-                                    $GLOBALS["OGHMA_HINT"] .= " \n# Lore Information (You have advanced knowledge on this subject, you can use it in your dialogue):{$topTopic["topic"]}  \"{$topTopic["topic_desc"]}\"";
+                                    $GLOBALS["OGHMA_HINT"] .= " \n#Lore Information (You have advanced knowledge on this subject, you can use it in your dialogue):{$topTopic["topic"]}\n\"".trim($topTopic["topic_desc"])."\"";
                                 } else {
                                     // -----------------------------
                                     // 2) Check basic article
@@ -211,9 +211,9 @@ if ($GLOBALS["MINIME_T5"]) {
                                     }
 
                                     if ($basicAllowed) {
-                                        $GLOBALS["OGHMA_HINT"] .= " \n# Lore Information (You only have basic knowledge on this subject, you can use it in your dialogue):{$topTopic["topic"]}  \"{$topTopic["topic_desc_basic"]}\"";
+                                        $GLOBALS["OGHMA_HINT"] .= " \n#Lore Information (You only have basic knowledge on this subject, you can use it in your dialogue): {$topTopic["topic"]}\n\"".trim($topTopic["topic_desc_basic"])."\"";
                                     } else {
-                                        $GLOBALS["OGHMA_HINT"] .= " \nYou do not know ANYTHING about {$topTopic["topic"]}";
+                                        $GLOBALS["OGHMA_HINT"] .= " \n#Lore Information\nYou do not know ANYTHING about {$topTopic["topic"]}";
                                     }
                                 }
                             } else {

--- a/prompts/command_prompt.php
+++ b/prompts/command_prompt.php
@@ -4,7 +4,7 @@ $COMMAND_PROMPT = "
 Don't write narrations.
 ";
 // Database Prompt (Command Prompt)
-$COMMAND_PROMPT_FUNCTIONS="Use # ACTIONS if your character needs to perfom an action.";
+$COMMAND_PROMPT_FUNCTIONS="\n#ACTIONS use if your character needs to perform an action";
 /*
 $COMMAND_PROMPT_FUNCTIONS = "
 Use tool calling to control {$GLOBALS["HERIKA_NAME"]}'s actions.

--- a/prompts/prompts.php
+++ b/prompts/prompts.php
@@ -140,7 +140,7 @@ $PROMPTS=array(
             "({$GLOBALS["HERIKA_NAME"]} asks {$GLOBALS["PLAYER_NAME"]} what they found) {$GLOBALS["TEMPLATE_DIALOG"]}",
             "({$GLOBALS["HERIKA_NAME"]} asks {$GLOBALS["PLAYER_NAME"]} to share what they found) {$GLOBALS["TEMPLATE_DIALOG"]}"
         ],
-        "player_request"=>["({$GLOBALS["PLAYER_NAME"]} has unlocked {$gameRequest[3]})"],
+        "player_request"=>["({$GLOBALS["PLAYER_NAME"]} has unlocked) {$gameRequest[3]})"],
         "extra" => (!empty($GLOBALS["RPG_COMMENTS"]) && in_array("lockpick", $GLOBALS["RPG_COMMENTS"])) ? [] : ["dontuse" => true]
     ],
     // Database Prompt (After Attack)


### PR DESCRIPTION
I have tidied up the command prompt injection so that we dont get double injection of CurrentTask data (command prompt was injected in main at context building, and then again in each connector). Along with this i have tidied up the formatting of the prompts so the prompt is properly sectioned off (previously the Task info could be considered part of `#Goals` due to dangling context)

will now produce prompt like this:
```
...dynamic profile

#PLANS
Current plan: Locate Grimsever.
Previous plan: Talk to Jarl.

#ACTIVE QUESTS
* Elder Knowledge/Learn the location of the Elder Scroll.

#ACTIONS use if your character needs to perform an action
AVAILABLE ACTION: Inspect (Inspects ONLY an ACTOR/NPC. Wait for result to give a dialogue message.)
AVAILABLE ACTION: InspectSurroundings (Looks for actors around.Wait for result to give a dialogue message)
...
```

I have commited changes in separate commits in case you want to cherry pick

Note on COMMAND_PROMPT, i simply reset it after we append it in the main.php context building, this is so we retain the current logic where imo command_prompt is abused to inject the CurrentTask and the initializer text "Don't write narrations.", even if FUNCTIONS_ENABLED is false, to make this more robust we should look at injecting the task as a separate part rather than letting command_prompt do the work