### PR TITLE
fix: error adding non-vanilla cells to named_cell

### DIFF
--- a/processor/comm.php
+++ b/processor/comm.php
@@ -1800,7 +1800,7 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
                         'dest_door_cell_id'=>intval($localData[4]),
                         'dest_door_exterior'=>intval($localData[5]),
                         'door_id'=>intval($localData[6]),
-                        'vanilla_cell'=>(intval($localData[1])<77175193) ? true : false,// IDs below 77175193 are vanilla cells 0x04999999
+                        'vanilla_cell'=>((intval($localData[1]) < 77175193) ? 'true' : 'false'),// IDs below 77175193 are vanilla cells 0x04999999
                         'worldspace'=> $localData[7],
                         'closed'=>intval($localData[8]),
                         'door_name'=> $localData[9],


### PR DESCRIPTION
# ⚠️ ALL PR'S MUST BE SUBMITTED TO THE `UNSTABLE` BRANCH ⚠️

---

## What
Fix the error when adding non-vanilla cells to 'named_cell' table. 

## Why
Boolean value conversion from  PHP to SQL - PHP false is translated to '' instead of 'false', 'no', 'off' etc.
