### PR TITLE
Update PHP 8.2 deprecated ${var} syntax in llm_connectors.php

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -2314,7 +2314,7 @@ function PackIntoSummary($onlyMissingDiary=false)
         $lastGameTsRecord = $GLOBALS["db"]->fetchOne("select gamets as gamets from eventlog order by gamets desc LIMIT 1"); // 2.1ms
         $results = $GLOBALS["db"]->fetchAll("select gamets_truncated from memory_summary order by gamets_truncated desc LIMIT 1"); // 0.5ms, faster 
 
-        $maxRow = intval($results[0]["gamets_truncated"]);
+        $maxRow = isset($results[0]["gamets_truncated"]) ? intval($results[0]["gamets_truncated"]) : 0;
         $minRow = intval($lastGameTsRecord["gamets"]);
         $minRowTs = intval($lastGameTsRecord["gamets"] -  ( 1 /0.0000024));
         

--- a/ui/core/llm_connectors.php
+++ b/ui/core/llm_connectors.php
@@ -997,7 +997,7 @@ if (isset($_GET["delete"])) {
         $inUse = 0;
     }
     if ($inUse > 0) {
-        $msg = "Cannot delete: connector is used by ${inUse} profile" . ($inUse>1? 's' : '') . ". Remove from all profiles first.";
+        $msg = "Cannot delete: connector is used by {$inUse} profile" . ($inUse>1? 's' : '') . ". Remove from all profiles first.";
         header("Location: llm_connectors.php?notice=" . urlencode($msg));
         exit;
     }


### PR DESCRIPTION
Changes ${inUse} to {$inUse} to silence PHP 8.2+ deprecation warning:
"Deprecated: Using ${var} in strings is deprecated, use {$var} instead