### PR TITLE
Add narrator_inputtext prompt entry (server-side companion to DLL PR #20)

### DIFF
--- a/prompts/prompts.php
+++ b/prompts/prompts.php
@@ -162,6 +162,11 @@ $PROMPTS=array(
             // Prompt is implicit
 
     ],
+    "narrator_inputtext"=>[
+        "cue"=>[
+            "$TEMPLATE_ACTION . {$GLOBALS["TEMPLATE_DIALOG"]} {$GLOBALS["MAXIMUM_WORDS"]}"
+        ]
+    ],
     "inputtext_s"=>[
         "cue"=>[
             "$TEMPLATE_ACTION . {$GLOBALS["TEMPLATE_DIALOG"]} {$GLOBALS["MAXIMUM_WORDS"]}"


### PR DESCRIPTION
Hey Rang, Tyler. This is the server-side companion to the DLL changes in abeiro/HerikaAI-NG PR #20.

## Problem

The dev DLL introduced narrator_inputtext as a new event type in HTTPManager.cpp line 1530. When player speech routes to The Narrator (no NPC nearby, looking at sky, etc), the DLL rewrites inputtext to narrator_inputtext so the server can scope it to the Narrator only and keep it out of nearby NPC conversations.

main.php already handles narrator_inputtext in all its in_array checks. But prompts.php had no entry for it. This caused "PHP Warning: Undefined array key narrator_inputtext" at request.php line 225, producing an empty cue and broken responses that freeze the game.

## Fix

**File:** prompts/prompts.php

Added narrator_inputtext to the PROMPTS array with the same cue structure as inputtext.

## Notes

This fix is tied to the dev DLL. The DLL creates the narrator_inputtext event type. The server needs to handle it. Without this prompt entry, every Narrator fallback crashes the response pipeline.