### PR TITLE
Fix SQL `ILIKE` pattern to correctly use `%` wildcard for `$pj` varia…

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -1307,7 +1307,7 @@ function lastKeyWordsContext($n, $npcname='')
         order by gamets desc limit $m offset 0"); */
     $lastRecords = $db->fetchAll("SELECT speaker, location, companions, speech, gamets 
      from (select * from speech where  gamets>{$whileago}) AS sp 
-     where ((speaker ilike '{$speaker}') or (speaker ilike '{%$pj%}' )) 
+     where ((speaker ilike '{$speaker}') or (speaker ilike '%{$pj}%' )) 
         order by gamets desc limit {$m} offset 0"); 
     
     $words=[];


### PR DESCRIPTION
During code review i noticed this interpolation error. Claude confirmed, see analysis below
Memory recall will be broken until this gets to AIAgent branch - recommend hotfix

ILIKE Pattern Matching
Old: speaker ilike '%$pj%'
New: speaker ilike '{%$pj%}'

Impact: 
CRITICAL BUG - The new version wraps the wildcard % inside the curly braces, which will be interpreted as a literal string {% and %} rather than SQL wildcards

Logic Difference:
The new code has a bug in the ILIKE clause.
Old behavior: Matches any speaker containing $pj anywhere in the string (e.g., "John Doe" matches if $pj = "ohn")
New behavior: Will try to match speaker exactly equal to the literal string {% + $pj + %}, which will never match