### PR TITLE
fix: filename typo debugStream.log

### DIFF
--- a/ui/cmd/ai_log_assistant.php
+++ b/ui/cmd/ai_log_assistant.php
@@ -277,7 +277,7 @@ Response queued in `responselog` table, fetched by game mod via `comm.php`
 | `output_to_plugin.log` | Data sent back to game mod |
 | `stt.log` | Speech-to-text processing |
 | `vision.log` | Vision/image processing |
-| `debugstream.log` | Streaming response debug data |
+| `debugStream.log` | Streaming response debug data |
 | `monitor.log` | Service monitor logs |
 | `service.log` | Background service logs |
 

--- a/ui/tests/apache2err.php
+++ b/ui/tests/apache2err.php
@@ -89,7 +89,7 @@ $llmContextPath = $logPath . 'context_sent_to_llm.log';
 $pluginOutputPath = $logPath . 'output_to_plugin.log';
 $sttLogPath = $logPath . 'stt.log';
 $visionLogPath = $logPath . 'vision.log';
-$debugStreamLogPath = $logPath . 'debugstream.log';
+$debugStreamLogPath = $logPath . 'debugStream.log';
 $llmContextFastPath = $logPath . 'context_sent_to_llm_fast.log';
 $monitorLogPath = $logPath . 'monitor.log';
 $serviceLogPath = $logPath . 'service.log';
@@ -2145,7 +2145,7 @@ if (isset($_GET['download_logs'])) {
         <div class="log-section">
             <?php
             // Display Debug Stream log
-            readRegularLog($debugStreamLogPath, "Debug Stream Log (debugstream.log)");
+            readRegularLog($debugStreamLogPath, "Debug Stream Log (debugStream.log)");
             ?>
         </div>
             </div>


### PR DESCRIPTION
# ⚠️ ALL PR'S MUST BE SUBMITTED TO THE `UNSTABLE` BRANCH ⚠️

---

## What
fix: filename typo debugStream.log

## Why
wrong filename used in UI: debugstream.log