### PR TITLE
Add Groq model autocomplete to LLM connector UI

### DIFF
--- a/ui/cmd/action_groq_get_models.php
+++ b/ui/cmd/action_groq_get_models.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Fetch available Groq models using user's API key
+ * Returns list of models for the connector UI autocomplete
+ */
+
+$enginePath = __DIR__.DIRECTORY_SEPARATOR."../../";
+require_once($enginePath . "conf".DIRECTORY_SEPARATOR."conf.php");
+require_once($enginePath . "lib" .DIRECTORY_SEPARATOR."{$GLOBALS["DBDRIVER"]}.class.php");
+require_once($enginePath . "lib" .DIRECTORY_SEPARATOR."core/api_badge.class.php");
+
+// Initialize database connection
+$GLOBALS["db"] = new sql();
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'POST') {
+    header('Content-Type: application/json');
+
+    // Read JSON data from the request
+    $jsonDataInput = json_decode(file_get_contents("php://input"), true);
+    $apiBadgeId = $jsonDataInput['api_badge_id'] ?? null;
+
+    if (empty($apiBadgeId)) {
+        echo json_encode(['error' => 'API badge ID required']);
+        exit;
+    }
+
+    // Fetch the API key from the database
+    $apiBadge = new ApiBadge();
+    $badgeRow = $apiBadge->getById((int)$apiBadgeId);
+
+    if (!$badgeRow || empty($badgeRow['api_key'])) {
+        echo json_encode(['error' => 'API key not found for badge ID ' . $apiBadgeId]);
+        exit;
+    }
+
+    $apiKey = $badgeRow['api_key'];
+
+    // Set the request headers
+    $headers = [
+        'Content-Type: application/json',
+        'Authorization: Bearer ' . $apiKey
+    ];
+
+    // Create a context for the stream
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'GET',
+            'header' => implode("\r\n", $headers),
+            'timeout' => 10
+        ],
+    ]);
+
+    // Groq models endpoint (OpenAI-compatible)
+    $url = "https://api.groq.com/openai/v1/models";
+
+    // Perform the HTTP GET request
+    $response = @file_get_contents($url, false, $context);
+
+    if ($response === false) {
+        echo json_encode(['error' => 'Failed to fetch models from Groq API']);
+        exit;
+    }
+
+    $data = json_decode($response, true);
+
+    if (!isset($data['data']) || !is_array($data['data'])) {
+        echo json_encode(['error' => 'Invalid response from Groq API']);
+        exit;
+    }
+
+    // Format the result for the autocomplete dropdown
+    // Groq returns: id, object, owned_by, active, context_window
+    $result = [];
+
+    foreach ($data['data'] as $model) {
+        $id = $model['id'] ?? '';
+        if (empty($id)) continue;
+
+        $owned_by = $model['owned_by'] ?? 'Groq';
+        $context_window = $model['context_window'] ?? null;
+
+        // Build label with context window if available
+        $label = $owned_by;
+        if ($context_window) {
+            $label .= ', ctx: ' . number_format($context_window / 1024, 0) . 'K';
+        }
+
+        $result[] = [
+            'value' => $id,
+            'label' => $label,
+            'id' => $id,
+            'owned_by' => $owned_by,
+            'context_window' => $context_window
+        ];
+    }
+
+    // Sort by model ID
+    usort($result, function($a, $b) {
+        return strcmp($a['id'], $b['id']);
+    });
+
+    echo json_encode($result);
+}
+
+?>

--- a/ui/core/llm_connectors.php
+++ b/ui/core/llm_connectors.php
@@ -848,6 +848,81 @@ if (isset($_GET["partial"]) && $_GET["partial"] === "editor") {
             document.querySelector('input[name="driver"]').addEventListener('change', update);
         })();
     })();
+    // Groq model dropdown
+    (function(){
+        const modelInput = document.querySelector('input[name="model"]');
+        if (!modelInput) return;
+        let groqCache = null, groqDropdown = null, groqIsOpen = false;
+        function ensureGroqDropdown(){ if (groqDropdown) return groqDropdown; groqDropdown = document.createElement('div'); groqDropdown.className = 'orm-dropdown'; document.body.appendChild(groqDropdown); groqDropdown.addEventListener('mousedown', (e)=>{ e.preventDefault(); }); return groqDropdown; }
+        function positionGroqDropdown(){ const rect = modelInput.getBoundingClientRect(); const style = groqDropdown.style; style.left = (rect.left + window.scrollX) + 'px'; style.top = (rect.bottom + window.scrollY + 4) + 'px'; style.minWidth = Math.max(rect.width, 420) + 'px'; style.display = 'block'; groqIsOpen = true; }
+        function closeGroqDropdown(){ if (!groqDropdown) return; groqDropdown.style.display = 'none'; groqIsOpen = false; }
+        function escapeHtml(s){ return (s==null? '': String(s)).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])); }
+        function encodeHtmlAttr(s){ return (s==null? '': String(s)).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+        function formatContext(val){ const num = Number(val); return isFinite(num) ? num.toLocaleString('en-US') : (val||''); }
+        function renderGroqList(models, filterText){
+            ensureGroqDropdown();
+            const q = (filterText || '').toLowerCase();
+            const list = (models || []).filter(m => { if (!q) return true; const id = (m.id || '').toLowerCase(); return id.includes(q); });
+            let html = '';
+            html += '<div class="orm-head">Groq Models</div>';
+            html += '<div class="orm-note">Click to select a model.</div>';
+            if (list.length === 0){ html += '<div class="orm-muted" style="padding:8px 10px;">No matches</div>'; }
+            else { list.forEach(m => { const ctx = m.context_window ? formatContext(m.context_window) : ''; const owner = m.owned_by || 'Groq'; const sub = owner + (ctx ? ` • context ${ctx}` : ''); html += `<div class=\"orm-item\" data-id=\"${encodeHtmlAttr(m.id)}\" title=\"${encodeHtmlAttr(m.id)}\"><div>${escapeHtml(m.id)}</div><div class=\"orm-muted\" style=\"font-size:12px; margin-top:2px;\">${sub}</div></div>`; }); }
+            groqDropdown.innerHTML = html;
+            groqDropdown.querySelectorAll('.orm-item').forEach(el => { el.addEventListener('click', () => { const id = el.getAttribute('data-id') || ''; modelInput.value = id; try { modelInput.dispatchEvent(new Event('input', { bubbles: true })); } catch (_) {} try { modelInput.dispatchEvent(new Event('change', { bubbles: true })); } catch (_) {} closeGroqDropdown(); }); });
+            positionGroqDropdown();
+        }
+        async function loadGroqModels(){
+            if (groqCache) return groqCache;
+            const apiBadgeSelect = document.getElementById('api_badge_id');
+            const apiBadgeId = apiBadgeSelect ? apiBadgeSelect.value : '';
+            if (!apiBadgeId) {
+                ensureGroqDropdown();
+                groqDropdown.innerHTML = '<div class="orm-head">Groq Models</div><div class="orm-err">Please select an API Key first.</div>';
+                positionGroqDropdown();
+                throw new Error('No API badge selected');
+            }
+            ensureGroqDropdown();
+            groqDropdown.innerHTML = '<div class="orm-head">Groq Models</div><div class="orm-note">Loading…</div>';
+            positionGroqDropdown();
+            try {
+                const res = await fetch('<?= $webRoot; ?>/ui/cmd/action_groq_get_models.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ api_badge_id: apiBadgeId })
+                });
+                if (!res.ok) throw new Error('HTTP '+res.status);
+                const json = await res.json();
+                if (json.error) {
+                    groqDropdown.innerHTML = '<div class="orm-head">Groq Models</div><div class="orm-err">' + escapeHtml(json.error) + '</div>';
+                    positionGroqDropdown();
+                    throw new Error(json.error);
+                }
+                groqCache = Array.isArray(json) ? json : [];
+                groqCache.sort((a,b)=> (a.id||'').localeCompare(b.id||''));
+                return groqCache;
+            } catch (e) {
+                if (!groqDropdown.innerHTML.includes('orm-err')) {
+                    groqDropdown.innerHTML = '<div class="orm-head">Groq Models</div><div class="orm-err">Failed to load models. Check API key.</div>';
+                    positionGroqDropdown();
+                }
+                throw e;
+            }
+        }
+        function isGroq(){ const svc = ((document.getElementById('service_input')||{}).value||'').toLowerCase(); if (svc !== 'groq') return false; const url = (document.querySelector('input[name="url"]').value||''); const driver = (document.querySelector('input[name="driver"]').value||''); return url.includes('groq.com') || /groq/.test(driver); }
+        async function maybeOpenGroqDropdown(){ if (!isGroq()) return; try { const models = await loadGroqModels(); renderGroqList(models, modelInput.value); } catch (_e) {} }
+        modelInput.addEventListener('focus', () => { if (isGroq()) maybeOpenGroqDropdown(); });
+        modelInput.addEventListener('click', () => { if (isGroq()) maybeOpenGroqDropdown(); });
+        modelInput.addEventListener('input', () => { if (groqIsOpen && groqCache) renderGroqList(groqCache, modelInput.value); });
+        modelInput.addEventListener('blur', () => { setTimeout(closeGroqDropdown, 120); });
+        window.addEventListener('resize', () => { if (groqIsOpen) positionGroqDropdown(); });
+        window.addEventListener('scroll', () => { if (groqIsOpen) positionGroqDropdown(); }, true);
+        document.addEventListener('keydown', (e)=>{ if (e.key==='Escape') closeGroqDropdown(); });
+        document.querySelector('input[name="url"]').addEventListener('change', () => { groqCache = null; closeGroqDropdown(); });
+        document.querySelector('input[name="driver"]').addEventListener('change', () => { groqCache = null; closeGroqDropdown(); });
+        const apiBadgeSel = document.getElementById('api_badge_id');
+        if (apiBadgeSel) apiBadgeSel.addEventListener('change', () => { groqCache = null; });
+    })();
     // Providers dropdown
     (function(){
         const providerInput = document.querySelector('input[name="provider"]');
@@ -1867,6 +1942,81 @@ function llmClamp(rangeId, numberId, min, max){ const r = document.getElementByI
         document.querySelector('input[name="url"]').addEventListener('change', update);
         document.querySelector('input[name="driver"]').addEventListener('change', update);
     })();
+})();
+// Groq model dropdown (standalone editor)
+(function(){
+    const modelInput = document.querySelector('input[name="model"]');
+    if (!modelInput) return;
+    let groqCache = null, groqDropdown = null, groqIsOpen = false;
+    function ensureGroqDropdown(){ if (groqDropdown) return groqDropdown; groqDropdown = document.createElement('div'); groqDropdown.className = 'orm-dropdown'; document.body.appendChild(groqDropdown); groqDropdown.addEventListener('mousedown', (e)=>{ e.preventDefault(); }); return groqDropdown; }
+    function positionGroqDropdown(){ const rect = modelInput.getBoundingClientRect(); const style = groqDropdown.style; style.left = (rect.left + window.scrollX) + 'px'; style.top = (rect.bottom + window.scrollY + 4) + 'px'; style.minWidth = Math.max(rect.width, 420) + 'px'; style.display = 'block'; groqIsOpen = true; }
+    function closeGroqDropdown(){ if (!groqDropdown) return; groqDropdown.style.display = 'none'; groqIsOpen = false; }
+    function escapeHtml(s){ return (s==null? '': String(s)).replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])); }
+    function encodeHtmlAttr(s){ return (s==null? '': String(s)).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+    function formatContext(val){ const num = Number(val); return isFinite(num) ? num.toLocaleString('en-US') : (val||''); }
+    function renderGroqList(models, filterText){
+        ensureGroqDropdown();
+        const q = (filterText || '').toLowerCase();
+        const list = (models || []).filter(m => { if (!q) return true; const id = (m.id || '').toLowerCase(); return id.includes(q); });
+        let html = '';
+        html += '<div class="orm-head">Groq Models</div>';
+        html += '<div class="orm-note">Click to select a model.</div>';
+        if (list.length === 0){ html += '<div class="orm-muted" style="padding:8px 10px;">No matches</div>'; }
+        else { list.forEach(m => { const ctx = m.context_window ? formatContext(m.context_window) : ''; const owner = m.owned_by || 'Groq'; const sub = owner + (ctx ? ` • context ${ctx}` : ''); html += `<div class=\"orm-item\" data-id=\"${encodeHtmlAttr(m.id)}\" title=\"${encodeHtmlAttr(m.id)}\"><div>${escapeHtml(m.id)}</div><div class=\"orm-muted\" style=\"font-size:12px; margin-top:2px;\">${sub}</div></div>`; }); }
+        groqDropdown.innerHTML = html;
+        groqDropdown.querySelectorAll('.orm-item').forEach(el => { el.addEventListener('click', () => { const id = el.getAttribute('data-id') || ''; modelInput.value = id; try { modelInput.dispatchEvent(new Event('input', { bubbles: true })); } catch (_) {} try { modelInput.dispatchEvent(new Event('change', { bubbles: true })); } catch (_) {} closeGroqDropdown(); }); });
+        positionGroqDropdown();
+    }
+    async function loadGroqModels(){
+        if (groqCache) return groqCache;
+        const apiBadgeSelect = document.getElementById('api_badge_id');
+        const apiBadgeId = apiBadgeSelect ? apiBadgeSelect.value : '';
+        if (!apiBadgeId) {
+            ensureGroqDropdown();
+            groqDropdown.innerHTML = '<div class="orm-head">Groq Models</div><div class="orm-err">Please select an API Key first.</div>';
+            positionGroqDropdown();
+            throw new Error('No API badge selected');
+        }
+        ensureGroqDropdown();
+        groqDropdown.innerHTML = '<div class="orm-head">Groq Models</div><div class="orm-note">Loading…</div>';
+        positionGroqDropdown();
+        try {
+            const res = await fetch('<?= $webRoot; ?>/ui/cmd/action_groq_get_models.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ api_badge_id: apiBadgeId })
+            });
+            if (!res.ok) throw new Error('HTTP '+res.status);
+            const json = await res.json();
+            if (json.error) {
+                groqDropdown.innerHTML = '<div class="orm-head">Groq Models</div><div class="orm-err">' + escapeHtml(json.error) + '</div>';
+                positionGroqDropdown();
+                throw new Error(json.error);
+            }
+            groqCache = Array.isArray(json) ? json : [];
+            groqCache.sort((a,b)=> (a.id||'').localeCompare(b.id||''));
+            return groqCache;
+        } catch (e) {
+            if (!groqDropdown.innerHTML.includes('orm-err')) {
+                groqDropdown.innerHTML = '<div class="orm-head">Groq Models</div><div class="orm-err">Failed to load models. Check API key.</div>';
+                positionGroqDropdown();
+            }
+            throw e;
+        }
+    }
+    function isGroq(){ const svc = ((document.getElementById('service_input')||{}).value||'').toLowerCase(); if (svc !== 'groq') return false; const url = (document.querySelector('input[name="url"]').value||''); const driver = (document.querySelector('input[name="driver"]').value||''); return url.includes('groq.com') || /groq/.test(driver); }
+    async function maybeOpenGroqDropdown(){ if (!isGroq()) return; try { const models = await loadGroqModels(); renderGroqList(models, modelInput.value); } catch (_e) {} }
+    modelInput.addEventListener('focus', () => { if (isGroq()) maybeOpenGroqDropdown(); });
+    modelInput.addEventListener('click', () => { if (isGroq()) maybeOpenGroqDropdown(); });
+    modelInput.addEventListener('input', () => { if (groqIsOpen && groqCache) renderGroqList(groqCache, modelInput.value); });
+    modelInput.addEventListener('blur', () => { setTimeout(closeGroqDropdown, 120); });
+    window.addEventListener('resize', () => { if (groqIsOpen) positionGroqDropdown(); });
+    window.addEventListener('scroll', () => { if (groqIsOpen) positionGroqDropdown(); }, true);
+    document.addEventListener('keydown', (e)=>{ if (e.key==='Escape') closeGroqDropdown(); });
+    document.querySelector('input[name="url"]').addEventListener('change', () => { groqCache = null; closeGroqDropdown(); });
+    document.querySelector('input[name="driver"]').addEventListener('change', () => { groqCache = null; closeGroqDropdown(); });
+    const apiBadgeSel = document.getElementById('api_badge_id');
+    if (apiBadgeSel) apiBadgeSel.addEventListener('change', () => { groqCache = null; });
 })();
 // Providers dropdown
 (function(){


### PR DESCRIPTION
## Summary
- Adds model autocomplete dropdown for Groq connectors in the LLM Connectors UI
- When editing a Groq connector and clicking the Model field, fetches available models from Groq API
- Displays model list with context window sizes, filterable by typing

## Files Added
- ui/cmd/action_groq_get_models.php - Backend endpoint that fetches models from Groq API using the selected API key

## Files Modified  
- ui/core/llm_connectors.php - Added Groq model dropdown JavaScript (follows same pattern as existing OpenRouter dropdown)

## How it works
1. User selects Groq as the service and picks their Groq API key
2. Clicking the Model field triggers a fetch to action_groq_get_models.php
3. Backend uses the API key to call Groq models endpoint
4. Returns model list with IDs, owners, and context window sizes
5. User can click to select or type to filter

## Notes
- Follows existing OpenRouter autocomplete pattern exactly
- Only activates when service is set to Groq
- Requires API key to be selected first (Groq model endpoint requires auth)