### PR TITLE
Add Oghma llm

### DIFF
--- a/conf/conf_schema.json
+++ b/conf/conf_schema.json
@@ -79,6 +79,8 @@
   "CORE_CONNECTOR_SUMMARY": {"userlvl":"basic","type": "foreign:core_llm_connector:id:label","description": "Connector used for creating memory summaries. Recommend to use a smaller LLM."},
   "CORE_CONNECTOR_MEDIUMTERM": {"userlvl":"basic","type": "foreign:core_llm_connector:id:label","description": "Connector used to generate longer memories summaries after every 10 memory summaries. Can be enabled in CHIM NPC page. Recommend to user a smaller LLM."},
   "CORE_CONNECTOR_PROFILES": {"userlvl":"basic","type": "foreign:core_llm_connector:id:label","description": "Connector used to update CHIM NPC Dynamic Profiles. Recommend to use a 🕹️Standard LLM.","scope":"global"},
+  "CORE_CONNECTOR_OGHMA_LLM": {"userlvl": "basic","type": "foreign:core_llm_connector:id:label","description": "Connector used for Oghma Infinium topic extraction. Recommend to use a 🏃‍♀️‍➡️Fast LLM.","scope": "global"},
+  "OGHMA_LLM_TOPIC_PROMPT": {"userlvl": "pro","type": "longstring","description": "Custom prompt for Oghma LLM topic extraction. Leave empty to use default prompt.","scope": "global"},
   "CLEAN_CONTEXT_FOCUS_CHAT_HISTORY": {"userlvl":"basic","type": "integer","description": "Historic context to use when Focus on Chat mode. Should be lower than normal context.","scope":"global"},
   "BGL_TRIGGER_DAYS": {"userlvl":"basic","type": "integer","description": "RECOMMEND TO NOT GO BELOW 5 DAYS! Number of in-game days between Background Life events. NPCs will generate thoughts and take actions based on this interval. Default: 5 days. Range: 1-30 days.","scope":"global"},
   "CONNECTOR": {

--- a/lib/oghma_llm_service.php
+++ b/lib/oghma_llm_service.php
@@ -43,7 +43,7 @@ You are an expert at extracting important topics from text and translating them 
 Follow these rules strictly:
 
 1. Extract only ONE most important topic (person, place, item, concept, etc.) from the text
-2. Convert Skyrim proper nouns to English (e.g., ドラゴン→dragons, ホワイトラン→Whiterun)
+2. Convert Skyrim proper nouns to English and ensure the output is in the **singular form** (e.g., ドラゴン→dragon, ホワイトラン→Whiterun)
 3. Translate general concepts to English (e.g., 魔法→magic, 戦闘→combat)
 4. Return ONLY the English word or phrase (no explanations, no Japanese text)
 5. If multiple candidates exist, choose the most important one
@@ -51,19 +51,19 @@ Follow these rules strictly:
 
 Examples:
 Input: 「ドラゴンについて聞いた」
-Output: dragons
+Output: dragon
 
 Input: 「ホワイトランに行く予定だ」
 Output: Whiterun
 
 Input: 「グレイビアードに会いに行った」
-Output: Greybeards
+Output: Greybeard
 
 Input: 「魔法を使った」
 Output: magic
 
 Input: "I heard about dragons"
-Output: dragons
+Output: dragon
 
 Bad examples (DO NOT DO THIS):
 Input: 「魔法を使った」

--- a/lib/oghma_llm_service.php
+++ b/lib/oghma_llm_service.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * LLM-based topic extraction for Japanese language support
+ * This replaces the T5-based minimeTopic function for multilingual support
+ */
+
+function LLMTopic($text, $language = 'ja') {
+    $startTime = microtime(true);
+    
+    // Check if we have a valid Oghma connector configured
+    if (!isset($GLOBALS["CORE_CONNECTOR_OGHMA_LLM"]) || empty($GLOBALS["CORE_CONNECTOR_OGHMA_LLM"])) {
+        error_log("[OGHMA LLM] CORE_CONNECTOR_OGHMA_LLM not configured");
+        return false;
+    }
+    
+    // Check cache first
+    $cacheKey = md5("topic_extraction_" . $text);
+    if (isset($GLOBALS["MINIME_TOPIC_CACHE"][$cacheKey])) {
+        error_log("[OGHMA LLM] Using cached topic for: " . substr($text, 0, 50));
+        return $GLOBALS["MINIME_TOPIC_CACHE"][$cacheKey];
+    }
+    
+    try {
+        // Get the Oghma-specific connector
+        $connector = new LLMConnector();
+        $connectorData = $connector->getById($GLOBALS["CORE_CONNECTOR_OGHMA_LLM"]);
+        
+        if (!$connectorData) {
+            error_log("[OGHMA LLM] Failed to load connector ID: " . $GLOBALS["CORE_CONNECTOR_OGHMA_LLM"]);
+            return false;
+        }
+        
+        $connectionHandler = $connector->getConnector($connectorData);
+        
+        // Use custom prompt from global settings if available
+        if (isset($GLOBALS["OGHMA_LLM_TOPIC_PROMPT"]) && !empty($GLOBALS["OGHMA_LLM_TOPIC_PROMPT"])) {
+            $systemPrompt = $GLOBALS["OGHMA_LLM_TOPIC_PROMPT"];
+        } else {
+            // Default prompt
+            $systemPrompt = <<<PROMPT
+You are an expert at extracting important topics from text and translating them to English.
+Follow these rules strictly:
+
+1. Extract only ONE most important topic (person, place, item, concept, etc.) from the text
+2. Convert Skyrim proper nouns to English (e.g., ドラゴン→dragons, ホワイトラン→Whiterun)
+3. Translate general concepts to English (e.g., 魔法→magic, 戦闘→combat)
+4. Return ONLY the English word or phrase (no explanations, no Japanese text)
+5. If multiple candidates exist, choose the most important one
+6. **CRITICAL: Your output must be 100% in English. Never include any Japanese characters.**
+
+Examples:
+Input: 「ドラゴンについて聞いた」
+Output: dragons
+
+Input: 「ホワイトランに行く予定だ」
+Output: Whiterun
+
+Input: 「グレイビアードに会いに行った」
+Output: Greybeards
+
+Input: 「魔法を使った」
+Output: magic
+
+Input: "I heard about dragons"
+Output: dragons
+
+Bad examples (DO NOT DO THIS):
+Input: 「魔法を使った」
+Output: 魔法 (magic) ← WRONG! Contains Japanese!
+Correct Output: magic
+PROMPT;
+        }
+        
+        $userPrompt = "Text: " . $text;
+        
+        // Prepare context for the connector
+        $contextData = [
+            ['role' => 'system', 'content' => $systemPrompt],
+            ['role' => 'user', 'content' => $userPrompt]
+        ];
+        
+        // Custom parameters for fast, simple extraction
+        $customParms = [
+            'max_tokens' => 50,  // Short response
+            'temperature' => 0.3, // Low temperature for consistency
+            'stream' => false     // No streaming needed
+        ];
+        
+        // Call the LLM using the fast method
+        $response = callLLMFast($contextData, $customParms);
+        
+        if (!$response) {
+            error_log("[OGHMA LLM] Failed to get response from LLM");
+            return false;
+        }
+        
+        // Extract the topic from response
+        $topic = trim($response);
+        
+        // Clean up the response (remove quotes, extra whitespace, etc.)
+        $topic = preg_replace('/^["\']|["\']$/', '', $topic);
+        $topic = preg_replace('/\s+/', ' ', $topic);
+        $topic = trim($topic);
+        
+        // Validate the topic (should be a simple word or phrase)
+        if (empty($topic) || strlen($topic) > 100) {
+            error_log("[OGHMA LLM] Invalid topic extracted: " . $topic);
+            return false;
+        }
+        
+        $elapsedTime = microtime(true) - $startTime;
+        
+        $result = json_encode([
+            'generated_tags' => $topic,
+            'elapsed_time' => $elapsedTime
+        ]);
+        
+        // Cache the result
+        $GLOBALS["MINIME_TOPIC_CACHE"][$cacheKey] = $result;
+        
+        error_log("[OGHMA LLM] Extracted topic: '$topic' in {$elapsedTime}s from: " . substr($text, 0, 50));
+        
+        return $result;
+        
+    } catch (Exception $e) {
+        error_log("[OGHMA LLM] Exception during topic extraction: " . $e->getMessage());
+        return false;
+    }
+}
+
+/**
+ * Fast LLM call for simple tasks like topic extraction
+ * Uses the Oghma-specific connector with minimal overhead
+ */
+function callLLMFast($contextData, $customParms = []) {
+    if (!isset($GLOBALS["CORE_CONNECTOR_OGHMA_LLM"]) || empty($GLOBALS["CORE_CONNECTOR_OGHMA_LLM"])) {
+        error_log("[OGHMA LLM] CORE_CONNECTOR_OGHMA_LLM not configured in callLLMFast");
+        return false;
+    }
+    
+    $connector = new LLMConnector();
+    $connectorData = $connector->getById($GLOBALS["CORE_CONNECTOR_OGHMA_LLM"]);
+    
+    if (!$connectorData) {
+        error_log("[OGHMA LLM] Failed to load connector in callLLMFast");
+        return false;
+    }
+    
+    // Build the request
+    $url = $connectorData["url"];
+    $model = $connectorData["model"];
+    $apiKeyId = $connectorData["api_badge_id"];
+    
+    // Get API key
+    $apiBadge = new ApiBadge();
+    $apiKeyData = $apiBadge->getById($apiKeyId);
+    $apiKey = $apiKeyData["api_key"];
+    
+    // Prepare request data
+    $data = [
+        'model' => $model,
+        'messages' => $contextData,
+        'max_tokens' => $customParms['max_tokens'] ?? 50,
+        'temperature' => $customParms['temperature'] ?? 0.3,
+        'stream' => false
+    ];
+    
+    // Prepare headers
+    $headers = [
+        'Content-Type: application/json',
+        'Authorization: Bearer ' . $apiKey,
+        'HTTP-Referer: https://dwemerdynamics.com/',
+        'X-Title: Dwemer Dynamics - Oghma Topic Extraction'
+    ];
+    
+    // Add provider-specific headers if needed
+    if (isset($connectorData["provider"]) && !empty($connectorData["provider"])) {
+        $headers[] = 'X-Provider: ' . $connectorData["provider"];
+    }
+    
+    // Make the request
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 10); // Short timeout for fast extraction
+    
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    
+    if ($httpCode !== 200) {
+        error_log("[OGHMA LLM] HTTP error $httpCode: $response");
+        return false;
+    }
+    
+    $responseData = json_decode($response, true);
+    
+    if (!isset($responseData['choices'][0]['message']['content'])) {
+        error_log("[OGHMA LLM] Invalid response format: " . substr($response, 0, 200));
+        return false;
+    }
+    
+    return $responseData['choices'][0]['message']['content'];
+}
+
+?>

--- a/main.php
+++ b/main.php
@@ -1043,7 +1043,7 @@ if (in_array($gameRequest[0],["rechat","narration"]) ) {
     $rndNumber = rand(1, 100);
     if ($rndNumber <= intval($GLOBALS["RECHAT_P"])) {
         // Process Oghma for rechat events using NPC's last dialogue
-        if ($GLOBALS["MINIME_T5"] && isset($FEATURES["MISC"]["OGHMA_INFINIUM"]) && ($FEATURES["MISC"]["OGHMA_INFINIUM"])) {
+        if (($GLOBALS["MINIME_T5"] || (isset($GLOBALS["OGHMA_LLM"]) && $GLOBALS["OGHMA_LLM"])) && isset($FEATURES["MISC"]["OGHMA_INFINIUM"]) && ($FEATURES["MISC"]["OGHMA_INFINIUM"])) {
                 require(__DIR__."/processor/oghma.php"); // Process Oghma
         }
     }

--- a/processor/oghma.php
+++ b/processor/oghma.php
@@ -2,7 +2,7 @@
 
 $GLOBALS["OGHMA_HINT"] = "";
 
-if ($GLOBALS["MINIME_T5"]) {
+if ($GLOBALS["MINIME_T5"] || (isset($GLOBALS["OGHMA_LLM"]) && $GLOBALS["OGHMA_LLM"])) {
     if (isset($GLOBALS["OGHMA_INFINIUM"]) && ($GLOBALS["OGHMA_INFINIUM"])) {
         if (in_array($gameRequest[0], ["inputtext","inputtext_s","ginputtext","ginputtext_s","rechat", "instruction", "suggestion"])) {
             
@@ -87,7 +87,14 @@ if ($GLOBALS["MINIME_T5"]) {
 
             // Extract topics up to OGHMA_AMOUNT times
             for ($i = 0; $i < $oghmaAmount; $i++) {
-                $topic_req = minimeTopic($remainingText);
+                if ($GLOBALS["OGHMA_LLM"]) {
+                    require_once(__DIR__."/../lib/oghma_llm_service.php");
+                    $lang = isset($GLOBALS["CORE_LANG"]) && !empty($GLOBALS["CORE_LANG"]) ? $GLOBALS["CORE_LANG"] : 'en';
+                    $topic_req = LLMTopic($remainingText, $lang);
+                } else {
+                    $topic_req = minimeTopic($remainingText);
+                }
+                
                 if ($topic_req) {
                     $topic_res = json_decode($topic_req, true);
                     $currentInputTopic = getArrayKey($topic_res, "generated_tags");
@@ -342,6 +349,6 @@ if ($GLOBALS["MINIME_T5"]) {
         error_log("[OGHMA] OGHMA_INFINIUM disabled: {$GLOBALS["OGHMA_INFINIUM"]}");
     }
 }  else {
-        error_log("[OGHMA]  MINIME_T5 disabled: {$GLOBALS["MINIME_T5"]}");
+        error_log("[OGHMA] Both MINIME_T5 and OGHMA_LLM are disabled");
 }
 ?>

--- a/ui/core/tmpl/metadata_json_editor.php
+++ b/ui/core/tmpl/metadata_json_editor.php
@@ -63,6 +63,10 @@ $localSchemaOverrides = [
         'type' => 'boolean',
         'description' => "Needs Minime-T5 enabled and running. Tamriel lore information will be added to the prompt, enhancing their understanding on specific topics.",
     ],
+    'OGHMA_LLM' => [
+        'type' => 'boolean',
+        'description' => 'Use LLM for Oghma keyword extraction. Do not enable Minime-T5.',
+    ],
     'AUTO_DIARY_WAIT' => [
         'type' => 'boolean',
         'description' => 'When AUTO_DIARY is enabled, this controls whether diary entries are created during wait events. If false, auto diary will only trigger on sleep events.',
@@ -112,24 +116,24 @@ $localSchemaOverrides = [
 
 // Visual keys to expose (can be expanded easily)
 $visualKeys = [
-  "RECHAT_H","RECHAT_P","CORE_LANG","MINIME_T5","BORED_EVENT",
-  "DIARY_PROMPT","OGHMA_AMOUNT","LANG_LLM_XTTS","QUEST_COMMENT","DIARY_COOLDOWN","COMBAT_BARK_COOLDOWN",
-  "OGHMA_INFINIUM","AUTO_DIARY_WAIT","CONTEXT_HISTORY","MAX_WORDS_LIMIT","HERIKA_ANIMATIONS",
-  "QUEST_COMMENT_CHANCE","RECHAT_ALLOW_ACTIONS","CONTEXT_HISTORY_DIARY","BORED_EVENT_SERVERSIDE","ENFORCE_ACTIONS_PROMPT",
-  "REMOVE_ASTERISKS_FROM_OUTPUT","CONTEXT_HISTORY_DYNAMIC_PROFILE"
+    "RECHAT_H","RECHAT_P","CORE_LANG","MINIME_T5","BORED_EVENT",
+    "DIARY_PROMPT","OGHMA_AMOUNT","LANG_LLM_XTTS","QUEST_COMMENT","DIARY_COOLDOWN","COMBAT_BARK_COOLDOWN",
+    "OGHMA_INFINIUM","OGHMA_LLM","AUTO_DIARY_WAIT","CONTEXT_HISTORY","MAX_WORDS_LIMIT","HERIKA_ANIMATIONS",
+    "QUEST_COMMENT_CHANCE","RECHAT_ALLOW_ACTIONS","CONTEXT_HISTORY_DIARY","BORED_EVENT_SERVERSIDE","ENFORCE_ACTIONS_PROMPT",
+    "REMOVE_ASTERISKS_FROM_OUTPUT","CONTEXT_HISTORY_DYNAMIC_PROFILE"
 ];
 
 // Organize visual keys into categories for display
 $visualGroups = [
-  'Core' => ["CORE_LANG","ENFORCE_ACTIONS_PROMPT","REMOVE_ASTERISKS_FROM_OUTPUT","MAX_WORDS_LIMIT"],
-  'Rechat' => ["RECHAT_H","RECHAT_P","RECHAT_ALLOW_ACTIONS"],
-  'Diary' => ["DIARY_PROMPT","DIARY_COOLDOWN","AUTO_DIARY_WAIT"],
-  'Combat' => ["COMBAT_BARK_COOLDOWN"],
-  'Oghma' => ["OGHMA_INFINIUM","OGHMA_AMOUNT","MINIME_T5"],
-  'Context' => ["CONTEXT_HISTORY","CONTEXT_HISTORY_DIARY","CONTEXT_HISTORY_DYNAMIC_PROFILE"],
-  'Quest' => ["QUEST_COMMENT","QUEST_COMMENT_CHANCE"],
-  'Behavior' => ["BORED_EVENT","BORED_EVENT_SERVERSIDE","HERIKA_ANIMATIONS"],
-  'Language/Voice' => ["LANG_LLM_XTTS"],
+    'Core' => ["CORE_LANG","ENFORCE_ACTIONS_PROMPT","REMOVE_ASTERISKS_FROM_OUTPUT","MAX_WORDS_LIMIT"],
+    'Rechat' => ["RECHAT_H","RECHAT_P","RECHAT_ALLOW_ACTIONS"],
+    'Diary' => ["DIARY_PROMPT","DIARY_COOLDOWN","AUTO_DIARY_WAIT"],
+    'Combat' => ["COMBAT_BARK_COOLDOWN"],
+    'Oghma' => ["OGHMA_INFINIUM","OGHMA_AMOUNT","MINIME_T5","OGHMA_LLM"],
+    'Context' => ["CONTEXT_HISTORY","CONTEXT_HISTORY_DIARY","CONTEXT_HISTORY_DYNAMIC_PROFILE"],
+    'Quest' => ["QUEST_COMMENT","QUEST_COMMENT_CHANCE"],
+    'Behavior' => ["BORED_EVENT","BORED_EVENT_SERVERSIDE","HERIKA_ANIMATIONS"],
+    'Language/Voice' => ["LANG_LLM_XTTS"],
 ];
 
 // Pretty label similar to global_settings General tab

--- a/ui/core/tmpl/metadata_json_editor.php
+++ b/ui/core/tmpl/metadata_json_editor.php
@@ -63,6 +63,10 @@ $localSchemaOverrides = [
         'type' => 'boolean',
         'description' => "Needs Minime-T5 enabled and running. Tamriel lore information will be added to the prompt, enhancing their understanding on specific topics.",
     ],
+    'OGHMA_LLM' => [
+        'type' => 'boolean',
+        'description' => 'Use LLM for Oghma keyword extraction. Do not enable Minime-T5.',
+    ],
     'AUTO_DIARY_WAIT' => [
         'type' => 'boolean',
         'description' => 'When AUTO_DIARY is enabled, this controls whether diary entries are created during wait events. If false, auto diary will only trigger on sleep events.',
@@ -114,7 +118,7 @@ $localSchemaOverrides = [
 $visualKeys = [
   "RECHAT_H","RECHAT_P","CORE_LANG","MINIME_T5","BORED_EVENT",
   "DIARY_PROMPT","OGHMA_AMOUNT","LANG_LLM_XTTS","QUEST_COMMENT","DIARY_COOLDOWN","COMBAT_BARK_COOLDOWN",
-  "OGHMA_INFINIUM","AUTO_DIARY_WAIT","CONTEXT_HISTORY","MAX_WORDS_LIMIT","HERIKA_ANIMATIONS",
+  "OGHMA_INFINIUM","OGHMA_LLM","AUTO_DIARY_WAIT","CONTEXT_HISTORY","MAX_WORDS_LIMIT","HERIKA_ANIMATIONS",
   "QUEST_COMMENT_CHANCE","RECHAT_ALLOW_ACTIONS","CONTEXT_HISTORY_DIARY","BORED_EVENT_SERVERSIDE","ENFORCE_ACTIONS_PROMPT",
   "REMOVE_ASTERISKS_FROM_OUTPUT","CONTEXT_HISTORY_DYNAMIC_PROFILE"
 ];
@@ -125,7 +129,7 @@ $visualGroups = [
   'Rechat' => ["RECHAT_H","RECHAT_P","RECHAT_ALLOW_ACTIONS"],
   'Diary' => ["DIARY_PROMPT","DIARY_COOLDOWN","AUTO_DIARY_WAIT"],
   'Combat' => ["COMBAT_BARK_COOLDOWN"],
-  'Oghma' => ["OGHMA_INFINIUM","OGHMA_AMOUNT","MINIME_T5"],
+  'Oghma' => ["OGHMA_INFINIUM","OGHMA_AMOUNT","MINIME_T5","OGHMA_LLM"],
   'Context' => ["CONTEXT_HISTORY","CONTEXT_HISTORY_DIARY","CONTEXT_HISTORY_DYNAMIC_PROFILE"],
   'Quest' => ["QUEST_COMMENT","QUEST_COMMENT_CHANCE"],
   'Behavior' => ["BORED_EVENT","BORED_EVENT_SERVERSIDE","HERIKA_ANIMATIONS"],

--- a/ui/global_settings.php
+++ b/ui/global_settings.php
@@ -248,6 +248,7 @@ function pretty_label(string $flatName): string {
         'CORE_CONNECTOR_MEDIUMTERM' => 'Middle Term Memory/Background Life',
         'CORE_CONNECTOR_PROFILES' => 'Dynamic Profiles',
         'CORE_CONNECTOR_DIRECTOR' => 'Director Mode',
+        'CORE_CONNECTOR_OGHMA_LLM' => 'Oghma Infinium LLM',
     ];
     if (isset($connectorLabels[$flatName])) {
         return $connectorLabels[$flatName];
@@ -276,6 +277,7 @@ function icon_for_field(string $flatName): string {
         if ($u === 'CORE_CONNECTOR_MEDIUMTERM') return '🧠';
         if ($u === 'CORE_CONNECTOR_PROFILES') return '👥';
         if ($u === 'CORE_CONNECTOR_DIRECTOR') return '🎬';
+        if ($u === 'CORE_CONNECTOR_OGHMA_LLM') return '🐙';
         return '🔌';
     }
     // Respeech related
@@ -316,6 +318,10 @@ $gsSections = [
         [ 'name' => 'CORE_CONNECTOR_MEDIUMTERM', 'type' => 'foreign:core_llm_connector:id:label' ],
         [ 'name' => 'CORE_CONNECTOR_PROFILES', 'type' => 'foreign:core_llm_connector:id:label' ],
         [ 'name' => 'CORE_CONNECTOR_DIRECTOR', 'type' => 'foreign:core_llm_connector:id:label' ],
+        [ 'name' => 'CORE_CONNECTOR_OGHMA_LLM', 'type' => 'foreign:core_llm_connector:id:label' ],
+    ],
+    'Oghma LLM' => [
+        [ 'name' => 'OGHMA_LLM_TOPIC_PROMPT', 'type' => 'longstring' ],
     ],
     // 'Dynamic Prompts' => [
     //     // All dynamic prompts have been migrated to Prompts Manager (⚙️Prompts Manager in Config Hub)


### PR DESCRIPTION
### LLM-based Topic Extraction for Multilingual Oghma Infinium Support
Since Minime-T5 doesn't support Japanese, I implemented LLM-based topic extraction to enable Oghma Infinium functionality for non-English languages.

### Key Features:
- Extracts topics from Japanese dialogue and translates them to English
- Queries the English Oghma Infinium database using translated keywords
- Configurable via Global Settings UI (Oghma LLM section)
- Tested by several users in the Discord "日本語" channel
### Performance:
- Slightly increased token usage, but Oghma Infinium now works reliably in Japanese
- With minor prompt adjustments, should work for other languages as well

Note: This PR was created with LLM assistance. Please let me know if anything needs clarification.