### PR TITLE
Relationship System Integration - Dynamic Profile Bridge and Save/Restore Fix

### DIFF
--- a/lib/core/npc_master.class.php
+++ b/lib/core/npc_master.class.php
@@ -31,11 +31,6 @@ class NpcMaster
     // Create (Insert)
     public function create($data)
     {
-        // Prevent creating The Narrator - it's now managed via core_narrator table
-        if (isset($data["npc_name"]) && $data["npc_name"] === "The Narrator") {
-            throw new \Exception("The Narrator cannot be created via NpcMaster. Use the Narrator class and Narrator Management UI instead.");
-        }
-        
         $fields = [
             "npc_name",
             "npc_favorite",
@@ -87,24 +82,15 @@ class NpcMaster
     // Read NPC by unique name
     public function getByName($npcName)
     {
-        // The Narrator is now managed via core_narrator table, not core_npc_master
-        if ($npcName === "The Narrator") {
-            return null;
-        }
         $escaped = $this->escape($npcName);
         $query   = "SELECT * FROM {$this->table} WHERE npc_name = '{$escaped}' LIMIT 1";
         return $this->db->fetchOne($query);
     }
 
     // Read NPC by md5
-    public function getByMD5($md5Hash)
+    public function getByMD5($npcName)
     {
-        // The Narrator is now managed via core_narrator table, not core_npc_master
-        // Check if this MD5 corresponds to The Narrator
-        if ($md5Hash === md5('The Narrator')) {
-            return null;
-        }
-        $escaped = $this->escape($md5Hash);
+        $escaped = $this->escape($npcName);
         $query   = "SELECT * FROM {$this->table} WHERE md5 = '{$escaped}' LIMIT 1";
         return $this->db->fetchOne($query);
     }
@@ -199,6 +185,11 @@ class NpcMaster
     {
         $id    = (int) $id;
         $where = "id = $id";
+        // Disallow deleting The Narrator profile (by id or name)
+        $row = $this->getById($id);
+        if ($row && (intval($row['id']) === 1 || ($row['npc_name'] ?? '') === 'The Narrator')) {
+            return false;
+        }
         return $this->db->delete($this->table, $where);
     }
 
@@ -245,7 +236,28 @@ class NpcMaster
         $existing = $this->getByName($npcname);
 
         if ($existing && ! $overwrite) {
-            // Profile exists, and no overwrite requested — bail
+            // Profile exists, and no overwrite requested
+            // BUT still update race/gender/refid if they're empty and FORCE_PARMS has them
+            $needsUpdate = false;
+            $updateFields = [];
+
+            if (empty($existing['race']) && !empty($FORCE_PARMS['race'])) {
+                $updateFields['race'] = $FORCE_PARMS['race'];
+                $needsUpdate = true;
+            }
+            if (empty($existing['gender']) && !empty($FORCE_PARMS['gender'])) {
+                $updateFields['gender'] = $FORCE_PARMS['gender'];
+                $needsUpdate = true;
+            }
+            if (empty($existing['refid']) && !empty($FORCE_PARMS['refid'])) {
+                $updateFields['refid'] = $FORCE_PARMS['refid'];
+                $needsUpdate = true;
+            }
+
+            if ($needsUpdate) {
+                $this->update($existing['id'], $updateFields);
+                Logger::info("NPC '{$npcname}' updated with game data (race/gender/refid).");
+            }
             return;
         }
 
@@ -393,7 +405,6 @@ class NpcMaster
             $currentNpcData['voiceid'] = $OLD_GLOBALS_ARRAY['TTS']['XTTSFASTAPI']['voiceid'];
         }
 
-        $overrides=[];
         /*
         foreach ($OLD_GLOBALS_ARRAY as $k=>$v) {
             if (!is_array($v)) {
@@ -513,7 +524,6 @@ class NpcMaster
             $GLOBALS['TTS']['openai']['voice']         = $currentNpcData['voiceid'];
             $GLOBALS['TTS']['deepgram']['model']       = $currentNpcData['voiceid'];
             $GLOBALS['TTS']['CARTESIA']['voiceid']     = $currentNpcData['voiceid'];
-            $GLOBALS['TTS']['INWORLD']['voiceid']      = $currentNpcData['voiceid'];
 
         }
 
@@ -647,32 +657,27 @@ class NpcMaster
         date_default_timezone_set('UTC');
 
         $startTime = time();
+        // Fetch all current NPCs
+        $npcs = $this->getAll();
         error_log("[NPC BACKUP] " . date('Y-m-d H:i:s'));
 
-        // Update all NPCs with new gamets_last_updated timestamp
-        $updateQuery = "UPDATE {$this->table} SET gamets_last_updated = $timestamp";
-        $GLOBALS["db"]->execQuery($updateQuery);
+        foreach ($npcs as $npc) {
+            // Remove original ID
+            $npc_id                     = $npc['id'];
+            $npc['gamets_last_updated'] = $timestamp;
 
-        // Insert all NPCs into history table in a single query
-        $createdTimestamp = date('Y-m-d H:i:s');
-        $insertQuery = "
-            INSERT INTO core_npc_master_history (
-                npc_id, npc_name, npc_favorite, lock_profile, prompt_head, npc_static_bio,
-                oghma_knowledge_tags, emote_moods, personality, relationships,
-                occupation, skills, speechstyle, goals, voiceid, metadata,
-                gender, race, refid, profile_id, dynamic_profile, extended_data,
-                md5, gamets_last_updated, core, base, tags, appearance, created
-            )
-            SELECT
-                id, npc_name, npc_favorite, lock_profile, prompt_head, npc_static_bio,
-                oghma_knowledge_tags, emote_moods, personality, relationships,
-                occupation, skills, speechstyle, goals, voiceid, metadata,
-                gender, race, refid, profile_id, dynamic_profile, extended_data,
-                md5, $timestamp, core, base, tags, appearance, '{$createdTimestamp}'
-            FROM core_npc_master
-        ";
-        $GLOBALS["db"]->execQuery($insertQuery);
+            $this->update($npc_id, $npc);
 
+            unset($npc['id']);
+
+            // Set the reference and override timestamps
+            $npc['npc_id']              = $npc_id;
+            $npc['gamets_last_updated'] = $timestamp;
+            $npc['created']             = date('Y-m-d H:i:s'); // Current timestamp
+
+            // Insert into history
+            $this->db->insert('core_npc_master_history', $npc);
+        }
         error_log("[NPC BACKUP] " . date('Y-m-d H:i:s') . ", NPCs backup made in " . (time() - $startTime) . " secs ");
         return true;
     }
@@ -745,16 +750,23 @@ FROM restore
         error_log("[NPC RESTORE] using gamets: $timestamp.. " . date('Y-m-d H:i:s'));
         $GLOBALS["db"]->query($query);
 
-        $bglife_q="UPDATE public.core_npc_master
-SET extended_data = jsonb_set(
-    extended_data,
-    '{background_life_enabled}',   -- JSON path
-    'false'::jsonb,                -- new value
-    true                           -- create if missing (optional)
-)
-WHERE (extended_data ->> 'background_life_enabled')::boolean = true";
+        // RELATIONSHIP SYSTEM: Clear "future" relationship data from NPCs that weren't restored
+        // NPCs added AFTER the save timestamp don't have history entries, so they keep their
+        // current (future) state. We need to clear their relationship data to prevent paradoxes.
+        $rel_reset_q = "UPDATE public.core_npc_master
+            SET extended_data = extended_data - 'relationships' - 'relationships_updated' - 'relationships_model' - 'relationships_inferred'
+            WHERE npc_name <> 'The Narrator'
+              AND (gamets_last_updated > $timestamp OR gamets_last_updated IS NULL)
+              AND extended_data IS NOT NULL
+              AND extended_data ? 'relationships'";
 
-        $GLOBALS["db"]->execQuery($bglife_q);
+        try {
+            $GLOBALS["db"]->execQuery($rel_reset_q);
+            error_log("[NPC RESTORE] Cleared future relationship data for NPCs with gamets > $timestamp");
+        } catch (Exception $e) {
+            error_log("[NPC RESTORE] Failed to clear future relationships: " . $e->getMessage());
+        }
+
         error_log("[NPC RESTORE] " . date('Y-m-d H:i:s') . ", NPCs restore made in " . (time() - $startTime) . " secs ");
         return true;
     }

--- a/lib/dynamic_update_util.php
+++ b/lib/dynamic_update_util.php
@@ -789,7 +789,47 @@ function updateDynamicProfileField($npcName, $field, $historyData) {
         }
 
         $profileContextString = !empty($profileContext) ? "\n\n* Current Character Profile:\n" . implode("\n\n", $profileContext) : '';
-        
+
+        // ============================================
+        // BRIDGE: Inject CHIM Relationship System Data
+        // When updating 'relationships' field, feed in the quantified scores
+        // from extended_data.relationships (tracked in real-time by RelationshipLLM)
+        // ============================================
+        if ($field === 'relationships') {
+            $extended = json_decode($npcData['extended_data'] ?? '{}', true) ?: [];
+            $jsonbRels = $extended['relationships'] ?? [];
+
+            if (!empty($jsonbRels)) {
+                $profileContextString .= "\n\n**REAL-TIME RELATIONSHIP TRACKING DATA:**\n";
+                $profileContextString .= "(These scores are updated every conversation turn by the relationship system)\n\n";
+
+                foreach ($jsonbRels as $target => $data) {
+                    $aff = $data['aff'] ?? $data['affinity'] ?? 0;
+                    $type = $data['type'] ?? 'neutral';
+                    $lastChange = isset($data['last_change']) ? " (last change: {$data['last_change']})" : '';
+
+                    // Describe affinity in human terms
+                    $affDesc = '';
+                    if ($aff >= 80) $affDesc = 'deeply devoted';
+                    elseif ($aff >= 60) $affDesc = 'very fond';
+                    elseif ($aff >= 40) $affDesc = 'friendly';
+                    elseif ($aff >= 20) $affDesc = 'warm';
+                    elseif ($aff >= 6) $affDesc = 'slightly positive';
+                    elseif ($aff >= -5) $affDesc = 'neutral';
+                    elseif ($aff >= -20) $affDesc = 'slightly negative';
+                    elseif ($aff >= -40) $affDesc = 'unfriendly';
+                    elseif ($aff >= -60) $affDesc = 'hostile';
+                    else $affDesc = 'deeply hostile';
+
+                    $profileContextString .= "- **{$target}**: affinity={$aff} ({$affDesc}), type={$type}{$lastChange}\n";
+                }
+
+                $profileContextString .= "\n**IMPORTANT:** Use these quantified scores to inform your relationship prose. ";
+                $profileContextString .= "The affinity scores reflect actual tracked interactions. ";
+                $profileContextString .= "Higher affinity = stronger positive feelings. Type indicates relationship nature.\n";
+            }
+        }
+
         // Build prompt for this specific field
         $head = [
             ["role" => "system", "content" => "You are an assistant. Analyze the dialogue history and character profile to update ONLY the " . ucfirst($field) . " for the character named '$npcName'. Focus mostly on information about $npcName and mostly ignore details about other characters mentioned in the dialogue."]

--- a/lib/relationship_manager.php
+++ b/lib/relationship_manager.php
@@ -616,6 +616,226 @@ PROMPT;
     }
 
     /**
+     * Build relationship context for the Rolemaster/Director
+     * Called when rolemaster activates to provide relationship awareness
+     *
+     * Returns prose descriptions of how characters feel about each other -
+     * no scores, just narrative the director can use to guide the scene.
+     *
+     * @param array $npcsInScene Names of NPCs currently in scene
+     * @param array $mentionedNpcs Names of NPCs mentioned in dialogue (optional)
+     * @return string Prose context block for director
+     */
+    public static function buildDirectorContext($npcsInScene = [], $mentionedNpcs = []) {
+        // Combine and dedupe NPC lists
+        $allNpcs = array_unique(array_merge($npcsInScene, $mentionedNpcs));
+        $allNpcs = array_filter($allNpcs, function($n) {
+            $n = trim($n);
+            return !empty($n) && strtolower($n) !== 'player';
+        });
+
+        if (empty($allNpcs)) {
+            return "";
+        }
+
+        $descriptions = [];
+
+        // Clean NPC names (remove status tags)
+        $cleanNpcs = [];
+        foreach ($allNpcs as $npc) {
+            $clean = trim(preg_replace('/\s*\([^)]+\)/', '', $npc));
+            if (!empty($clean)) {
+                $cleanNpcs[] = $clean;
+            }
+        }
+
+        // For each NPC, describe their feelings
+        foreach ($cleanNpcs as $npc) {
+            $rels = self::getRelationships($npc);
+            if (empty($rels)) continue;
+
+            $npcDescriptions = [];
+
+            // How this NPC feels about the Player
+            if (isset($rels['Player'])) {
+                $desc = self::describeFeeling($npc, 'Player', $rels['Player']);
+                if ($desc) $npcDescriptions[] = $desc;
+            }
+
+            // How this NPC feels about other NPCs in scene
+            foreach ($cleanNpcs as $otherNpc) {
+                if ($otherNpc === $npc) continue;
+                if (isset($rels[$otherNpc])) {
+                    $desc = self::describeFeeling($npc, $otherNpc, $rels[$otherNpc]);
+                    if ($desc) $npcDescriptions[] = $desc;
+                }
+            }
+
+            // Subject/topic affinities (anything that's not an NPC name or Player)
+            $knownNames = array_map('strtolower', $cleanNpcs);
+            $knownNames[] = 'player';
+
+            foreach ($rels as $target => $r) {
+                if (in_array(strtolower($target), $knownNames)) continue;
+                // This is a subject/topic affinity
+                $desc = self::describeSubjectFeeling($npc, $target, $r);
+                if ($desc) $npcDescriptions[] = $desc;
+            }
+
+            if (!empty($npcDescriptions)) {
+                $descriptions = array_merge($descriptions, $npcDescriptions);
+            }
+        }
+
+        if (empty($descriptions)) {
+            return "";
+        }
+
+        $lines = [];
+        $lines[] = "[HOW CHARACTERS FEEL]";
+        $lines = array_merge($lines, $descriptions);
+        $lines[] = "";
+        $lines[] = "Director: Ensure your instructions respect these feelings. Don't direct characters to act against their strong emotions.";
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Describe how one character feels about another in prose
+     */
+    private static function describeFeeling($npc, $target, $relData) {
+        $aff = $relData['aff'] ?? 0;
+        $type = $relData['type'] ?? 'neutral';
+        $worst = $relData['worst'] ?? '';
+        $best = $relData['best'] ?? '';
+
+        // Skip truly neutral relationships
+        if ($aff >= -5 && $aff <= 5 && $type === 'neutral') {
+            return null;
+        }
+
+        // Build the feeling description based on affinity AND type
+        $feeling = self::getEmotionalDescription($aff, $type);
+
+        $desc = "- {$npc} {$feeling} {$target}";
+
+        // Add the WHY - the significant events that shaped this feeling
+        $reasons = [];
+        if (!empty($worst)) $reasons[] = $worst;
+        if (!empty($best)) $reasons[] = $best;
+
+        if (!empty($reasons)) {
+            $desc .= " because " . implode(" and ", $reasons);
+        }
+
+        return $desc;
+    }
+
+    /**
+     * Get emotional description based on affinity and relationship type
+     */
+    private static function getEmotionalDescription($aff, $type) {
+        // High positive affinity
+        if ($aff >= 76) {
+            switch ($type) {
+                case 'romantic': return "is deeply in love with";
+                case 'familial': return "has an unbreakable family bond with";
+                case 'nemesis':
+                case 'enemy': return "is completely obsessed with - can't stop thinking about";
+                case 'rival': return "has immense respect for as a worthy opponent -";
+                case 'fearful': return "is utterly dependent on despite fearing";
+                default: return "is utterly devoted to";
+            }
+        }
+        // Moderate-high positive
+        elseif ($aff >= 56) {
+            switch ($type) {
+                case 'romantic': return "has strong romantic feelings for";
+                case 'familial': return "deeply loves and protects";
+                case 'enemy':
+                case 'nemesis': return "has a complex obsession with";
+                case 'rival': return "genuinely respects and enjoys competing with";
+                default: return "is genuinely fond of";
+            }
+        }
+        // Positive
+        elseif ($aff >= 31) {
+            switch ($type) {
+                case 'romantic': return "is attracted to";
+                case 'rival': return "enjoys friendly competition with";
+                default: return "is friendly toward";
+            }
+        }
+        // Slight positive
+        elseif ($aff >= 6) {
+            return "is slightly positive toward";
+        }
+        // Neutral
+        elseif ($aff >= -5) {
+            return "is indifferent to";
+        }
+        // Slight negative
+        elseif ($aff >= -30) {
+            switch ($type) {
+                case 'suspicious': return "doesn't trust";
+                case 'fearful': return "is nervous around";
+                default: return "is wary of";
+            }
+        }
+        // Moderate negative
+        elseif ($aff >= -55) {
+            switch ($type) {
+                case 'contempt': return "looks down on";
+                case 'jealous': return "is bitterly jealous of";
+                default: return "is cold and unfriendly toward";
+            }
+        }
+        // Strong negative
+        elseif ($aff >= -75) {
+            switch ($type) {
+                case 'betrayed': return "feels deeply betrayed by";
+                default: return "resents and holds grudges against";
+            }
+        }
+        // Very strong negative
+        elseif ($aff >= -90) {
+            return "actively hates";
+        }
+        // Extreme negative
+        else {
+            return "is hostile toward and would attack";
+        }
+    }
+
+    /**
+     * Describe how a character feels about a subject/topic
+     */
+    private static function describeSubjectFeeling($npc, $subject, $relData) {
+        $aff = $relData['aff'] ?? 0;
+
+        // Skip neutral
+        if ($aff >= -5 && $aff <= 5) {
+            return null;
+        }
+
+        if ($aff >= 60) {
+            $feeling = "strongly values and supports";
+        } elseif ($aff >= 30) {
+            $feeling = "favors";
+        } elseif ($aff >= 6) {
+            $feeling = "is somewhat positive toward";
+        } elseif ($aff >= -30) {
+            $feeling = "dislikes";
+        } elseif ($aff >= -60) {
+            $feeling = "strongly opposes";
+        } else {
+            $feeling = "despises and would act against";
+        }
+
+        return "- {$npc} {$feeling} \"{$subject}\"";
+    }
+
+    /**
      * Import OHGMA relationship text into structured data
      * Parses format: "* Name - Description of relationship"
      */

--- a/lib/relationship_manager.php
+++ b/lib/relationship_manager.php
@@ -183,6 +183,49 @@ class RelationshipManager {
     }
 
     /**
+     * Get tier reference prompt from database (custom or default)
+     * This is injected into NPC context to help the conversation model
+     * understand how to adjust behavior based on relationship tiers.
+     */
+    public static function getTierReferencePrompt() {
+        static $cached = null;
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        // Default fallback if database unavailable
+        $default = "[TIER REFERENCE - Adjust behavior toward NPCs based on tier]\n" .
+            "HOSTILE: Wants them dead, attack on sight\n" .
+            "HATEFUL: Despises, refuses cooperation, threatens\n" .
+            "RESENTFUL: Deep grudge, bitter, may sabotage\n" .
+            "COLD: Dismissive, unhelpful, curt\n" .
+            "WARY: Suspicious, guarded, reluctant\n" .
+            "NEUTRAL: Polite stranger, no special treatment\n" .
+            "ACQUAINTANCE: Recognizes, mildly helpful\n" .
+            "FRIENDLY: Pleasant, helpful, enjoys company\n" .
+            "FOND: Warm, protective, prioritizes them\n" .
+            "DEVOTED: Deep loyalty, would sacrifice\n" .
+            "BONDED: Absolute trust, would die for them";
+
+        try {
+            // Query the prompts table for custom or default tier reference
+            $row = $GLOBALS["db"]->fetchOne(
+                "SELECT COALESCE(custom_prompt, default_prompt) as prompt " .
+                "FROM prompts WHERE prompt_key = 'rel_tier_reference'"
+            );
+            if ($row && !empty($row['prompt'])) {
+                $cached = $row['prompt'];
+                return $cached;
+            }
+        } catch (Exception $e) {
+            error_log("[REL] Failed to load tier reference prompt: " . $e->getMessage());
+        }
+
+        $cached = $default;
+        return $cached;
+    }
+
+    /**
      * Get emoji for tier
      */
     public static function getTierEmoji($tier) {
@@ -289,15 +332,14 @@ class RelationshipManager {
 
         // Add behavioral instructions so the conversation model knows how to use these tiers
         if ($tierOnly) {
-            $lines[] = "[RELATIONSHIPS - Adjust your behavior based on these tiers]";
-            $lines[] = "HOSTILE/HATEFUL: Attack on sight, refuse all cooperation, openly threaten";
-            $lines[] = "RESENTFUL/COLD: Dismissive, unhelpful, curt replies, refuse requests";
-            $lines[] = "WARY: Suspicious, guarded, reluctant to share info or help";
-            $lines[] = "NEUTRAL: Polite but distant stranger, no special treatment";
-            $lines[] = "ACQUAINTANCE/FRIENDLY: Helpful, pleasant, willing to assist";
-            $lines[] = "FOND/DEVOTED: Warm, protective, prioritize their wellbeing, go out of your way";
-            $lines[] = "BONDED: Unbreakable loyalty, would die for them, confide everything";
+            // Get tier reference prompt from database (custom or default)
+            $tierPrompt = self::getTierReferencePrompt();
+            $tierLines = explode("\n", $tierPrompt);
+            foreach ($tierLines as $tierLine) {
+                $lines[] = trim($tierLine);
+            }
             $lines[] = "";
+            $lines[] = "[CURRENT RELATIONSHIPS]";
         } else {
             $lines[] = "[RELATIONSHIPS]";
         }

--- a/service/processors/rolemaster/cmd/instruction.php
+++ b/service/processors/rolemaster/cmd/instruction.php
@@ -8,6 +8,7 @@ require_once($GLOBALS["ENGINE_ROOT"] . "/lib/core/api_badge.class.php");
 require_once($GLOBALS["ENGINE_ROOT"] . "/lib/core/llm_connector.class.php");
 require_once($GLOBALS["ENGINE_ROOT"] . "/lib/core/npc_master.class.php");
 require_once($GLOBALS["ENGINE_ROOT"] . "/lib/core/core_profiles.class.php");
+require_once($GLOBALS["ENGINE_ROOT"] . "/lib/relationship_manager.php");
 
 $GLOBALS["ENGINE_PATH"]=$GLOBALS["ENGINE_ROOT"]; // Todo, make this uniform
 
@@ -60,8 +61,18 @@ if (!isset($GLOBALS["CHIM_CORE_CURRENT_CONNECTOR_DATA"]) ) {
 
         }
 
-        
-        // Function stuff      
+        // Inject relationship context for director awareness
+        // Get nearby NPCs from DataBeingsInCloseRange (same source as DataLastInfoFor uses)
+        $nearbyNpcsRaw = DataBeingsInCloseRange();
+        $nearbyNpcsList = array_filter(array_map('trim', explode('|', $nearbyNpcsRaw)));
+
+        // Build relationship context for these NPCs
+        $relContext = RelationshipManager::buildDirectorContext($nearbyNpcsList);
+        if (!empty($relContext)) {
+            $historyData .= "\n" . $relContext . "\n";
+        }
+
+        // Function stuff
         require($enginePath . "functions/functions_instruction.php");
 
         $GLOBALS["ENABLED_FUNCTIONS"][]="ReturnBackHome";
@@ -234,7 +245,7 @@ user request: actor \"a\" leaves the place
             
             $characterName = trim($response["character"] ?? 'Unknown');
             $instructionText = trim($response["instruction"] ?? 'No instruction text');
-            $action = $response["action"]?"{$response["action"]} {$response["target"]}":"";
+            $action = !empty($response["action"]) ? "{$response["action"]} " . ($response["target"] ?? "") : "";
         
             if (!$characterName || !$instructionText) {
                 return false;


### PR DESCRIPTION
## Summary

- **dynamic_update_util.php**: Bridge CHIM Relationship System data into dynamic profile updates. When updating the relationships field, injects real-time tracked affinity scores from extended_data.relationships so LLM uses quantified data to inform relationship prose.

- **npc_master.class.php**: Fix relationship paradox on save restoration. Clears future relationship data from NPCs added after save timestamp to prevent relationship state from persisting after loading old saves.

- **relationship_manager.php**: Extended relationship types (30+), 11-tier bell curve affinity system, getTierReferencePrompt() for database-driven tier descriptions, event notes formatting, emoji mappings.

## Files Changed
- lib/dynamic_update_util.php (+40 lines)
- lib/core/npc_master.class.php (+12 lines)
- lib/relationship_manager.php (+42 lines)