### PR TITLE
fix: improve Japanese sentence splitting in chat_helper_functions

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -285,6 +285,7 @@ function split_sentences($paragraph)
     }
 
     $paragraphNcr = br2nl($paragraph); // Remove any BR tags
+    $paragraphNcr = preg_replace('/([。！？])(?=\S)/u', '$1 ', $paragraphNcr);
 
     $sentences = split_at_end_of_sentence($paragraphNcr);
 
@@ -297,6 +298,7 @@ function split_sentences_stream($paragraph)
         return [$paragraph];
     }
 
+    $paragraph = preg_replace('/([。！？])(?=\S)/u', '$1 ', $paragraph);
     // Split at sentence boundaries
     $sentences = split_at_end_of_sentence($paragraph);
 


### PR DESCRIPTION
## What
- Add `preg_replace` to insert a space after Japanese end-of-sentence punctuation (`。！？`) when immediately followed by a non-space character, in both `split_sentences` and `split_sentences_stream`

## Why
Japanese text does not use spaces between sentences. Without this fix, the sentence splitter cannot detect boundaries at `。！？`, causing multiple sentences to be merged into one long TTS chunk.

## Notes
- The regex `/([。！？])(?=\S)/u` only fires when a Japanese EOS character is directly followed by a non-space character, so there is no impact on English or other spaced languages
- Affects `split_sentences` (via `$paragraphNcr`) and `split_sentences_stream` (via `$paragraph`) in `lib/chat_helper_functions.php`
