### PR TITLE
Add Gemini 2.5 Flash as STT provider with emotion detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,0 @@
-https://en.wikipedia.org/wiki/MIT_License

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2023-2024 Augusto Beiro and others
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-# HerikaServer
+# AI Follower Framework
 
-New version of saig-gwserver. Also know as "Simple AI Gateway Skyrim Mod Gateway Server".
-
-Part of the mod for Skyrim: Herika - The ChatGPT Companion. This component serves as a bridge between the SKSE plugin and various providers of text-to-voice, voice-to-text, and AI-based chat generators such as ChatGPT, koboldcpp, text-generation-webui, or openrouter.ai.
+Server for the Skyrim mod "AI Follower Framework". This component serves as a bridge between the SKSE plugin and various providers of text-to-voice, voice-to-text, and AI-based chat generators such as ChatGPT, koboldcpp, Openrouter, XTTS, etc.
 
 It also serves as the character's memory, employing various techniques to mitigate the lack of long-term memory in current LLMs (Language Model Models)
 
-To run this you will only need a working Apache/PHP8.2 installation.
+# Vanilla NPC Bio's Credit/Source
+The npc_templates_custom_mantella_currated.sql and npc_templates_custom_mantella.sql are modifications taken from the source code of Mantella here: https://github.com/art-from-the-machine/Mantella
+
+# Attributions
+AI-FF uses material from "Mantella" NPC character biographies. Their biographies use material from the "Skyrim: Characters" articles on the Elder Scrolls wiki at Fandom and is licensed under the Creative Commons Attribution-Share Alike License.
 
 Full mod page:
-
-https://www.nexusmods.com/skyrimspecialedition/mods/89931
+https://www.nexusmods.com/skyrimspecialedition/mods/126330
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AI Follower Framework
+# AI Follower Framework Server
 
 Server for the Skyrim mod "AI Follower Framework". This component serves as a bridge between the SKSE plugin and various providers of text-to-voice, voice-to-text, and AI-based chat generators such as ChatGPT, koboldcpp, Openrouter, XTTS, etc.
 
@@ -10,7 +10,7 @@ The npc_templates_custom_mantella_currated.sql and npc_templates_custom_mantella
 # Attributions
 AI-FF uses material from "Mantella" NPC character biographies. Their biographies use material from the "Skyrim: Characters" articles on the Elder Scrolls wiki at Fandom and is licensed under the Creative Commons Attribution-Share Alike License.
 
-Full mod page:
+# AI-FF Mod Page
 https://www.nexusmods.com/skyrimspecialedition/mods/126330
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AI Follower Framework Server
+# CHIM Server
 
-Server for the Skyrim mod "AI Follower Framework". This component serves as a bridge between the SKSE plugin and various AI providers of text-to-speech, speech-to-text, and AI-based chat generators such as ChatGPT, MeloTTS, koboldcpp, Openrouter, XTTS, etc.
+Server for the Skyrim mod "CHIM". This component serves as a bridge between the SKSE plugin and various AI providers of text-to-speech, speech-to-text, and AI-based chat generators such as ChatGPT, MeloTTS, koboldcpp, Openrouter, XTTS, etc.
 
 Ultimately you will have meaningful interactions with AI NPCs. 
 
@@ -13,7 +13,7 @@ Ultimately you will have meaningful interactions with AI NPCs.
 - Dynamic character personalities that update over your playthrough.
 
 ## Attributions
-AI-FF character biographies use material from the "Skyrim: Characters" articles on Unofficial Elder Scrolls Pages and are licensed under the Creative Commons Attribution-Share Alike License.
+CHIM character biographies use material from the "Skyrim: Characters" articles on Unofficial Elder Scrolls Pages and are licensed under the Creative Commons Attribution-Share Alike License.
 
-## AI-FF Mod Page
-[AI Follower Framework Skyrim Mod](https://www.nexusmods.com/skyrimspecialedition/mods/126330)
+## CHIM Mod Page
+[CHIM Skyrim Mod](https://www.nexusmods.com/skyrimspecialedition/mods/126330)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ Server for the Skyrim mod "AI Follower Framework". This component serves as a br
 
 It also serves as the character's memory, employing various techniques to mitigate the lack of long-term memory in current LLMs (Language Model Models)
 
-# Vanilla NPC Bio's Credit/Source
-The npc_templates_custom_mantella_currated.sql and npc_templates_custom_mantella.sql are modifications taken from the source code of Mantella here: https://github.com/art-from-the-machine/Mantella
+# NPC Bio's Credit/Source
+The npc_templates_custom_mantella_currated.sql and npc_templates_custom_mantella.sql are modifications taken from the source code.
+
+Mantella Source Code: https://github.com/art-from-the-machine/Mantella
+Mantella License: https://github.com/art-from-the-machine/Mantella/blob/main/LICENSE
 
 # Attributions
 AI-FF uses material from "Mantella" NPC character biographies. Their biographies use material from the "Skyrim: Characters" articles on the Elder Scrolls wiki at Fandom and is licensed under the Creative Commons Attribution-Share Alike License.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # AI Follower Framework Server
 
-Server for the Skyrim mod "AI Follower Framework". This component serves as a bridge between the SKSE plugin and various providers of text-to-voice, voice-to-text, and AI-based chat generators such as ChatGPT, koboldcpp, Openrouter, XTTS, etc.
+Server for the Skyrim mod "AI Follower Framework". This component serves as a bridge between the SKSE plugin and various AI providers of text-to-speech, speech-to-text, and AI-based chat generators such as ChatGPT, MeloTTS, koboldcpp, Openrouter, XTTS, etc.
 
-It also serves as the character's memory, employing various techniques to mitigate the lack of long-term memory in current LLMs (Language Model Models)
+Ultimately you will have meaningful interactions with AI NPCs. 
 
-# NPC Bio's Credit/Source
-The npc_templates_custom_mantella_currated.sql and npc_templates_custom_mantella.sql are modifications taken from the source code.
+## Other Features:
+- Any NPC can be an AI, including group conversations.
+- Long-term memory for in-game characters, employing various techniques to mitigate the lack of long-term memory in current LLMs (Language Model Models).
+- Deep world awareness.
+- An AI Narrator to narrate your adventures and provide help.
+- Function calling action commands (e.g., trade with me, move here, attack that monster, etc.).
+- Dynamic character personalities that update over your playthrough.
 
-Mantella Source Code: https://github.com/art-from-the-machine/Mantella
-Mantella License: https://github.com/art-from-the-machine/Mantella/blob/main/LICENSE
+## Attributions
+AI-FF character biographies use material from the "Skyrim: Characters" articles on Unofficial Elder Scrolls Pages and are licensed under the Creative Commons Attribution-Share Alike License.
 
-# Attributions
-AI-FF uses material from "Mantella" NPC character biographies. Their biographies use material from the "Skyrim: Characters" articles on the Elder Scrolls wiki at Fandom and is licensed under the Creative Commons Attribution-Share Alike License.
-
-# AI-FF Mod Page
-https://www.nexusmods.com/skyrimspecialedition/mods/126330
-
-
+## AI-FF Mod Page
+[AI Follower Framework Skyrim Mod](https://www.nexusmods.com/skyrimspecialedition/mods/126330)

--- a/conf/conf.sample.php
+++ b/conf/conf.sample.php
@@ -209,6 +209,9 @@ $TTS["STYLETTSV2"]["beta"]=0.7;	//From 0.0 to 1.0 - The higher the value of `bet
 $TTS["STYLETTSV2"]["diffusion_steps"]=15;	//From 5 - Since the sampler is ancestral, the higher the steps, the more diverse the samples are, with the cost of slower synthesis speed
 $TTS["STYLETTSV2"]["embedding_scale"]=1.5;	//From 0.0 to 1.0 - This is the classifier-free guidance scale. The higher the scale, the more conditional the style is to the input text and hence more emotional.
 
+$TTS["XTTSFASTAPI"]["endpoint"]='';	//End point
+$TTS["XTTSFASTAPI"]["language"]='en';	//
+$TTS["XTTSFASTAPI"]["voiceid"]='';	//Voice json file
 
 
 ?>

--- a/conf/conf.sample.php
+++ b/conf/conf.sample.php
@@ -63,6 +63,8 @@ $STT["AZURE"]["LANG"]="en-US";
 $STT["AZURE"]["API_KEY"]="";
 $STT["AZURE"]["profanity"]="masked";
 
+$STT["DEEPGRAM"]["API_KEY"]="";
+
 $STT["WHISPER"]["LANG"]="en";
 $STT["WHISPER"]["API_KEY"]="";
 $STT["WHISPER"]["TRANSLATE"]=false;
@@ -89,7 +91,7 @@ $ITT["openai"]["AI_VISION_PROMPT"]='Let\'s roleplay in the world of Skyrim.  Des
 $ITT["openai"]["AI_PROMPT"]='#HERIKA_NPC1# describes what is seeing using rhymes';
 
 
-$STTFUNCTION="whisper";								// Valid options are azure or whisper so far
+$STTFUNCTION="whisper";								// Valid options are azure or whisper or localwhisper or deepgram
 $TTSFUNCTION="none";								// Valid options are azure or mimic3, or 11labs so far
 $ITTFUNCTION="none";								// Valid options are azure or mimic3, or 11labs so far
 

--- a/conf/conf_schema.json
+++ b/conf/conf_schema.json
@@ -183,7 +183,7 @@
     }
   },
   "STTFUNCTION": {
-    "type":"select","values":["whisper","localwhisper","azure"],"description":"Speech-to-Text service options. Translates your voice to text.", 
+    "type":"select","values":["whisper","localwhisper","azure", "deepgram"],"description":"Speech-to-Text service options. Translates your voice to text.", 
     "_title":"Speech-to-Text Service"
     },
   "STT": {
@@ -193,6 +193,10 @@
       "LANG": {"type":"string","description":"Language to detect for STT."},
       "TRANSLATE": {"type":"boolean","description":"Will try to translate to english."},
       "API_KEY": {"type":"apikey","description":"OpenAI API key. Same used for OpenAI/ChatGPT AI service.","code":"OPENAI_API_KEY"}
+    },
+    "DEEPGRAM": {
+      "_title":"Deepgram's Whisper Speech-to-Text",
+      "API_KEY": {"type":"apikey","description":"Deepgram API key.","code":"DEEPGRAM_API_KEY"}
     },
     "AZURE": {
       "_title":"Azure Speech-to-Text",

--- a/conf/conf_schema.json
+++ b/conf/conf_schema.json
@@ -88,7 +88,7 @@
       "rep_pen": {"type":"number","description":"LLM parameter rep_pen"}
     }
   },
-  "TTSFUNCTION": {"type":"select","values":["none","mimic3","azure","11labs","gcp","coqui-ai","xvasynth","openai","convai","xtts","stylettsv2"],"description":"Text-to-Speech service options. Used to generate your follower's voice.","_title":"Text-to-Speech Service"},
+  "TTSFUNCTION": {"type":"select","values":["none","mimic3","azure","11labs","gcp","coqui-ai","xvasynth","openai","convai","xtts","stylettsv2","xtts-fastapi"],"description":"Text-to-Speech service options. Used to generate your follower's voice.","_title":"Text-to-Speech Service"},
   "TTS": {
     "_title":"Text-to-Speech Service",
     "AZURE": {
@@ -174,6 +174,12 @@
       "beta":{"type":"number","description":"From 0.0 to 1.0 - The higher the value of `beta` the more suitable the style it is to the text but less similar to the reference. Using higher beta makes the synthesized speech more emotional, at the cost of lower similarity to the reference. `beta` determines the prosody of the speaker.","helpurl":""},
       "diffusion_steps":{"type":"number","description":"From 5 - Since the sampler is ancestral, the higher the steps, the more diverse the samples are, with the cost of slower synthesis speed","helpurl":""},
       "embedding_scale":{"type":"number","description":"From 0.0 to 1.0 - This is the classifier-free guidance scale. The higher the scale, the more conditional the style is to the input text and hence more emotional.","helpurl":""}
+    },
+    "XTTSFASTAPI": {
+      "_title":"XTTSv2 via fast-api",
+      "endpoint":{"type":"url","description":"End point URL","helpurl":""},
+      "language":{"type":"select","values":[  "ar","pt","zh-cn", "cs","nl","en","fr", "de", "it", "pl", "ru", "es", "tr","ja", "ko","hu","hi"],"description":"Language"},
+      "voiceid":{"type":"string","description":"WAV refernce (must be into server's voice folder)","helpurl":""}
     }
   },
   "STTFUNCTION": {

--- a/conf/conf_schema.json
+++ b/conf/conf_schema.json
@@ -183,7 +183,7 @@
     }
   },
   "STTFUNCTION": {
-    "type":"select","values":["whisper","localwhisper","azure", "deepgram"],"description":"Speech-to-Text service options. Translates your voice to text.", 
+    "type":"select","values":["whisper","localwhisper","azure", "deepgram", "gemini"],"description":"Speech-to-Text service options. Translates your voice to text.",
     "_title":"Speech-to-Text Service"
     },
   "STT": {
@@ -207,6 +207,12 @@
     "LOCALWHISPER": {
       "_title":"Local Whisper Speech-to-Text (Installed with DwemerDistro)",
       "URL": {"type":"url","description":"Local whisper endpoint. Leave as Default.","helpurl":"https://www.nexusmods.com/skyrimspecialedition/mods/89931?tab=files"}
+    },
+    "GEMINI": {
+      "_title":"Google Gemini STT + Emotion Detection",
+      "API_KEY": {"type":"apikey","description":"Google AI API key (from aistudio.google.com).","code":"GEMINI_API_KEY"},
+      "LANG": {"type":"string","description":"Language (e.g., en, es, ja)"},
+      "MODEL": {"type":"select","values":["gemini-2.5-flash","gemini-2.5-flash-lite","gemini-2.5-pro"],"description":"Gemini model. 2.5 Flash recommended for best speed and quality."}
     }
   },
   "ITTFUNCTION": {

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -107,7 +107,7 @@ $FUNCTIONS = [
     ],
     [
         "name" => $F_NAMES["LookAt"],
-        "description" => $F_TRANSLATIONS["Inspect"],
+        "description" => $F_TRANSLATIONS["LookAt"],
         "parameters" => [
             "type" => "object",
             "properties" => [

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -327,71 +327,63 @@ function returnLines($lines,$writeOutput=true)
                 require_once(__DIR__."/../tts/tts-azure.php");
                 $GLOBALS["TRACK"]["FILES_GENERATED"][]=tts($responseTextUnmooded, $mood, $responseText);
 
-            }
-
-            if ($GLOBALS["TTSFUNCTION"] == "mimic3") {
+            } else if ($GLOBALS["TTSFUNCTION"] == "mimic3") {
 
                 require_once(__DIR__."/../tts/tts-mimic3.php");
                 $GLOBALS["TRACK"]["FILES_GENERATED"][]=ttsMimic($responseTextUnmooded, $mood, $responseText);
 
-            }
-
-            if ($GLOBALS["TTSFUNCTION"] == "11labs") {
+            } else if ($GLOBALS["TTSFUNCTION"] == "11labs") {
 
                 require_once(__DIR__."/../tts/tts-11labs.php");
                 $GLOBALS["TRACK"]["FILES_GENERATED"][]=tts($responseTextUnmooded, $mood, $responseText);
 
-            }
-
-            if ($GLOBALS["TTSFUNCTION"] == "gcp") {
+            } else if ($GLOBALS["TTSFUNCTION"] == "gcp") {
 
                 require_once(__DIR__."/../tts/tts-gcp.php");
                 $GLOBALS["TRACK"]["FILES_GENERATED"][]=tts($responseTextUnmooded, $mood, $responseText);
 
-            }
-
-            if ($GLOBALS["TTSFUNCTION"] == "coqui-ai") {
+            } else if ($GLOBALS["TTSFUNCTION"] == "coqui-ai") {
 
                 require_once(__DIR__."/../tts/tts-coqui-ai.php");
                 $GLOBALS["TRACK"]["FILES_GENERATED"][]=tts($responseTextUnmooded, $mood, $responseText);
 
-            }
-
-
-            if ($GLOBALS["TTSFUNCTION"] == "xvasynth") {
+            } else if ($GLOBALS["TTSFUNCTION"] == "xvasynth") {
 
                 require_once(__DIR__."/../tts/tts-xvasynth.php");
                 $GLOBALS["TRACK"]["FILES_GENERATED"][]=tts($responseTextUnmooded, $mood, $responseText);
 
-            }
-            
-            if ($GLOBALS["TTSFUNCTION"] == "openai") {
+            } else if ($GLOBALS["TTSFUNCTION"] == "openai") {
 
                 require_once(__DIR__."/../tts/tts-openai.php");
                 $GLOBALS["TRACK"]["FILES_GENERATED"][]=tts($responseTextUnmooded, $mood, $responseText);
 
-            }
-            
-            if ($GLOBALS["TTSFUNCTION"] == "convai") {
+            } else if ($GLOBALS["TTSFUNCTION"] == "convai") {
 
                 require_once(__DIR__."/../tts/tts-convai.php");
                 $GLOBALS["TRACK"]["FILES_GENERATED"][]=tts($responseTextUnmooded, $mood, $responseText);
 
-            }
-            
-            if ($GLOBALS["TTSFUNCTION"] == "xtts") {
+            } else if ($GLOBALS["TTSFUNCTION"] == "xtts") {
 
                 require_once(__DIR__."/../tts/tts-xtts.php");
                 $GLOBALS["TRACK"]["FILES_GENERATED"][]=tts($responseTextUnmooded, $mood, $responseText);
 
-            }
-            
-            if ($GLOBALS["TTSFUNCTION"] == "stylettsv2") {
+            } else if ($GLOBALS["TTSFUNCTION"] == "stylettsv2") {
 
                 require_once(__DIR__."/../tts/tts-stylettsv2-2.php");
                 $GLOBALS["TRACK"]["FILES_GENERATED"][]=tts($responseTextUnmooded, $mood, $responseText);
 
+            } else if ($GLOBALS["TTSFUNCTION"] == "stylettsv2") {
+
+                require_once(__DIR__."/../tts/tts-stylettsv2-2.php");
+                $GLOBALS["TRACK"]["FILES_GENERATED"][]=tts($responseTextUnmooded, $mood, $responseText);
+
+            } else {
+                if (file_exists(__DIR__."/../tts/tts-".$GLOBALS["TTSFUNCTION"].".php")) {
+                    require_once(__DIR__."/../tts/tts-".$GLOBALS["TTSFUNCTION"].".php");
+                    $GLOBALS["TRACK"]["FILES_GENERATED"][]=tts($responseTextUnmooded, $mood, $responseText);
+                }
             }
+            
             
             if (trim($responseText)) {
                 $talkedSoFar[] = $responseText;

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -832,14 +832,24 @@ function selectRandomInArray($arraySource)
         return "";
     
     $n=sizeof($arraySource);
-    if ($n==1) {
-        return strtr($arraySource[0],["#HERIKA_NPC1#"=>$GLOBALS["HERIKA_NAME"]]);
-        //return $arraySource[0];
+
+    //$arraySource could be empty, could contain undefined element, could contain empty element, could contain array element
+    if ($n > 0) {   
+        if ($n > 1) {
+            $ix = rand(0, $n-1);
+        } else {
+            $ix = 0;
+        }
+        if (isset($arraySource[$ix])) {
+            if (is_array($arraySource[$ix])) {
+                error_log("selectRandomInArray: expecting string, received array " . print_r($arraySource[$ix], true) ); 
+            } else {
+                if (strlen($arraySource[$ix]) > 0) {
+                    return strtr($arraySource[$ix],["#HERIKA_NPC1#"=>$GLOBALS["HERIKA_NAME"]]);
+                }
+            }
+        }
     }
-    
-    return strtr($arraySource[rand(0, $n-1)],["#HERIKA_NPC1#"=>$GLOBALS["HERIKA_NAME"]]);
-    //return $arraySource[rand(0, $n-1)];
-
-
+    return "";
 
 }

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -69,7 +69,7 @@ function DataLastDataFor($actor, $lastNelements = -10)
 
     foreach ($lastDialogFull as $n => $line) {
 
-        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\ ]+), 4E (\d+)/';
+        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\'\ ]+), 4E (\d+)/'; //extract also for months with apostrophe like Sun's Something
         $replacement = 'Day name: $1, Hour: $2, Day Number: $3, Month: $4, 4th Era, Year: $5';
         $result = preg_replace($pattern, $replacement, $line["content"]);
         $lastDialogFull[$n]["content"] = $result;
@@ -121,7 +121,7 @@ function DataLastInfoFor($actor, $lastNelements = -2)
 
     foreach ($lastDialog as $n => $line) {
 
-        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\ ]+), 4E (\d+)/';
+        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\'\ ]+), 4E (\d+)/'; //extract also for months with apostrophe like Sun's Something
         $replacement = 'Day name: $1, Hour: $2, Day Number: $3, Month: $4, 4th Era, Year: $5';
         $result = preg_replace($pattern, $replacement, $line["content"]);
         $lastDialogFull[$n]["content"] = $result;
@@ -442,7 +442,7 @@ function DataLastDataExpandedFor($actor, $lastNelements = -10)
 
     foreach ($lastDialogFull as $n => $line) {
 
-        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\ ]+), 4E (\d+)/';
+        $pattern = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\'\ ]+), 4E (\d+)/'; //extract also for months with apostrophe like Sun's Something
         $replacement = 'Day name: $1, Hour: $2, Day Number: $3, Month: $4, 4th Era, Year: $5';
         $result = preg_replace($pattern, $replacement, $line["content"]);
         $lastDialogFull[$n]["content"] = $result;
@@ -653,14 +653,17 @@ function DataLastKnowDate()
 
     global $db;
 
-    $lastLoc=$db->fetchAll("select  a.data  as data  FROM  eventlog a  WHERE type in ('infoloc')  order by gamets desc,ts desc LIMIT 0,1");
+    $lastLoc=$db->fetchAll("select  a.data  as data  FROM  eventlog a  WHERE (type in ('infoloc')) and (data like '%Current Date%')  order by gamets desc, ts desc LIMIT 1"); //make sure record has datetime
     if (!is_array($lastLoc) || sizeof($lastLoc)==0) {
         return "";
     }
-    $re = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\ ]+), 4E (\d+)/';
-    preg_match($re, $lastLoc[0]["data"], $matches, PREG_OFFSET_CAPTURE, 0);
-    return $matches[0][0];
-
+    $re = '/(\w+), (\d{1,2}:\d{2} (?:AM|PM)), (\d{1,2})(?:st|nd|rd|th) of ([A-Za-z\'\ ]+), 4E (\d+)/'; //extract also for months with apostrophe like Sun's Something
+    if (preg_match($re, $lastLoc[0]["data"], $matches, PREG_OFFSET_CAPTURE, 0)) {
+        return $matches[0][0];
+    } else {
+        error_log("DataLastKnowDate: NO match found");
+        return "";
+    }
 }
 
 function DataLastKnownLocation()

--- a/stt.php
+++ b/stt.php
@@ -25,6 +25,11 @@ if ($STTFUNCTION=="azure") {
 
     require_once($path."stt/stt-whisper.php");
     $text= stt($finalName);
+
+} else if ($STTFUNCTION=="deepgram") { 
+
+    require_once($path."stt/stt-deepgram.php");
+    $text= stt($finalName);
     
 } else if ($STTFUNCTION=="localwhisper") { 
 

--- a/stt.php
+++ b/stt.php
@@ -31,11 +31,16 @@ if ($STTFUNCTION=="azure") {
     require_once($path."stt/stt-deepgram.php");
     $text= stt($finalName);
     
-} else if ($STTFUNCTION=="localwhisper") { 
+} else if ($STTFUNCTION=="localwhisper") {
 
     require_once($path."stt/stt-localwhisper.php");
     $text= stt($finalName);
-    
+
+} else if ($STTFUNCTION=="gemini") {
+
+    require_once($path."stt/stt-gemini.php");
+    $text= stt($finalName);
+
 }
 
 echo $text;

--- a/stt/stt-deepgram.php
+++ b/stt/stt-deepgram.php
@@ -1,0 +1,44 @@
+<?php
+
+// API-DOC https://developers.deepgram.com/docs/getting-started-with-pre-recorded-audio
+
+$localPath = dirname((__FILE__)) . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR;
+require_once($localPath . "conf".DIRECTORY_SEPARATOR."conf.php"); // API KEY must be there
+require_once($localPath . "lib" .DIRECTORY_SEPARATOR."{$GLOBALS["DBDRIVER"]}.class.php");
+require_once($localPath . "lib" .DIRECTORY_SEPARATOR."chat_helper_functions.php");
+
+
+
+function stt($file)
+{
+    //global $AZURETTS_CONF;
+    $GLOBALS["db"] = new sql();
+
+    $filePath = $file;
+    $fileContent = file_get_contents($filePath);
+    $url = "https://api.deepgram.com/v1/listen?smart_format=false&language=en&model=whisper-medium";
+
+    $contextOptions = [
+        'http' => [
+            'method' => 'POST',
+            'header' => [
+                "Authorization: Token {$GLOBALS["STT"]["DEEPGRAM"]["API_KEY"]}",
+                "Content-Type: audio/wav"
+            ],
+            'content' => $fileContent,
+        ],
+    ];
+
+    $context = stream_context_create($contextOptions);
+    $response = file_get_contents($url, false, $context);
+
+    if ($response === false) {
+        // Handle error
+        return null;
+    }
+
+    $responseParsed = json_decode($response, true);
+
+    return $responseParsed['results']['channels'][0]['alternatives'][0]['transcript'];
+}
+

--- a/stt/stt-gemini.php
+++ b/stt/stt-gemini.php
@@ -1,0 +1,184 @@
+<?php
+
+// Gemini 2.5 Flash STT — transcription + player emotion detection in one call
+// Drop-in replacement for Deepgram. Detects player vocal tone and caches it
+// for context injection so NPCs react to HOW the player speaks.
+
+$localPath = dirname(__FILE__) . '/../';
+require_once($localPath . "conf/conf.php");
+require_once($localPath . "lib/{$GLOBALS["DBDRIVER"]}.class.php");
+require_once($localPath . "lib/chat_helper_functions.php");
+
+// Cache file for player tone — read by context builders
+define('PLAYER_TONE_CACHE', dirname(__FILE__) . '/../soundcache/_player_tone.json');
+
+function stt($filePath)
+{
+    if (!isset($GLOBALS["db"]) || !$GLOBALS["db"])
+        $GLOBALS["db"] = new sql();
+
+    $fileContent = file_get_contents($filePath);
+    if ($fileContent === false) {
+        error_log("STT Gemini: warning - input file missing or unreadable! {$filePath}");
+        return null;
+    }
+
+    $i_sz = filesize($filePath);
+    if ($i_sz == 144046) {
+        error_log("STT Gemini: warning input file {$filePath} probably contains silence.");
+    }
+
+    // Resolve API key: prefer STT conf, fallback to API Badge 'gemini' or 'google'
+    $apiKey = trim($GLOBALS['STT']['GEMINI']['API_KEY'] ?? '');
+    if ($apiKey === '') {
+        try {
+            if (isset($GLOBALS["db"]) && $GLOBALS["db"]) {
+                $row = $GLOBALS["db"]->fetchOne("SELECT api_key FROM core_api_badge WHERE lower(label)='gemini' LIMIT 1");
+                if (is_array($row) && !empty($row['api_key'])) $apiKey = trim($row['api_key']);
+            }
+        } catch (Throwable $_e) {
+            error_log("STT Gemini: DB error looking up gemini badge: " . $_e->getMessage());
+        }
+    }
+    if ($apiKey === '') {
+        try {
+            if (isset($GLOBALS["db"]) && $GLOBALS["db"]) {
+                $row = $GLOBALS["db"]->fetchOne("SELECT api_key FROM core_api_badge WHERE lower(label)='google' LIMIT 1");
+                if (is_array($row) && !empty($row['api_key'])) $apiKey = trim($row['api_key']);
+            }
+        } catch (Throwable $_e) {
+            error_log("STT Gemini: DB error looking up google badge: " . $_e->getMessage());
+        }
+    }
+
+    if (empty($apiKey)) {
+        error_log("STT Gemini: No API key found. DB initialized=" . (isset($GLOBALS["db"]) ? "yes" : "no") . ". Set in STT config or add API badge with label 'gemini' or 'google'.");
+        return null;
+    }
+
+    $model = !empty($GLOBALS['STT']['GEMINI']['MODEL']) ? $GLOBALS['STT']['GEMINI']['MODEL'] : 'gemini-2.5-flash';
+    $lang = !empty($GLOBALS['STT']['GEMINI']['LANG']) ? $GLOBALS['STT']['GEMINI']['LANG'] : 'en';
+    error_log("STT Gemini: Using model={$model} lang={$lang} key=" . substr($apiKey, 0, 10) . "...");
+
+    // Build keyword hints from recent context (NPC names, locations, etc.)
+    $keywordHints = '';
+    try {
+        $keywords = lastKeyWordsNew(30);
+        if (!empty($keywords)) {
+            $keywordHints = "\n\nThe following proper nouns may appear in the audio (use these for spelling): " . implode(', ', $keywords);
+        }
+    } catch (Throwable $_e) {}
+
+    // Base64 encode the audio
+    $audioBase64 = base64_encode($fileContent);
+
+    // Build request — ask for both transcription and emotion in one shot
+    $requestData = [
+        'contents' => [[
+            'parts' => [
+                ['text' => "You are a speech-to-text system for a fantasy RPG game. Transcribe this audio accurately and detect the speaker's emotional tone from their voice.\n\nLanguage: {$lang}{$keywordHints}\n\nReturn ONLY valid JSON with exactly these two fields:\n{\"transcript\": \"the transcribed text\", \"tone\": \"one or two words describing the emotional tone of the speaker's voice\"}\n\nFor tone, use descriptive words like: calm, angry, excited, nervous, sad, happy, sarcastic, scared, commanding, playful, seductive, desperate, bored, suspicious, threatening, gentle, annoyed, confused, etc.\n\nIf the audio is silent or unintelligible, return: {\"transcript\": \"\", \"tone\": \"neutral\"}"],
+                ['inline_data' => [
+                    'mime_type' => 'audio/wav',
+                    'data' => $audioBase64
+                ]]
+            ]
+        ]],
+        'generationConfig' => [
+            'temperature' => 0.1,
+            'maxOutputTokens' => 256,
+            'responseMimeType' => 'application/json'
+        ]
+    ];
+
+    $url = "https://generativelanguage.googleapis.com/v1beta/models/{$model}:generateContent?key={$apiKey}";
+
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($requestData));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json'
+    ]);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($response === false) {
+        error_log("STT Gemini: cURL request failed");
+        return null;
+    }
+
+    if ($httpCode !== 200) {
+        error_log("STT Gemini: API returned HTTP {$httpCode} for model={$model}: " . substr($response, 0, 500));
+        return null;
+    }
+
+    $responseParsed = json_decode($response, true);
+    error_log("STT Gemini: raw response: " . substr($response, 0, 1000));
+
+    // Extract the generated text
+    $generatedText = $responseParsed['candidates'][0]['content']['parts'][0]['text'] ?? null;
+    if (empty($generatedText)) {
+        error_log("STT Gemini: no generated text in response");
+        return null;
+    }
+
+    // Parse the JSON response from Gemini
+    $result = json_decode($generatedText, true);
+    if (!is_array($result)) {
+        // Try to extract JSON from markdown code blocks
+        if (preg_match('/```(?:json)?\s*(\{.*?\})\s*```/s', $generatedText, $m)) {
+            $result = json_decode($m[1], true);
+        }
+        // Last resort — treat entire response as plain transcript
+        if (!is_array($result)) {
+            error_log("STT Gemini: could not parse JSON, using raw text as transcript");
+            return trim($generatedText);
+        }
+    }
+
+    $transcript = trim($result['transcript'] ?? '');
+    $tone = trim($result['tone'] ?? 'neutral');
+
+    // Cache the player's vocal tone for context injection
+    if (!empty($tone) && $tone !== 'neutral') {
+        $toneData = [
+            'tone' => $tone,
+            'timestamp' => time(),
+            'transcript_preview' => substr($transcript, 0, 100)
+        ];
+        @file_put_contents(PLAYER_TONE_CACHE, json_encode($toneData));
+        error_log("STT Gemini: Detected player tone: {$tone}");
+    } else {
+        // Clear stale tone cache
+        @unlink(PLAYER_TONE_CACHE);
+    }
+
+    error_log("STT Gemini: transcript=\"{$transcript}\" tone=\"{$tone}\"");
+    return $transcript;
+}
+
+/**
+ * Read the cached player tone (called by context builders)
+ * Returns the tone string if fresh (within $maxAge seconds), null otherwise.
+ *
+ * @param int $maxAge Maximum age in seconds (default 60)
+ * @return string|null
+ */
+function getPlayerTone($maxAge = 60) {
+    if (!file_exists(PLAYER_TONE_CACHE)) {
+        return null;
+    }
+    $data = json_decode(@file_get_contents(PLAYER_TONE_CACHE), true);
+    if (!is_array($data) || empty($data['tone'])) {
+        return null;
+    }
+    // Only return if fresh
+    if ((time() - ($data['timestamp'] ?? 0)) > $maxAge) {
+        return null;
+    }
+    return $data['tone'];
+}

--- a/tts/tts-xtts-fastapi.php
+++ b/tts/tts-xtts-fastapi.php
@@ -1,0 +1,148 @@
+<?php
+
+
+
+/*
+ * Clone voice 
+ * 
+curl -X 'POST' \
+  'https://k-looked-appointments-ordered.trycloudflare.com/clone_speaker' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: multipart/form-data' \
+  -F 'wav_file=@bella.wav;type=audio/wav'
+
+*/
+
+/*
+ "en", "de", "fr", "es", "it", "pl", "pt", "tr", "ru", "nl", "cs", "ar", "zh", "ja", "hu", "ko",
+ 
+ */
+
+function xtts_fastapi_settings($settings) {
+	$url = $GLOBALS["TTS"]["XTTSFASTAPI"]["endpoint"].'/set_tts_settings';
+	$data = json_decode('{
+		"stream_chunk_size": 20,
+		"temperature": 1,
+		"speed": 1,
+		"length_penalty": 0,
+		"repetition_penalty": 5,
+		"top_p": 0.5,
+		"top_k": 50,
+		"enable_text_splitting": true
+		}',true);
+	
+	$finalData=array_merge($settings,$data);
+	
+	$options = array(
+		'http' => array(
+			'header' => "Content-type: application/json\r\n" .
+						"Accept: application/json\r\n",
+			'method' => 'POST',
+			'content' => json_encode($finalData)
+		)
+	);
+	$context = stream_context_create($options);
+	$result = file_get_contents($url, false, $context);
+
+	if ($result === FALSE) {
+		// Handle error
+		error_log("Error occurred.".__FILE__);
+	} else {
+		;//ok
+	}
+}
+
+function tts($textString, $mood , $stringforhash) {
+
+		//xtts_fastapi_settings([]); //Check this
+		
+		if (!isset($GLOBALS["AVOID_TTS_CACHE"]))
+			if (file_exists(dirname((__FILE__)) . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "soundcache/" . md5(trim($stringforhash)) . ".wav"))
+				return dirname((__FILE__)) . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "soundcache/" . md5(trim($stringforhash)) . ".wav";
+	
+	    $starTime = microtime(true);
+
+		$url = $GLOBALS["TTS"]["XTTSFASTAPI"]["endpoint"]."/tts_to_audio";
+
+		// Request headers
+		$headers = array(
+			'Accept: audio/wav',
+			'Content-Type: application/json'
+		);
+		
+		$lang=isset($GLOBALS["TTS"]["FORCED_LANG_DEV"])?$GLOBALS["TTS"]["FORCED_LANG_DEV"]:$GLOBALS["TTS"]["XTTSFASTAPI"]["language"];
+		if (empty($lang))
+			$lang=$GLOBALS["TTS"]["XTTSFASTAPI"]["language"];
+	
+		// Request data
+		$data = array(
+			'text' => $textString,
+			'language' => $lang
+		);
+		
+		$voice=isset($GLOBALS["TTS"]["FORCED_VOICE_DEV"])?$GLOBALS["TTS"]["FORCED_VOICE_DEV"]:$GLOBALS["TTS"]["XTTSFASTAPI"]["voiceid"];
+		
+		if (empty($voice))
+			$voice=$GLOBALS["TTS"]["XTTSFASTAPI"]["voiceid"];
+	
+		
+
+		$data = array(
+			'text' => $textString,
+			'speaker_wav' => $voice,
+			'language' => $lang
+		);
+		$options = array(
+			'http' => array(
+				'header' => "Content-type: application/json\r\n" .
+							"Accept: application/json\r\n",
+				'method' => 'POST',
+				'content' => json_encode($data)
+			)
+		);
+		$context = stream_context_create($options);
+		$response = file_get_contents($url, false, $context);
+
+		if ($response === FALSE) {
+			// Handle error
+			error_log("Error occurred.".__FILE__);
+			return "";
+		}
+		
+		// Handle the response
+		if ($response !== false ) {
+			// Handle the successful response
+			$size=strlen($response);
+			$oname=dirname((__FILE__)) . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "soundcache/" . md5(trim($stringforhash)) . "_o.wav";
+			$fname=dirname((__FILE__)) . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "soundcache/" . md5(trim($stringforhash)) . ".wav";
+			
+			file_put_contents($oname, $response); // Save the audio response to a file
+			$startTimeTrans = microtime(true);
+			shell_exec("ffmpeg -y -i $oname -filter:a \"speechnorm=e=6:r=0.0001:l=1\" $fname 2>/dev/null >/dev/null");
+			$endTimeTrans = microtime(true)-$startTimeTrans;
+			
+            file_put_contents(dirname((__FILE__)) . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "soundcache/" . md5(trim($stringforhash)) . ".txt", trim($textString) . "\n\rtotal call time:" . (microtime(true) - $starTime) . " ms\n\rsize of wav ($size)\n\rfunction tts($textString,$mood=\"cheerful\",$stringforhash)");
+			$GLOBALS["DEBUG_DATA"][]=(microtime(true) - $starTime)." secs in xtts-fast-api call";
+			return "soundcache/" . md5(trim($stringforhash)) . ".wav";
+			
+		} else {
+			$textString.=print_r($http_response_header,true);
+			file_put_contents(dirname((__FILE__)) . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "soundcache/" . md5(trim($stringforhash)) . ".err", trim($textString));
+            return false;
+			
+		}
+
+}
+
+/*
+$GLOBALS["TTS"]["XTTSFASTAPI"]["endpoint"]='http://localhost:8020';
+$GLOBALS["TTS"]["XTTSFASTAPI"]["voiceid"]='jenassa';
+$GLOBALS["TTS"]["XTTSFASTAPI"]["language"]='en';
+
+$textTosay="Hello fellows...this is a new text to speech connector";
+
+echo tts($textTosay,'',$textTosay);
+*/
+
+
+

--- a/ui/conf_checker.php
+++ b/ui/conf_checker.php
@@ -113,6 +113,12 @@ if ($STTFUNCTION=="whisper")
         $errorFlag=true;
     }
 
+if ($STTFUNCTION=="deepgram")
+    if (!isset($STT["DEEPGRAM"]["API_KEY"])) {
+        echo 'Error: Deepgram is in use but $STT["DEEPGRAM"]["API_KEY"] not found <br/>';
+        $errorFlag=true;
+    }
+
 if ($STTFUNCTION=="localwhisper")
     if (!isset($STT["LOCALWHISPER"]["URL"])) {
         echo 'Error: Local Whisper is in use but $STT["LOCALWHISPER"]["URL"] not found <br/>';


### PR DESCRIPTION
## Summary
- Adds **Google Gemini 2.5 Flash** as a new speech-to-text provider alongside Whisper, Azure, Deepgram, and Local Whisper
- Single API call does both **transcription and vocal emotion detection** — NPCs can react to *how* the player sounds, not just what they say
- Player's detected tone is cached to `soundcache/_player_tone.json` with a 60-second TTL for context injection by downstream systems

## How it works
1. Player speaks → audio sent to Gemini as base64 WAV
2. Gemini returns JSON: `{"transcript": "...", "tone": "questioning"}`
3. Transcript returned to game as normal STT output
4. Tone cached for optional context injection (e.g., `[Player's voice sounds questioning]`)

## Features
- **Keyword hints** from `lastKeyWordsNew(30)` improve recognition of fantasy names (Whiterun, Lydia, etc.)
- **API key resolution**: STT config → `gemini` API badge → `google` API badge (flexible setup)
- **Configurable**: model selection (Flash, Flash Lite, Pro), language
- **Robust parsing**: handles raw JSON, markdown-wrapped JSON, and plain text fallback
- **Silence detection**: warns on known-silent file sizes

## Files changed
| File | Change |
|---|---|
| `stt/stt-gemini.php` | **New** — Full Gemini STT implementation (185 lines) |
| `stt.php` | Added `gemini` routing block (5 lines) |
| `conf/conf_schema.json` | Added `gemini` to STTFUNCTION values + GEMINI config block |

## Testing
Tested in-game with CHIM/HerikaServer stack:
- Transcription accuracy comparable to Deepgram Nova
- Emotion detection working: "Hello can anyone hear me?" → `tone: "questioning"`
- Tone injection confirmed in NPC context pipeline
- Handles empty/silent audio gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)