### PR TITLE
Fix Gemini STT: token limit + tone injection

### DIFF
--- a/stt/stt-gemini.php
+++ b/stt/stt-gemini.php
@@ -85,7 +85,7 @@ function stt($filePath)
         ]],
         'generationConfig' => [
             'temperature' => 0.1,
-            'maxOutputTokens' => 256,
+            'maxOutputTokens' => 1024,
             'responseMimeType' => 'application/json'
         ]
     ];
@@ -158,6 +158,11 @@ function stt($filePath)
     }
 
     error_log("STT Gemini: transcript=\"{$transcript}\" tone=\"{$tone}\"");
+
+    // Inject tone directly into transcript so the LLM sees it in conversation history
+    if (!empty($tone) && $tone !== 'neutral' && !empty($transcript)) {
+        return "({$tone}) {$transcript}";
+    }
     return $transcript;
 }
 

--- a/ui/tests/stt-test.php
+++ b/ui/tests/stt-test.php
@@ -194,7 +194,13 @@ if (php_sapi_name() != "cli") {
 
         if (!empty($transcription)) {
             echo '<div class="status"><span class="label ok">Transcription Successful!</span></div>';
-            echo '<div class="response">Output: ' . nl2br(htmlspecialchars($transcription)) . '</div>';            
+            echo '<div class="response">Output: ' . nl2br(htmlspecialchars($transcription)) . '</div>';
+
+            // Show detected tone if available
+            $detectedTone = function_exists('getPlayerTone') ? getPlayerTone(30) : null;
+            if (!empty($detectedTone)) {
+                echo '<div class="message"><strong style="color: #17a2b8;">Detected tone: ' . htmlspecialchars($detectedTone) . '</strong></div>';
+            }
 
             // Calculate similarity percentage using levenshtein
             $lev_distance = levenshtein(strtolower($expected_transcription), strtolower($transcription));


### PR DESCRIPTION
## Summary
- **maxOutputTokens 256→1024**: longer player speech was getting silently truncated
- **Inject detected tone into transcript**: returns `(angry) text` instead of just `text`, so the LLM naturally reacts to how the player speaks — no extra context builder needed

## How it works
Gemini already detects player vocal tone (from PR #483). This fix makes the tone visible in the conversation history so NPCs respond to it organically.

## Test plan
- [ ] Speak a long sentence (30+ words) into mic — verify full transcription
- [ ] Speak angrily — verify `(angry)` prefix appears in eventlog
- [ ] Verify NPC response reflects player tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)