### PR TITLE
Fix typo in SQL query's eventlog type condition

### DIFF
--- a/functions/functions.php
+++ b/functions/functions.php
@@ -1064,7 +1064,7 @@ if ($GLOBALS["ENABLED_FUNCTIONS"]) {
         $isCombat=$GLOBALS["db"]->fetchOne("SELECT EXISTS (
     SELECT 1 as combat_active
     FROM public.eventlog start_evt
-    WHERE start_evt.data LIKE '%$cnName%engages fair combat with $playerCnName%' and type='funcrect'
+    WHERE start_evt.data LIKE '%$cnName engages fair combat with $playerCnName%' and type='funcret'
       AND NOT EXISTS (
           SELECT 1
           FROM public.eventlog defeat_evt


### PR DESCRIPTION
Fixed typo in funcret and fairly sure this LIKE clause is the intention, however none of the php functions actually generate that cue: `X engages fair combat with Y`, so unless the dll produces this it wont trigger anyway