### PR TITLE
Support CHIM spatial status metadata

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -2609,6 +2609,11 @@ function normalizeDialogTextForComparison($text)
     return mb_strtolower($text, 'UTF-8');
 }
 
+function chimActorStatusSuffixPattern()
+{
+    return '/\s*\((?:busy|hostile|in combat|far away|too far away|restrained|dead|disabled|unavailable|audible|narrator|checking(?: hearing|: [^)]+)?|can hear you(?:, muffled|: [^)]+)?|can[\'"]?t hear you(?: clearly)?(?:: [^)]+)?|no (?:target|crosshair target))\)\s*$/iu';
+}
+
 function stripActorStateSuffix($name)
 {
     $name = trim((string)$name);
@@ -2617,7 +2622,7 @@ function stripActorStateSuffix($name)
     }
 
     $name = trim($name, "|");
-    $name = preg_replace('/\s*\((?:busy|hostile|in combat|far away|restrained|dead|disabled)\)\s*$/i', '', $name);
+    $name = preg_replace(chimActorStatusSuffixPattern(), '', $name);
     return trim((string)$name);
 }
 
@@ -2830,7 +2835,7 @@ function chimResolveEffectiveRechatMode($configuredMode, array $members)
 
 function normalizeDialogueListenerName($listenerName)
 {
-    $listenerName = trim((string)$listenerName);
+    $listenerName = stripActorStateSuffix($listenerName);
     if ($listenerName === "") {
         return "";
     }
@@ -3657,7 +3662,7 @@ function extractEventPayloadParticipants($eventType, $eventData)
     }
 
     if ($eventType === "infonpc_close") {
-        return extractActorNamesFromDelimitedEventPayload($eventData, '/\s*\/\s*/u');
+        return extractActorNamesFromDelimitedEventPayload($eventData, '/\s*[\/|]\s*/u');
     }
 
     if ($eventType === "infonpc") {

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -3937,6 +3937,41 @@ function DataBeingsOrDeathsInRangeExcluding($excludeNPC="", $excludePlayer=true)
     return $GLOBALS["CACHE_BEINGS_OR_DEATHS_IN_RANGE_EXCLUDING"][$excludeNPC][(int)$excludePlayer];
 }
 
+function chimDataActorStatusSuffixPattern()
+{
+    return '/\s*\((?:busy|hostile|in combat|far away|too far away|restrained|dead|disabled|unavailable|audible|narrator|checking(?: hearing|: [^)]+)?|can hear you(?:, muffled|: [^)]+)?|can[\'"]?t hear you(?: clearly)?(?:: [^)]+)?|no (?:target|crosshair target))\)\s*$/iu';
+}
+
+function chimDataStripActorStateSuffix($name)
+{
+    $name = trim((string)$name);
+    if ($name === "") {
+        return "";
+    }
+
+    $name = trim($name, "|");
+    $name = preg_replace(chimDataActorStatusSuffixPattern(), '', $name);
+    return trim((string)$name);
+}
+
+function chimDataActorStatusBlocksCloseRange($token)
+{
+    if (!preg_match('/\s*\(([^()]*)\)\s*$/u', (string)$token, $matches)) {
+        return false;
+    }
+
+    $status = strtolower(trim((string)$matches[1]));
+    if ($status === "") {
+        return false;
+    }
+
+    if (strpos($status, "can hear you") === 0) {
+        return false;
+    }
+
+    return preg_match('/^(?:busy|hostile|in combat|far away|too far away|restrained|dead|disabled|unavailable|checking|can[\'"]?t hear you|no target|no crosshair target)/i', $status) === 1;
+}
+
 function DataBeingsInCloseRange($excludeFarAway=false)
 {
 
@@ -3955,29 +3990,35 @@ function DataBeingsInCloseRange($excludeFarAway=false)
             $beings=strtr($s_npcs,["beings in range:"=>""]);
         } else 
             $beings=$s_npcs;
-        $beingsArray=explode("/",$beings);
+        $beingsArray=preg_split('/[\/|]/', $beings);
+        if (!is_array($beingsArray))
+            $beingsArray=[];
         $beingsArrayNew=[];
         foreach ($beingsArray as $k=>$v) {
-            if ($excludeFarAway && strpos($v,"(far away)")>0)
+            $v = trim((string)$v);
+            if ($excludeFarAway && chimDataActorStatusBlocksCloseRange($v))
                 continue;
-            if (strpos($v,"(dead)")>0) //??
+            if (preg_match('/\((?:dead|disabled)\)\s*$/i', $v)) //??
                 continue;
             if (empty($v))
                 continue;
+            $actorName = chimDataStripActorStateSuffix($v);
+            if (empty($actorName))
+                continue;
             //if (strpos($v,")")===false) 
-                if (strpos($v,"Horse")!==0) 
-                    if (strpos($v,"Chicken")!==0) 
-                    if (strpos($v,"Goat")!==0) 
-                    if (strpos($v,"House Cat")!==0) 
-                    if (strpos($v,"Stray Cat")!==0) 
-                    if (strpos($v,"Cow")!==0) 
-                    if (strpos($v,"Deer")!==0) 
-                    if (strpos($v,"Elk")!==0) 
-                    if (strpos($v,"Bear")!==0) 
-                    if (strpos($v,"Rabbit")!==0) 
-                    if (strpos($v,"Troll")!==0) 
-                    if (strpos($v,"Fox")!==0) 
-                        $beingsArrayNew[]=$v;
+                if (strpos($actorName,"Horse")!==0)
+                    if (strpos($actorName,"Chicken")!==0)
+                    if (strpos($actorName,"Goat")!==0)
+                    if (strpos($actorName,"House Cat")!==0)
+                    if (strpos($actorName,"Stray Cat")!==0)
+                    if (strpos($actorName,"Cow")!==0)
+                    if (strpos($actorName,"Deer")!==0)
+                    if (strpos($actorName,"Elk")!==0)
+                    if (strpos($actorName,"Bear")!==0)
+                    if (strpos($actorName,"Rabbit")!==0)
+                    if (strpos($actorName,"Troll")!==0)
+                    if (strpos($actorName,"Fox")!==0)
+                        $beingsArrayNew[]=$actorName;
         }
         $beingsFormatted=implode("|",$beingsArrayNew);
         $s_res = "|".$beingsFormatted."|";

--- a/ui/api/chim_overlay.php
+++ b/ui/api/chim_overlay.php
@@ -24,6 +24,23 @@ require_once(LIB_PATH .DIRECTORY_SEPARATOR."core".DIRECTORY_SEPARATOR."player.cl
 
 $db = new sql();
 
+function chimOverlayActorStatusSuffixPattern()
+{
+    return '/\s*\((?:busy|hostile|in combat|far away|too far away|restrained|dead|disabled|unavailable|audible|narrator|checking(?: hearing|: [^)]+)?|can hear you(?:, muffled|: [^)]+)?|can[\'"]?t hear you(?: clearly)?(?:: [^)]+)?|no (?:target|crosshair target))\)\s*$/iu';
+}
+
+function chimOverlayCleanActorName($name)
+{
+    $name = trim((string)$name);
+    if ($name === "") {
+        return "";
+    }
+
+    $name = trim($name, "|/");
+    $name = preg_replace(chimOverlayActorStatusSuffixPattern(), '', $name);
+    return trim((string)$name);
+}
+
 // Set JSON header
 header('Content-Type: application/json');
 
@@ -106,18 +123,21 @@ $lastClose = $db->fetchOne("
 
 if ($lastClose && isset($lastClose['data'])) {
     $npcData = $lastClose['data'];
-    // Parse pipe-delimited NPC list
-    $npcs = explode('|', trim($npcData, '|'));
+    // Parse current slash-delimited DLL output and older pipe-delimited rows.
+    $npcs = preg_split('/[\/|]/', trim($npcData, "|/"));
+    if (!is_array($npcs)) {
+        $npcs = [];
+    }
     
     foreach ($npcs as $npc) {
-        $npc = trim($npc);
-        if (!empty($npc)) {
-            // Remove status indicators like "(busy)" or "(hostile)"
-            $cleanName = preg_replace('/\s*\([^)]+\)\s*$/', '', $npc);
-            if (!empty($cleanName) && $cleanName !== 'The Narrator') {
-                $activeAgents[] = $cleanName;
-            }
+        $cleanName = chimOverlayCleanActorName($npc);
+        if ($cleanName === "" || strcasecmp($cleanName, 'The Narrator') === 0) {
+            continue;
         }
+        if (!empty($GLOBALS["PLAYER_NAME"]) && strcasecmp($cleanName, (string)$GLOBALS["PLAYER_NAME"]) === 0) {
+            continue;
+        }
+        $activeAgents[] = $cleanName;
     }
     
     // Remove duplicates and limit to reasonable number


### PR DESCRIPTION
﻿## Summary
- Treat CHIM DLL spatial/hearing labels as metadata, not as part of actor names.
- Strip statuses like `(Can hear you)`, `(Can't hear you: around a wall)`, `(Too far away)`, `(In combat)`, and related labels before server-side name comparison/routing.
- Parse both slash-delimited and pipe-delimited `infonpc_close` rows so older rows and newer DLL output both work.
- Keep blocked/unavailable spatial statuses out of nearby/rechat candidate selection when close-range filtering is requested.
- Keep Prisma overlay active-agent names clean when the DLL sends richer spatial status labels.

## Why
The CHIM unstable spatial refactor now sends richer listener/status metadata through the DLL and Prisma UI paths. The server still needs to resolve the actual NPC identity underneath that metadata.

Without this compatibility layer, a row like `Greta (Can't hear you: around a wall)` can be treated as a different actor from `Greta`, and blocked/far/status-tagged actors can leak back into rechat, overlay, or listener selection.

This PR does not change the relationship/action-rework logic. It is server compatibility for the CHIM DLL spatial-status stack.

## Validation
- `php -l lib/chat_helper_functions.php`
- `php -l lib/data_functions.php`
- `php -l ui/api/chim_overlay.php`
- `git diff --check`

PHP lint was run through the `DwemerAI4Skyrim3` WSL distro because PHP is not on the Windows PATH.

## Related CHIM PR Stack
Supports the CHIM unstable spatial/status work:
- Dwemer-Dynamics/CHIM#21
- Dwemer-Dynamics/CHIM#23
- Dwemer-Dynamics/CHIM#25
- Dwemer-Dynamics/CHIM#26

Relationship/action-rework fixes are intentionally separate in abeiro/HerikaServer#521.
