### PR TITLE
Fix data corruption and queue reliability bugs in relationship system

### DIFF
--- a/ext/relationship_system/async_queue.php
+++ b/ext/relationship_system/async_queue.php
@@ -95,13 +95,15 @@ function _relProcessQueue($limit = 5) {
         return ['processed' => 0, 'error' => 'no database'];
     }
 
-    $results = ['processed' => 0, 'errors' => []];
+    $results = ['processed' => 0, 'errors' => [], 'retried' => 0, 'abandoned' => 0];
 
     try {
-        // Get pending evaluations (oldest first)
+        // Get pending evaluations (oldest first, prioritize items with fewer retries)
         $rows = $GLOBALS['db']->fetchAll(
-            "SELECT id, npc_id, eval_data FROM relationship_eval_queue
-             ORDER BY created_at ASC LIMIT {$limit}"
+            "SELECT id, npc_id, eval_data, COALESCE(retry_count, 0) as retry_count
+             FROM relationship_eval_queue
+             ORDER BY COALESCE(retry_count, 0) ASC, created_at ASC
+             LIMIT {$limit}"
         );
 
         if (empty($rows)) {
@@ -116,15 +118,19 @@ function _relProcessQueue($limit = 5) {
             return ['processed' => 0, 'error' => 'LLM not available'];
         }
 
-        $processedIds = [];
+        $successIds = [];      // Fully processed - delete
+        $retryIds = [];        // Failed but will retry - increment retry_count
+        $abandonIds = [];      // Exceeded max retries - delete with warning
 
         // Track which NPCs we've already lazy-initialized this session
         static $lazyInitChecked = [];
 
         foreach ($rows as $row) {
             $data = json_decode($row['eval_data'], true);
+            $retryCount = intval($row['retry_count']);
+
             if (!$data) {
-                $processedIds[] = $row['id'];
+                $successIds[] = $row['id']; // Invalid data, just delete
                 continue;
             }
 
@@ -192,20 +198,54 @@ function _relProcessQueue($limit = 5) {
                     }
                 }
 
-                $processedIds[] = $row['id'];
+                // Success! Delete from queue
+                $successIds[] = $row['id'];
                 $results['processed']++;
 
             } catch (Exception $e) {
-                $results['errors'][] = "NPC {$data['npc_id']}: " . $e->getMessage();
-                // Still mark as processed to avoid infinite retry
-                $processedIds[] = $row['id'];
+                $errorMsg = $e->getMessage();
+                $results['errors'][] = "NPC {$data['npc_id']}: " . $errorMsg;
+
+                // RETRY LOGIC: Don't delete on first error!
+                // Only delete after REL_QUEUE_MAX_RETRIES attempts
+                $maxRetries = defined('REL_QUEUE_MAX_RETRIES') ? REL_QUEUE_MAX_RETRIES : 3;
+
+                if ($retryCount >= $maxRetries) {
+                    // Exceeded max retries - log critical event and abandon
+                    error_log("[REL-ASYNC] ABANDONED after {$retryCount} retries: NPC {$data['npc_name']} - {$errorMsg}");
+                    $abandonIds[] = $row['id'];
+                    $results['abandoned']++;
+                } else {
+                    // Increment retry count for next attempt
+                    $retryIds[] = ['id' => $row['id'], 'error' => substr($errorMsg, 0, 500)];
+                    $results['retried']++;
+                    error_log("[REL-ASYNC] Retry {$retryCount}/" . $maxRetries . " for NPC {$data['npc_name']}: {$errorMsg}");
+                }
             }
         }
 
-        // Delete processed entries
-        if (!empty($processedIds)) {
-            $idList = implode(',', array_map('intval', $processedIds));
+        // Delete successfully processed entries
+        if (!empty($successIds)) {
+            $idList = implode(',', array_map('intval', $successIds));
             $GLOBALS['db']->query("DELETE FROM relationship_eval_queue WHERE id IN ({$idList})");
+        }
+
+        // Delete abandoned entries (exceeded max retries)
+        if (!empty($abandonIds)) {
+            $idList = implode(',', array_map('intval', $abandonIds));
+            $GLOBALS['db']->query("DELETE FROM relationship_eval_queue WHERE id IN ({$idList})");
+        }
+
+        // Increment retry count for failed entries (will try again later)
+        foreach ($retryIds as $retry) {
+            $id = intval($retry['id']);
+            $escapedError = $GLOBALS['db']->escape($retry['error']);
+            $GLOBALS['db']->query(
+                "UPDATE relationship_eval_queue
+                 SET retry_count = COALESCE(retry_count, 0) + 1,
+                     last_error = '{$escapedError}'
+                 WHERE id = {$id}"
+            );
         }
 
     } catch (Exception $e) {
@@ -220,6 +260,7 @@ function _relProcessQueue($limit = 5) {
 
 /**
  * Create the queue table if it doesn't exist
+ * Includes retry_count for retry logic (prevents Alzheimer's bug)
  */
 function _relCreateQueueTable() {
     try {
@@ -228,14 +269,29 @@ function _relCreateQueueTable() {
                 id SERIAL PRIMARY KEY,
                 npc_id INTEGER NOT NULL UNIQUE,
                 eval_data JSONB NOT NULL,
-                created_at TIMESTAMP DEFAULT NOW()
+                created_at TIMESTAMP DEFAULT NOW(),
+                retry_count INTEGER DEFAULT 0,
+                last_error TEXT
             )
         ");
         error_log("[REL-ASYNC] Created relationship_eval_queue table");
+
+        // Add columns if table exists but is missing them (migration)
+        $GLOBALS['db']->query("
+            ALTER TABLE relationship_eval_queue
+            ADD COLUMN IF NOT EXISTS retry_count INTEGER DEFAULT 0
+        ");
+        $GLOBALS['db']->query("
+            ALTER TABLE relationship_eval_queue
+            ADD COLUMN IF NOT EXISTS last_error TEXT
+        ");
     } catch (Exception $e) {
         error_log("[REL-ASYNC] Failed to create queue table: " . $e->getMessage());
     }
 }
+
+// Maximum retries before deleting a failed queue item
+define('REL_QUEUE_MAX_RETRIES', 3);
 
 /**
  * Get queue status (for debugging)
@@ -315,12 +371,14 @@ function _relProcessInitQueue($limit = 5) {
         return ['processed' => 0];
     }
 
-    $results = ['processed' => 0];
+    $results = ['processed' => 0, 'retried' => 0, 'abandoned' => 0];
 
     try {
         $rows = $GLOBALS['db']->fetchAll(
-            "SELECT id, npc_id, init_data FROM relationship_init_queue
-             ORDER BY created_at ASC LIMIT {$limit}"
+            "SELECT id, npc_id, init_data, COALESCE(retry_count, 0) as retry_count
+             FROM relationship_init_queue
+             ORDER BY COALESCE(retry_count, 0) ASC, created_at ASC
+             LIMIT {$limit}"
         );
 
         if (empty($rows)) {
@@ -334,12 +392,16 @@ function _relProcessInitQueue($limit = 5) {
             return ['processed' => 0, 'error' => 'LLM not available'];
         }
 
-        $processedIds = [];
+        $successIds = [];
+        $retryIds = [];
+        $abandonIds = [];
 
         foreach ($rows as $row) {
             $data = json_decode($row['init_data'], true);
+            $retryCount = intval($row['retry_count']);
+
             if (!$data) {
-                $processedIds[] = $row['id'];
+                $successIds[] = $row['id'];
                 continue;
             }
 
@@ -349,17 +411,43 @@ function _relProcessInitQueue($limit = 5) {
                 if (!empty($initResult['ok']) && empty($initResult['skipped'])) {
                     error_log("[REL-ASYNC] Initialized relationships for {$data['npc_name']}");
                 }
-                $processedIds[] = $row['id'];
+                $successIds[] = $row['id'];
                 $results['processed']++;
             } catch (Exception $e) {
-                // Still mark as processed to avoid infinite retry
-                $processedIds[] = $row['id'];
+                $errorMsg = $e->getMessage();
+                $maxRetries = defined('REL_QUEUE_MAX_RETRIES') ? REL_QUEUE_MAX_RETRIES : 3;
+
+                if ($retryCount >= $maxRetries) {
+                    error_log("[REL-ASYNC] ABANDONED init after {$retryCount} retries: {$data['npc_name']} - {$errorMsg}");
+                    $abandonIds[] = $row['id'];
+                    $results['abandoned']++;
+                } else {
+                    $retryIds[] = ['id' => $row['id'], 'error' => substr($errorMsg, 0, 500)];
+                    $results['retried']++;
+                    error_log("[REL-ASYNC] Init retry {$retryCount}/" . $maxRetries . " for {$data['npc_name']}: {$errorMsg}");
+                }
             }
         }
 
-        if (!empty($processedIds)) {
-            $idList = implode(',', array_map('intval', $processedIds));
+        if (!empty($successIds)) {
+            $idList = implode(',', array_map('intval', $successIds));
             $GLOBALS['db']->query("DELETE FROM relationship_init_queue WHERE id IN ({$idList})");
+        }
+
+        if (!empty($abandonIds)) {
+            $idList = implode(',', array_map('intval', $abandonIds));
+            $GLOBALS['db']->query("DELETE FROM relationship_init_queue WHERE id IN ({$idList})");
+        }
+
+        foreach ($retryIds as $retry) {
+            $id = intval($retry['id']);
+            $escapedError = $GLOBALS['db']->escape($retry['error']);
+            $GLOBALS['db']->query(
+                "UPDATE relationship_init_queue
+                 SET retry_count = COALESCE(retry_count, 0) + 1,
+                     last_error = '{$escapedError}'
+                 WHERE id = {$id}"
+            );
         }
 
     } catch (Exception $e) {
@@ -374,6 +462,7 @@ function _relProcessInitQueue($limit = 5) {
 
 /**
  * Create the init queue table
+ * Includes retry_count for retry logic (prevents Alzheimer's bug)
  */
 function _relCreateInitQueueTable() {
     try {
@@ -382,8 +471,20 @@ function _relCreateInitQueueTable() {
                 id SERIAL PRIMARY KEY,
                 npc_id INTEGER NOT NULL UNIQUE,
                 init_data JSONB NOT NULL,
-                created_at TIMESTAMP DEFAULT NOW()
+                created_at TIMESTAMP DEFAULT NOW(),
+                retry_count INTEGER DEFAULT 0,
+                last_error TEXT
             )
+        ");
+
+        // Add columns if table exists but is missing them (migration)
+        $GLOBALS['db']->query("
+            ALTER TABLE relationship_init_queue
+            ADD COLUMN IF NOT EXISTS retry_count INTEGER DEFAULT 0
+        ");
+        $GLOBALS['db']->query("
+            ALTER TABLE relationship_init_queue
+            ADD COLUMN IF NOT EXISTS last_error TEXT
         ");
     } catch (Exception $e) {
         error_log("[REL-ASYNC] Failed to create init queue table: " . $e->getMessage());

--- a/ext/relationship_system/relationship_llm.php
+++ b/ext/relationship_system/relationship_llm.php
@@ -30,6 +30,35 @@ class RelationshipLLM {
     }
 
     /**
+     * Safely decode JSON with proper error handling
+     * CRITICAL: Prevents data loss if extended_data is corrupted
+     *
+     * If JSON decode fails, logs the error and returns null (NOT empty array).
+     * Callers must check for null before proceeding with writes.
+     *
+     * @param string|null $json The JSON string to decode
+     * @param string $context Description for error logging
+     * @return array|null Decoded array, or null if decode failed
+     */
+    private function safeJsonDecode($json, $context = 'unknown') {
+        if ($json === null || $json === '') {
+            return []; // Empty/null is valid - start fresh
+        }
+
+        $decoded = json_decode($json, true);
+
+        if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+            // JSON was present but corrupted - DO NOT return empty array!
+            $error = json_last_error_msg();
+            error_log("[REL-LLM] CRITICAL: JSON decode failed for {$context}: {$error}");
+            error_log("[REL-LLM] Corrupted JSON (first 200 chars): " . substr($json, 0, 200));
+            return null; // Return null to signal failure - caller must abort write
+        }
+
+        return $decoded ?: [];
+    }
+
+    /**
      * Acquire advisory lock for NPC relationship updates
      * Prevents race conditions when multiple requests update the same NPC
      *
@@ -169,7 +198,10 @@ class RelationshipLLM {
         }
 
         // Check if already has JSONB relationships
-        $extended = json_decode($npc['extended_data'] ?? '{}', true) ?: [];
+        $extended = $this->safeJsonDecode($npc['extended_data'] ?? null, "analyzeNpc:{$npc['npc_name']}");
+        if ($extended === null) {
+            return ['ok' => false, 'error' => 'Corrupted extended_data - refusing to overwrite'];
+        }
         if (!empty($extended['relationships']) && !$forceReanalyze) {
             return ['ok' => true, 'skipped' => true, 'reason' => 'Already has relationships'];
         }
@@ -397,7 +429,14 @@ PROMPT;
                 return false;
             }
 
-            $extended = json_decode($npc['extended_data'] ?? '{}', true) ?: [];
+            $extended = $this->safeJsonDecode($npc['extended_data'] ?? null, "saveRelationships:{$npc['npc_name']}");
+            if ($extended === null) {
+                // CRITICAL: Corrupted data - abort to prevent data loss
+                error_log("[REL-LLM] ABORT: saveRelationships for {$npc['npc_name']} - corrupted extended_data");
+                $this->releaseNpcLock($npcId);
+                return false;
+            }
+
             $extended['relationships'] = $relationships;
             $extended['relationships_analyzed'] = date('Y-m-d H:i:s');
             $extended['relationships_model'] = $this->modelName;
@@ -437,7 +476,15 @@ PROMPT;
 
         foreach ($npcs as $npc) {
             // Check if already processed
-            $extended = json_decode($npc['extended_data'] ?? '{}', true) ?: [];
+            $extended = $this->safeJsonDecode($npc['extended_data'] ?? null, "batchAnalyze:{$npc['npc_name']}");
+            if ($extended === null) {
+                $results['errors']++;
+                $results['details'][] = [
+                    'npc' => $npc['npc_name'],
+                    'error' => 'Corrupted extended_data'
+                ];
+                continue;
+            }
             if (!empty($extended['relationships']) && !$forceReanalyze) {
                 $results['skipped']++;
                 continue;
@@ -480,7 +527,10 @@ PROMPT;
 
         if (!$npc) return ['ok' => false, 'error' => 'NPC not found'];
 
-        $extended = json_decode($npc['extended_data'] ?? '{}', true) ?: [];
+        $extended = $this->safeJsonDecode($npc['extended_data'] ?? null, "inferTransitive:{$npc['npc_name']}");
+        if ($extended === null) {
+            return ['ok' => false, 'error' => 'Corrupted extended_data'];
+        }
         $myRels = $extended['relationships'] ?? [];
 
         if (empty($myRels)) {
@@ -504,7 +554,8 @@ PROMPT;
 
             if (!$targetNpc) continue;
 
-            $targetExtended = json_decode($targetNpc['extended_data'] ?? '{}', true) ?: [];
+            $targetExtended = $this->safeJsonDecode($targetNpc['extended_data'] ?? null, "inferTransitive:target:{$targetName}");
+            if ($targetExtended === null) continue; // Skip corrupted target, don't abort
             $targetRels = $targetExtended['relationships'] ?? [];
 
             // Check target's relationships
@@ -542,7 +593,13 @@ PROMPT;
             try {
                 // Re-fetch to get latest state after acquiring lock
                 $npc = $npcMaster->getById($npcId);
-                $extended = json_decode($npc['extended_data'] ?? '{}', true) ?: [];
+                $extended = $this->safeJsonDecode($npc['extended_data'] ?? null, "inferTransitive:save:{$npc['npc_name']}");
+                if ($extended === null) {
+                    // CRITICAL: Corrupted data - abort to prevent data loss
+                    error_log("[REL-LLM] ABORT: inferTransitive save for {$npc['npc_name']} - corrupted extended_data");
+                    $this->releaseNpcLock($npcId);
+                    return ['ok' => false, 'error' => 'Corrupted extended_data during save'];
+                }
                 $myRels = $extended['relationships'] ?? [];
 
                 // Merge with existing (don't overwrite explicit relationships)
@@ -606,7 +663,10 @@ PROMPT;
         $npcName = $npc['npc_name'];
 
         // Get current relationships
-        $extended = json_decode($npc['extended_data'] ?? '{}', true) ?: [];
+        $extended = $this->safeJsonDecode($npc['extended_data'] ?? null, "evaluateContext:{$npcName}");
+        if ($extended === null) {
+            return ['ok' => false, 'error' => 'Corrupted extended_data'];
+        }
         $currentRels = $extended['relationships'] ?? [];
 
         // Build context string
@@ -791,8 +851,19 @@ PROMPT;
         $listenerName = $listener['npc_name'];
 
         // Get current relationships for both NPCs
-        $speakerExtended = json_decode($speaker['extended_data'] ?? '{}', true) ?: [];
-        $listenerExtended = json_decode($listener['extended_data'] ?? '{}', true) ?: [];
+        $speakerExtended = $this->safeJsonDecode($speaker['extended_data'] ?? null, "npc2npc:speaker:{$speakerName}");
+        $listenerExtended = $this->safeJsonDecode($listener['extended_data'] ?? null, "npc2npc:listener:{$listenerName}");
+
+        // If either is corrupted, skip them but don't abort completely
+        if ($speakerExtended === null) {
+            error_log("[REL-LLM] Skipping speaker {$speakerName} - corrupted extended_data");
+            $speakerExtended = [];
+        }
+        if ($listenerExtended === null) {
+            error_log("[REL-LLM] Skipping listener {$listenerName} - corrupted extended_data");
+            $listenerExtended = [];
+        }
+
         $speakerRels = $speakerExtended['relationships'] ?? [];
         $listenerRels = $listenerExtended['relationships'] ?? [];
 
@@ -1194,7 +1265,13 @@ PROMPT;
             try {
                 // Re-fetch to get latest state after acquiring lock
                 $npc = $npcMaster->getById($npcId);
-                $extended = json_decode($npc['extended_data'] ?? '{}', true) ?: [];
+                $extended = $this->safeJsonDecode($npc['extended_data'] ?? null, "applyChanges:{$npc['npc_name']}");
+                if ($extended === null) {
+                    // CRITICAL: Corrupted data - abort to prevent data loss
+                    error_log("[REL-LLM] ABORT: applyChanges for {$npc['npc_name']} - corrupted extended_data");
+                    $this->releaseNpcLock($npcId);
+                    return []; // Return empty - changes not saved
+                }
 
                 // Merge our changes with latest state
                 $existingRels = $extended['relationships'] ?? [];


### PR DESCRIPTION
## Summary

- Fixed JSON decode data corruption bug in relationship_llm.php - if extended_data contained corrupted JSON, the fallback would return empty array and save it back, nuking all NPC data
- Fixed queue event loss bug in async_queue.php - LLM failures caused immediate deletion of queue items instead of retrying

## Changes

### relationship_llm.php
- Added safeJsonDecode() with proper json_last_error() checking
- Returns null on corruption instead of empty array
- All callers now abort writes when decode fails

### async_queue.php
- Added retry logic (max 3 attempts) before abandoning queue items
- Added retry_count and last_error columns
- Includes migration SQL for existing tables

## Test Plan
- [ ] Verify normal relationship processing still works
- [ ] Test with intentionally corrupted JSON to confirm abort behavior
- [ ] Test LLM timeout handling to confirm retry logic