### PR TITLE
Revert per-NPC semaphore to global MAIN lock

### DIFF
--- a/main.php
+++ b/main.php
@@ -225,20 +225,13 @@ $GLOBALS["all_fast_commands"] = $fast_commands;
 $semaphore_timeout = $GLOBALS["SEMAPHORES_TIMEOUT"] ?? 300;
 
 
-// Per-NPC semaphore: each NPC gets its own lock so different NPCs process in parallel.
-// Same NPC's sequential requests still serialize correctly.
-$_mainSemId = "MAIN";
-if (isset($_GET["profile"]) && !empty($_GET["profile"])) {
-    $_mainSemId = "MAIN_" . substr($_GET["profile"], 0, 8);
-}
-$GLOBALS["_mainSemId"] = $_mainSemId;
-
+// Use logical id "MAIN" so other code can still find $GLOBALS["SEMAPHORES"]["MAIN"]
 if (!in_array($gameRequest[0],$fast_commands)) {
-    if (!SemaphoreWait($_mainSemId, $semaphore_timeout, 1003, null)) {
-        Logger::warn("[main] main semaphore wait failed for {$gameRequest[0]} (sem: {$_mainSemId})");
+    if (!SemaphoreWait("MAIN", $semaphore_timeout, 1003, null)) {
+        Logger::warn("[main] main semaphore wait failed for {$gameRequest[0]}");
         terminate();
     }
-    Logger::info("Audit:Lock acquired by {$gameRequest[0]} (sem: {$_mainSemId})");
+    Logger::info("Audit:Lock acquired by {$gameRequest[0]}");
 } 
 
 // adnpc has its custom semaphore, as it write files
@@ -1241,7 +1234,7 @@ if (in_array($gameRequest[0],["rechat","narration"]) ) {
     if (sizeof($rechatHistory)>=(intval($GLOBALS["RECHAT_H"])))    {   // TOO MUCH RECHAT
         Logger::info("Rechat discarded, rechatHistory:".sizeof($rechatHistory).">={$GLOBALS["RECHAT_H"]}");
         // Lets try to summarize
-        SemaphoreManager::release($GLOBALS["_mainSemId"] ?? "MAIN");
+        SemaphoreManager::release("MAIN");
         while(ob_get_length() && ob_end_clean());
         require(__DIR__.DIRECTORY_SEPARATOR."processor".DIRECTORY_SEPARATOR."postrequest.php");
         terminate();
@@ -1299,12 +1292,12 @@ if (in_array($gameRequest[0],["rechat","narration"]) ) {
 
     if (sizeof($rechatHistory)>1) {
         // Lets make rechat wait a bit, so events while NPCs are speaking get into context// disabled if using new rechat fire event
-        SemaphoreManager::release($GLOBALS["_mainSemId"] ?? "MAIN");
+        SemaphoreManager::release("MAIN");
         Logger::info("HOLDING RECHAT EVENT ".sizeof($rechatHistory));
         // Check if this conflicts with smart rechat
         // Is this doing something?
         $semaphore_timeout = $GLOBALS["SEMAPHORES_TIMEOUT"] ?? 300;
-        if (!SemaphoreWait($GLOBALS["_mainSemId"] ?? "MAIN", $semaphore_timeout, 1007, function() use ($db, $gameRequest) {
+        if (!SemaphoreWait("MAIN", $semaphore_timeout, 1007, function() use ($db, $gameRequest) {
             //$user_input_after=$db->fetchAll("select count(*) as N from eventlog where type='user_input' and ts>$gameRequest[1]"); // 72 ms 
             $user_input_after=$db->fetchAll("SELECT rowid as N FROM eventlog WHERE type='user_input' AND ts>{$gameRequest[1]} ORDER BY rowid DESC LIMIT 1 "); // faster, 1.5 ms
             if (isset($user_input_after[0])) {
@@ -2682,7 +2675,7 @@ if (php_sapi_name()=="cli" && !getenv('PHPUNIT_TEST')) {
 
 
 // POST PROCESS TASKS
-SemaphoreManager::release($GLOBALS["_mainSemId"] ?? "MAIN");
+SemaphoreManager::release("MAIN");
 SemaphoreManager::release("ADDNPC");
 
 


### PR DESCRIPTION
## Summary
- Reverts commit 411c830 (PR #484) which changed the global `MAIN` semaphore to per-NPC locks (`MAIN_` + profile prefix)
- Per-NPC semaphores allowed parallel NPC processing but caused **conversation turn-order scrambling** when multiple NPCs responded simultaneously with varying LLM latency (reported by id1001)
- Restores the original global `MAIN` semaphore which serializes all NPC requests to preserve correct dialogue ordering

## What changed
Single file (`main.php`), 6 locations reverted:
1. Removed per-NPC semaphore ID generation (profile-based `MAIN_xxxx` logic)
2. Restored hardcoded `"MAIN"` in `SemaphoreWait()` and `SemaphoreManager::release()` calls

## Test plan
- [ ] Verify conversation turn order is correct with multiple NPCs in scene
- [ ] Verify rechat sequences maintain proper ordering
- [ ] Confirm no semaphore deadlocks under normal gameplay

🤖 Generated with [Claude Code](https://claude.com/claude-code)