### PR TITLE
Separate emitted chat visibility from spoken confirmation

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -1693,7 +1693,7 @@ function returnLines($lines,$writeOutput=true)
             $originalRequest[3]="{$outBuffer["actor"]}: $responseForContext $addonlistener";
             $originalRequest[5] = [
                 'utterance_id' => $GLOBALS["SCRIPTLINE_UTTERANCE_ID"] ?? chimGenerateUtteranceId(),
-                'delivery_state' => 'pending'
+                'delivery_state' => 'emitted'
             ];
             logEvent($originalRequest);
         }
@@ -2310,6 +2310,7 @@ function getGametsLimitFor($actor) {
     $actorEscaped = $db->escape($actor);
     $limit = (int) $GLOBALS["CONTEXT_HISTORY"];
 
+    $visibleChatStateSql = chimBuildChatDeliveryStateSql('delivery_state');
     $query = "
         SELECT 
             (MAX(gamets) - MIN(gamets)) * 0.0000024 AS hour_threshold
@@ -2317,7 +2318,7 @@ function getGametsLimitFor($actor) {
             SELECT gamets 
             FROM eventlog 
             WHERE type='chat'
-            AND COALESCE(delivery_state, 'spoken')='spoken'
+            AND {$visibleChatStateSql}
             and people LIKE '%$actorEscaped%'
             ORDER BY gamets DESC
             LIMIT $limit
@@ -3507,6 +3508,46 @@ function extractCoreUtteranceFromChatEvent($eventData)
 
     $eventData = preg_replace('/\s*\(\s*(?:(?:talking|whispering|shouting)\s+to|speaking\s+loudly\s+to)\s+[^)]*\)\s*$/iu', '', $eventData);
     return trim((string)$eventData);
+}
+
+function chimGetVisibleChatDeliveryStates()
+{
+    return ['emitted', 'spoken'];
+}
+
+function chimGetInFlightChatDeliveryStates()
+{
+    return ['pending', 'emitted'];
+}
+
+function chimBuildChatDeliveryStateSql($column = 'delivery_state', array $states = null, $legacyDefault = 'spoken')
+{
+    $column = trim((string)$column);
+    if ($column === '') {
+        $column = 'delivery_state';
+    }
+
+    if ($states === null) {
+        $states = chimGetVisibleChatDeliveryStates();
+    }
+
+    $normalizedStates = array_values(array_unique(array_filter(array_map(static function ($state) {
+        return trim((string)$state);
+    }, $states))));
+    if (empty($normalizedStates)) {
+        $normalizedStates = ['spoken'];
+    }
+
+    $legacyDefault = trim((string)$legacyDefault);
+    if ($legacyDefault === '') {
+        $legacyDefault = 'spoken';
+    }
+
+    $quotedStates = array_map(static function ($state) {
+        return "'" . str_replace("'", "''", $state) . "'";
+    }, $normalizedStates);
+
+    return "COALESCE({$column}, '{$legacyDefault}') IN (" . implode(', ', $quotedStates) . ")";
 }
 
 function lookupSpatialCompanionsFromSpeech($speakerName, $listenerName = "", $utterance = "")

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -1924,6 +1924,8 @@ function buildHistoricContext($actor, $lastNelements = -10,$sqlfilter="") {
         $actorEscaped='';
     //$playerEscaped=$db->escape($GLOBALS["PLAYER_NAME"]);
 
+    $visibleChatStateSql = chimBuildChatDeliveryStateSql('delivery_state');
+
     $query="select  
     case 
       when type='infoaction' and a.data like '#%MEMORY%' then 'MEMORY'
@@ -1958,7 +1960,7 @@ function buildHistoricContext($actor, $lastNelements = -10,$sqlfilter="") {
     and type<>'infonpc_close' and type<>'instruction'
     and type<>'request' and type<>'playerinfo' and type<>'im_alive' and type<>'region' and type<>'named_cell'
     AND type<>'narrator_welcome'
-    and (type<>'chat' or COALESCE(delivery_state, 'spoken')='spoken')
+    and (type<>'chat' or {$visibleChatStateSql})
     AND type<>'funccall' AND type<>'togglemodel'
     {$removeBooks} {$sqlfilter} {$ext_sqlfilter1}
     ".(($b_actor) ? "

--- a/main.php
+++ b/main.php
@@ -1267,7 +1267,8 @@ if (in_array($gameRequest[0],["rechat","narration"]) ) {
         }
     }
 
-    $sqlfilter=" and (type in ('prechat','inputtext','ginputtext','infonpc','infonpc_close','logaction','infoaction','death','itemfound','innerchat') or (type='chat' and COALESCE(delivery_state,'spoken')='spoken' and data like '(Context%') )";  // Use prechat
+    $visibleChatStateSql = chimBuildChatDeliveryStateSql('delivery_state');
+    $sqlfilter=" and (type in ('prechat','inputtext','ginputtext','infonpc','infonpc_close','logaction','infoaction','death','itemfound','innerchat') or (type='chat' and {$visibleChatStateSql} and data like '(Context%') )";  // Use prechat
     // chat entries starting by "(Context%" are standard skyrim dialogue
 
     $FUNCTIONS_ARE_ENABLED=false;       // Enabling this can be funny => CHAOS MODE

--- a/processor/comm.php
+++ b/processor/comm.php
@@ -589,11 +589,17 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
             $quotedIds = array_map(function ($escapedId) {
                 return "'" . $escapedId . "'";
             }, array_values($utteranceIds));
+            $abortableChatStateSql = chimBuildChatDeliveryStateSql(
+                'delivery_state',
+                chimGetInFlightChatDeliveryStates(),
+                'emitted'
+            );
             $db->execQuery(
-                "DELETE FROM public.eventlog
+                "UPDATE public.eventlog
+                 SET delivery_state='aborted'
                  WHERE type='chat'
                    AND utterance_id IN (" . implode(",", $quotedIds) . ")
-                   AND COALESCE(delivery_state, 'pending')='pending'"
+                   AND {$abortableChatStateSql}"
             );
         }
     }
@@ -606,6 +612,7 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
    
     // error_log(print_r($speech,true));
     if (is_array($speech)) {
+        $nonAbortedChatStateSql = "COALESCE(delivery_state, 'emitted')<>'aborted'";
         $speechSpeaker = isset($speech["speaker"]) ? trim((string)$speech["speaker"]) : "";
         $speechListener = isset($speech["listener"]) ? trim((string)$speech["listener"]) : "";
         $speechUtteranceId = isset($speech["utterance_id"]) ? trim((string)$speech["utterance_id"]) : "";
@@ -674,6 +681,7 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
                  FROM eventlog
                  WHERE type='chat'
                    AND utterance_id='{$speechUtteranceIdEscaped}'
+                   AND {$nonAbortedChatStateSql}
                  ORDER BY rowid DESC"
             );
             foreach ((array)$matchedRows as $matchedRow) {
@@ -785,6 +793,7 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
                          FROM eventlog
                          WHERE gamets={$speechGamets}
                            AND type='chat'
+                           AND {$nonAbortedChatStateSql}
                            AND data ILIKE '{$speakerEscaped}:%'
                          ORDER BY ts DESC, rowid DESC
                          LIMIT 40"
@@ -812,6 +821,7 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
                         "SELECT rowid, gamets, data
                          FROM eventlog
                          WHERE type='chat'
+                           AND {$nonAbortedChatStateSql}
                            AND localts>" . (time() - 180) . "
                            AND data ILIKE '{$speakerEscaped}:%'
                          ORDER BY rowid DESC
@@ -916,7 +926,7 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
                         if ($rowIdToUpdate <= 0) {
                             continue;
                         }
-                        $db->update("eventlog", "delivery_state='spoken'", "rowid={$rowIdToUpdate}");
+                        $db->update("eventlog", "delivery_state='spoken'", "rowid={$rowIdToUpdate} AND {$nonAbortedChatStateSql}");
                     }
                 }
             } elseif (!empty($matchedUtteranceRowIds)) {
@@ -924,7 +934,7 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
                     if ($matchedRowId <= 0) {
                         continue;
                     }
-                    $db->update("eventlog", "delivery_state='spoken'", "rowid={$matchedRowId}");
+                    $db->update("eventlog", "delivery_state='spoken'", "rowid={$matchedRowId} AND {$nonAbortedChatStateSql}");
                 }
             }
         }

--- a/unittests/tests/CommTest.php
+++ b/unittests/tests/CommTest.php
@@ -109,7 +109,8 @@ final class CommTest extends DatabaseTestCase
                 'localts' => 2,
                 'people'=> "|Lydia|",
                 'location'=> "",
-                'party'=> "[]"
+                'party'=> "[]",
+                'delivery_state' => 'emitted'
             )
         );
         $testDb->close();
@@ -131,6 +132,65 @@ final class CommTest extends DatabaseTestCase
         });
 
         // comm.php?data=funcret|100|200|command@InspectSurroundings@@Ghost(hostile),Skeleton(dead),Lydia, (base64 encoded)
+        $encodedData = base64_encode("funcret|100|200|command@InspectSurroundings@@Ghost(hostile),Skeleton(dead),Lydia,");
+        $_SERVER["QUERY_STRING"] = "data={$encodedData}";
+        require(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."comm.php");
+    }
+
+    public function testComm_WhenLatestAssistantMessageIsPending_ContextShouldStillContainContentExample(): void
+    {
+        require("conf.php");
+        $GLOBALS["HERIKA_NAME"] = "Lydia";
+        $GLOBALS["HERIKA_PERS"] = "Roleplay as Lydia.";
+
+        $testDb = new sql();
+        $testDb->insert(
+            'eventlog',
+            array(
+                'ts' => "0",
+                'gamets' => "0",
+                'type' => "inputtext",
+                'data' => "Prisoner:Inspect the area again. (Talking to Lydia)",
+                'sess' => 'pending',
+                'localts' => 0,
+                'people'=> "|Lydia|",
+                'location'=> "",
+                'party'=> "[]"
+            )
+        );
+        $testDb->insert(
+            'eventlog',
+            array(
+                'ts' => "0",
+                'gamets' => "0",
+                'type' => "chat",
+                'data' => "Lydia: This line should stay hidden until emitted. (talking to Prisoner)",
+                'sess' => 'pending',
+                'localts' => 2,
+                'people'=> "|Lydia|",
+                'location'=> "",
+                'party'=> "[]",
+                'delivery_state' => 'pending'
+            )
+        );
+        $testDb->close();
+
+        $GLOBALS["mockConnectorSend"]=$this->createMock(CallableMock::class);
+        $GLOBALS["mockConnectorSend"]->expects($this->once())
+        ->method('__invoke')
+        ->with(
+            $this->equalTo('https://openrouter.ai/api/v1/chat/completions'),
+            $this->callback(function ($streamContext) {
+                $expectedPrompt = ["role"=>"user", "content"=>"The Narrator: Prisoner looks at The Narrator"];
+                $this->expectPromptInContext($streamContext, $expectedPrompt);
+
+                return true;
+            })
+        )
+        ->willReturnCallback(function($url, $context) {
+            return $this->defaultConnectorResponse($url, $context);
+        });
+
         $encodedData = base64_encode("funcret|100|200|command@InspectSurroundings@@Ghost(hostile),Skeleton(dead),Lydia,");
         $_SERVER["QUERY_STRING"] = "data={$encodedData}";
         require(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."comm.php");
@@ -393,6 +453,41 @@ final class CommTest extends DatabaseTestCase
         $this->assertSame("chat", $rows[0]["type"]);
         $this->assertSame("The Narrator: Unit test message (talking to Prisoner)", $rows[0]["data"]);
         $this->assertSame("pending", $rows[0]["sess"]);
+        $this->assertSame("emitted", $rows[0]["delivery_state"]);
+    }
+
+    public function testComm_WhenSpeechIsAborted_EmittedChatRowShouldBeMarkedAborted(): void
+    {
+        require("conf.php");
+
+        $testDb = new sql();
+        $testDb->insert(
+            'eventlog',
+            array(
+                'ts' => "100",
+                'gamets' => "200",
+                'type' => "chat",
+                'data' => "Lydia: Hold there. (talking to Prisoner)",
+                'sess' => 'pending',
+                'localts' => 10,
+                'people'=> "|Lydia|Prisoner|",
+                'location'=> "",
+                'party'=> "[]",
+                'delivery_state' => 'emitted',
+                'utterance_id' => 'utt_abort_1'
+            )
+        );
+        $testDb->close();
+
+        $encodedData = base64_encode('_speech_abort|101|201|{"utterance_ids":["utt_abort_1"]}');
+        $_SERVER["QUERY_STRING"] = "data={$encodedData}";
+        require(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."comm.php");
+
+        $testDb = new sql();
+        $rows = $testDb->fetchAll("SELECT delivery_state FROM eventlog WHERE utterance_id='utt_abort_1' ORDER BY rowid DESC LIMIT 1;");
+        $testDb->close();
+
+        $this->assertSame("aborted", $rows[0]["delivery_state"]);
     }
 
     public function testComm_WhenNarratorInputTextAndHideFromContextDisabled_NarratorReplyShouldKeepNearbyPeopleInEventLog(): void

--- a/unittests/tests/HistoricContextTest.php
+++ b/unittests/tests/HistoricContextTest.php
@@ -82,14 +82,15 @@ final class HistoricContextTest extends DatabaseTestCase
         string $people,
         int $ts,
         int $gameTs,
-        int $localTs
+        int $localTs,
+        ?string $deliveryState = null
     ): void {
         $connection = pg_connect($this->connString);
         $this->assertNotFalse($connection);
         pg_query_params(
             $connection,
-            "INSERT INTO eventlog (ts, gamets, type, data, sess, localts, people, location, party)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+            "INSERT INTO eventlog (ts, gamets, type, data, sess, localts, people, location, party, delivery_state)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
             [
                 (string)$ts,
                 (string)$gameTs,
@@ -100,6 +101,7 @@ final class HistoricContextTest extends DatabaseTestCase
                 $people,
                 "",
                 "[]",
+                $deliveryState,
             ]
         );
         pg_close($connection);
@@ -160,6 +162,66 @@ final class HistoricContextTest extends DatabaseTestCase
         }, $context);
 
         $this->assertNotContains("Belethor: Everything's for sale, my friend.", $contents);
+    }
+
+    public function testBuildHistoricContextIncludesEmittedChatRows(): void
+    {
+        $this->insertEvent(
+            "chat",
+            "Lydia: The perimeter is secure, my Thane. (talking to Prisoner)",
+            "|Lydia|Prisoner|",
+            100,
+            100,
+            100,
+            "emitted"
+        );
+
+        $context = buildHistoricContext("Lydia", -5);
+        $contents = array_map(static function (array $row): string {
+            return (string)($row["content"] ?? "");
+        }, $context);
+
+        $this->assertContains("Lydia: The perimeter is secure, my Thane. (talking to Prisoner)", $contents);
+    }
+
+    public function testBuildHistoricContextExcludesPendingChatRows(): void
+    {
+        $this->insertEvent(
+            "chat",
+            "Lydia: I have not actually said this yet. (talking to Prisoner)",
+            "|Lydia|Prisoner|",
+            100,
+            100,
+            100,
+            "pending"
+        );
+
+        $context = buildHistoricContext("Lydia", -5);
+        $contents = array_map(static function (array $row): string {
+            return (string)($row["content"] ?? "");
+        }, $context);
+
+        $this->assertNotContains("Lydia: I have not actually said this yet. (talking to Prisoner)", $contents);
+    }
+
+    public function testBuildHistoricContextExcludesAbortedChatRows(): void
+    {
+        $this->insertEvent(
+            "chat",
+            "Lydia: This line was canceled. (talking to Prisoner)",
+            "|Lydia|Prisoner|",
+            100,
+            100,
+            100,
+            "aborted"
+        );
+
+        $context = buildHistoricContext("Lydia", -5);
+        $contents = array_map(static function (array $row): string {
+            return (string)($row["content"] ?? "");
+        }, $context);
+
+        $this->assertNotContains("Lydia: This line was canceled. (talking to Prisoner)", $contents);
     }
 
     public function testNormalizeActorNameForComparisonStripsRestrainedSuffix(): void


### PR DESCRIPTION
## What

- introduce shared chat delivery-state helpers so prompt/history visibility is defined in one place
- log NPC chat rows as emitted after ScriptQueue output is sent, instead of keeping them pending until _speech
- treat emitted and spoken chat rows as visible to historic context and memory-recency queries
- mark _speech_abort rows as borted and block late _speech callbacks from promoting aborted rows back to spoken
- add regression coverage for emitted visibility, pending exclusion, aborted exclusion, and uncret follow-up context behavior

## Why

uncret follow-up requests could arrive after a line had already been sent to the game but before _speech promoted its eventlog row to spoken. At that point HerikaServer rebuilt context without the just-spoken NPC line, so action follow-ups could see nearly the same context as the previous request and repeat themselves. This change separates "already emitted to the game" from "confirmed spoken" so immediate follow-ups can reuse the line without letting truly unplayed pending rows leak into prompt history.

## Related PRs

- None.

## Notes

- _speech_abort now preserves in-flight chat rows as delivery_state='aborted' instead of deleting them, which prevents late _speech callbacks from reviving canceled lines.
- Validation run locally: php -l passed for all edited PHP files.
- PHPUnit could not be executed in this environment because the available PHP build is missing the mbstring extension required by PHPUnit.
