### PR TITLE
Add Gemini 2.5 Flash as STT provider with emotion detection

### DIFF
--- a/conf/conf_schema.json
+++ b/conf/conf_schema.json
@@ -422,7 +422,7 @@
   },
   "PLAYER_RESPEECH":{"type":"boolean","description":"Allows the AI to rewrite player speech with Chat Assist & Creation modes.","scope":"global"},
   "STTFUNCTION": {
-    "type":"select","values":["none","whisper","localwhisper","azure","deepgram","parakeet"],"description":"Speech-to-Text service options. Translates your voice to text.", 
+    "type":"select","values":["none","whisper","localwhisper","azure","deepgram","gemini","parakeet"],"description":"Speech-to-Text service options. Translates your voice to text.", 
     "_title":"Speech-to-Text Service","scope":"global"
     },
   "STT": {
@@ -448,6 +448,11 @@
       "API_KEY": {"type":"apikey","description":"Deepgram API key.","code":"DEEPGRAM_API_KEY"},
       "LANG":{"type":"string","description":"Language"},
       "MODEL":{"type":"select","values":["nova-3","nova-2","whisper-medium","enhanced","nova","base"],"description":"Model to use"}
+    }, "GEMINI": {
+      "_title":"Google Gemini STT + Emotion Detection",
+      "API_KEY": {"type":"apikey","description":"Google AI API key (from aistudio.google.com).","code":"GEMINI_API_KEY"},
+      "LANG": {"type":"string","description":"Language (e.g., en, es, ja)"},
+      "MODEL": {"type":"select","values":["gemini-2.5-flash","gemini-2.5-flash-lite","gemini-2.5-pro"],"description":"Gemini model. 2.5 Flash recommended for best speed and quality."}
     }, "PARAKEET": {
       "_title":"parakeet-api-server",
       "LANG": {"type":"string","description":"Language to detect for STT."}

--- a/stt.php
+++ b/stt.php
@@ -42,10 +42,14 @@ if ($STTFUNCTION=="azure") {
     require_once($path."stt/stt-localwhisper.php");
     $text= stt($finalName);
     
-} else if ($STTFUNCTION=="deepgram") { 
+} else if ($STTFUNCTION=="deepgram") {
     require_once($path."stt/stt-deepgram.php");
     $text= stt($finalName);
-    
+
+} else if ($STTFUNCTION=="gemini") {
+    require_once($path."stt/stt-gemini.php");
+    $text= stt($finalName);
+
 } else if (file_exists($path . "stt" . DIRECTORY_SEPARATOR . "stt-{$STTFUNCTION}.php")){
     require_once($path . "stt" . DIRECTORY_SEPARATOR . "stt-{$STTFUNCTION}.php");
     $text= stt($finalName);

--- a/stt/stt-gemini.php
+++ b/stt/stt-gemini.php
@@ -1,0 +1,183 @@
+<?php
+
+// Gemini 2.5 Flash STT — transcription + player emotion detection in one call
+// Drop-in replacement for Deepgram. Detects player vocal tone and caches it
+// for context injection so NPCs react to HOW the player speaks.
+
+$localPath = dirname(__FILE__) . '/../';
+require_once($localPath . "conf/conf.php");
+require_once($localPath . "lib/{$GLOBALS["DBDRIVER"]}.class.php");
+require_once($localPath . "lib/chat_helper_functions.php");
+
+// Cache file for player tone — read by context builders
+define('PLAYER_TONE_CACHE', dirname(__FILE__) . '/../soundcache/_player_tone.json');
+
+function stt($filePath)
+{
+    if (!isset($GLOBALS["db"]) || !$GLOBALS["db"])
+        $GLOBALS["db"] = new sql();
+
+    $fileContent = file_get_contents($filePath);
+    if ($fileContent === false) {
+        error_log("STT Gemini: warning - input file missing or unreadable! {$filePath}");
+        return null;
+    }
+
+    $i_sz = filesize($filePath);
+    if ($i_sz == 144046) {
+        error_log("STT Gemini: warning input file {$filePath} probably contains silence.");
+    }
+
+    // Resolve API key: prefer STT conf, fallback to API Badge 'gemini' or 'google'
+    $apiKey = trim($GLOBALS['STT']['GEMINI']['API_KEY'] ?? '');
+    if ($apiKey === '') {
+        try {
+            if (isset($GLOBALS["db"]) && $GLOBALS["db"]) {
+                $row = $GLOBALS["db"]->fetchOne("SELECT api_key FROM core_api_badge WHERE lower(label)='gemini' LIMIT 1");
+                if (is_array($row) && !empty($row['api_key'])) $apiKey = trim($row['api_key']);
+            }
+        } catch (Throwable $_e) {
+            error_log("STT Gemini: DB error looking up gemini badge: " . $_e->getMessage());
+        }
+    }
+    if ($apiKey === '') {
+        try {
+            if (isset($GLOBALS["db"]) && $GLOBALS["db"]) {
+                $row = $GLOBALS["db"]->fetchOne("SELECT api_key FROM core_api_badge WHERE lower(label)='google' LIMIT 1");
+                if (is_array($row) && !empty($row['api_key'])) $apiKey = trim($row['api_key']);
+            }
+        } catch (Throwable $_e) {
+            error_log("STT Gemini: DB error looking up google badge: " . $_e->getMessage());
+        }
+    }
+
+    if (empty($apiKey)) {
+        error_log("STT Gemini: No API key found. Set in STT config or add API badge with label 'gemini' or 'google'.");
+        return null;
+    }
+
+    $model = !empty($GLOBALS['STT']['GEMINI']['MODEL']) ? $GLOBALS['STT']['GEMINI']['MODEL'] : 'gemini-2.5-flash';
+    $lang = !empty($GLOBALS['STT']['GEMINI']['LANG']) ? $GLOBALS['STT']['GEMINI']['LANG'] : 'en';
+    error_log("STT Gemini: Using model={$model} lang={$lang} key=" . substr($apiKey, 0, 10) . "...");
+
+    // Build keyword hints from recent context (NPC names, locations, etc.)
+    $keywordHints = '';
+    try {
+        $keywords = lastKeyWordsNew(30);
+        if (!empty($keywords)) {
+            $keywordHints = "\n\nThe following proper nouns may appear in the audio (use these for spelling): " . implode(', ', $keywords);
+        }
+    } catch (Throwable $_e) {}
+
+    // Base64 encode the audio
+    $audioBase64 = base64_encode($fileContent);
+
+    // Build request — ask for both transcription and emotion in one shot
+    $requestData = [
+        'contents' => [[
+            'parts' => [
+                ['text' => "You are a speech-to-text system for a fantasy RPG game. Transcribe this audio accurately and detect the speaker's emotional tone from their voice.\n\nLanguage: {$lang}{$keywordHints}\n\nReturn ONLY valid JSON with exactly these two fields:\n{\"transcript\": \"the transcribed text\", \"tone\": \"one or two words describing the emotional tone of the speaker's voice\"}\n\nFor tone, use descriptive words like: calm, angry, excited, nervous, sad, happy, sarcastic, scared, commanding, playful, seductive, desperate, bored, suspicious, threatening, gentle, annoyed, confused, etc.\n\nIf the audio is silent or unintelligible, return: {\"transcript\": \"\", \"tone\": \"neutral\"}"],
+                ['inline_data' => [
+                    'mime_type' => 'audio/wav',
+                    'data' => $audioBase64
+                ]]
+            ]
+        ]],
+        'generationConfig' => [
+            'temperature' => 0.1,
+            'maxOutputTokens' => 256,
+            'responseMimeType' => 'application/json'
+        ]
+    ];
+
+    $url = "https://generativelanguage.googleapis.com/v1beta/models/{$model}:generateContent?key={$apiKey}";
+
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($requestData));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json'
+    ]);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($response === false) {
+        error_log("STT Gemini: cURL request failed");
+        return null;
+    }
+
+    if ($httpCode !== 200) {
+        error_log("STT Gemini: API returned HTTP {$httpCode} for model={$model}: " . substr($response, 0, 500));
+        return null;
+    }
+
+    $responseParsed = json_decode($response, true);
+    error_log("STT Gemini: raw response: " . substr($response, 0, 1000));
+
+    // Extract the generated text
+    $generatedText = $responseParsed['candidates'][0]['content']['parts'][0]['text'] ?? null;
+    if (empty($generatedText)) {
+        error_log("STT Gemini: no generated text in response");
+        return null;
+    }
+
+    // Parse the JSON response from Gemini
+    $result = json_decode($generatedText, true);
+    if (!is_array($result)) {
+        // Try to extract JSON from markdown code blocks
+        if (preg_match('/```(?:json)?\s*(\{.*?\})\s*```/s', $generatedText, $m)) {
+            $result = json_decode($m[1], true);
+        }
+        // Last resort — treat entire response as plain transcript
+        if (!is_array($result)) {
+            error_log("STT Gemini: could not parse JSON, using raw text as transcript");
+            return trim($generatedText);
+        }
+    }
+
+    $transcript = trim($result['transcript'] ?? '');
+    $tone = trim($result['tone'] ?? 'neutral');
+
+    // Cache the player's vocal tone for context injection
+    if (!empty($tone) && $tone !== 'neutral') {
+        $toneData = [
+            'tone' => $tone,
+            'timestamp' => time(),
+            'transcript_preview' => substr($transcript, 0, 100)
+        ];
+        @file_put_contents(PLAYER_TONE_CACHE, json_encode($toneData));
+        error_log("STT Gemini: Detected player tone: {$tone}");
+    } else {
+        // Clear stale tone cache
+        @unlink(PLAYER_TONE_CACHE);
+    }
+
+    error_log("STT Gemini: transcript=\"{$transcript}\" tone=\"{$tone}\"");
+    return $transcript;
+}
+
+/**
+ * Read the cached player tone (called by context builders)
+ * Returns the tone string if fresh (within $maxAge seconds), null otherwise.
+ *
+ * @param int $maxAge Maximum age in seconds (default 60)
+ * @return string|null
+ */
+function getPlayerTone($maxAge = 60) {
+    if (!file_exists(PLAYER_TONE_CACHE)) {
+        return null;
+    }
+    $data = json_decode(@file_get_contents(PLAYER_TONE_CACHE), true);
+    if (!is_array($data) || empty($data['tone'])) {
+        return null;
+    }
+    if ((time() - ($data['timestamp'] ?? 0)) > $maxAge) {
+        return null;
+    }
+    return $data['tone'];
+}


### PR DESCRIPTION
## Summary
- Adds **Google Gemini 2.5 Flash** as a new speech-to-text provider
- Single API call does both **transcription and vocal emotion detection**
- Player's detected tone cached to `soundcache/_player_tone.json` (60s TTL) for context injection

## How it works
1. Player speaks → audio sent to Gemini as base64 WAV
2. Gemini returns JSON: `{"transcript": "...", "tone": "questioning"}`
3. Transcript returned as normal STT output
4. Tone cached for optional context injection (e.g., `[Player's voice sounds questioning]`)

## Features
- Keyword hints from `lastKeyWordsNew(30)` for fantasy name recognition
- API key resolution: STT config → `gemini` badge → `google` badge
- Configurable model (Flash, Flash Lite, Pro) and language
- JSON response parsing with markdown code block fallback

## Files changed
| File | Change |
|---|---|
| `stt/stt-gemini.php` | **New** — Gemini STT implementation |
| `stt.php` | Added `gemini` routing block |
| `conf/conf_schema.json` | Added `gemini` to STTFUNCTION values + GEMINI config block |

## Tested in-game with CHIM stack
- Transcription accuracy comparable to Deepgram Nova
- Emotion detection: "Hello can anyone hear me?" → `tone: "questioning"`
- Handles empty/silent audio gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)