### PR TITLE
fix: return end byte position of multi-byte EOS punctuation in findFastSentencePosition

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -186,12 +186,15 @@ function findFastSentencePosition($s_string) {
     if (preg_match_all($splitSentenceRegex, $s_string, $matches, PREG_OFFSET_CAPTURE)) {
         foreach ($matches[1] as $match) {
             $position = $match[1];
-            $candidate = substr($s_string, 0, $position + 1);
+            // Use the end of the matched punctuation so that multi-byte characters
+            // (e.g. Japanese 。！？ which are 3 bytes in UTF-8) are not split mid-character.
+            $endPosition = $position + strlen($match[0]) - 1;
+            $candidate = substr($s_string, 0, $endPosition + 1);
             if (hasUnclosedSingleAsteriskBlock($candidate)) {
                 continue;
             }
 
-            return $position;
+            return $endPosition;
         }
     }
 


### PR DESCRIPTION
## What
- Fix `findFastSentencePosition` to return the last byte offset of the matched punctuation character instead of the first byte offset

## Why
The return value is used in the streaming path as `substr($buffer, 0, $position + 1)`. For multi-byte UTF-8 punctuation (e.g. Japanese `。！？` at 3 bytes each), returning the start byte offset cuts mid-character, producing corrupted output.

## Notes
- Single-byte punctuation (`.!?`) is unaffected since `strlen($match[0]) - 1` evaluates to `0`
- Affects `lib/chat_helper_functions.php` only
- As with the previous PR, this has no impact on the English version.