### PR TITLE
fix: filename typo output_to_plugin.log

### DIFF
--- a/ui/cmd/ai_log_assistant.php
+++ b/ui/cmd/ai_log_assistant.php
@@ -269,7 +269,7 @@ Response queued in `responselog` table, fetched by game mod via `comm.php`
 | `output_from_llm.log` | Raw LLM responses with timestamps |
 | `context_sent_to_llm.log` | Full context sent to LLM |
 | `context_sent_to_llm_fast.log` | Context for fast/helper calls |
-| `ouput_to_plugin.log` | Data sent back to game mod |
+| `output_to_plugin.log` | Data sent back to game mod |
 | `stt.log` | Speech-to-text processing |
 | `vision.log` | Vision/image processing |
 | `debugstream.log` | Streaming response debug data |

--- a/ui/tests/apache2err.php
+++ b/ui/tests/apache2err.php
@@ -86,7 +86,7 @@ $distroLogPath = $logPath . 'apache_error.log';
 $chimLogPath = $logPath . 'chim.log';
 $llmOutputPath = $logPath . 'output_from_llm.log';
 $llmContextPath = $logPath . 'context_sent_to_llm.log';
-$pluginOutputPath = $logPath . 'ouput_to_plugin.log';
+$pluginOutputPath = $logPath . 'output_to_plugin.log';
 $sttLogPath = $logPath . 'stt.log';
 $visionLogPath = $logPath . 'vision.log';
 $debugStreamLogPath = $logPath . 'debugstream.log';
@@ -2065,7 +2065,7 @@ if (isset($_GET['download_logs'])) {
         <div class="log-section">
             <?php
             // Display plugin output log
-            readRegularLog($pluginOutputPath, "Plugin Output (ouput_to_plugin.log)");
+            readRegularLog($pluginOutputPath, "Plugin Output (output_to_plugin.log)");
             ?>
         </div>
 


### PR DESCRIPTION
# ⚠️ ALL PR'S MUST BE SUBMITTED TO THE `UNSTABLE` BRANCH ⚠️

---

## What
fix: filename typo output_to_plugin.log

## Why
wrong filename used in UI: ouput_to_plugin.log


