### PR TITLE
Handle disabled TTS cleanly

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -18,6 +18,10 @@ function callConfiguredTts($textString, $mood, $stringforhash)
         return false;
     }
 
+    if (strcasecmp($ttsFunction, 'none') === 0) {
+        return false;
+    }
+
     $specialFiles = [
         'stylettsv2' => __DIR__ . "/../tts/tts-stylettsv2-2.php",
     ];
@@ -58,7 +62,11 @@ function canRetryNpcTtsWithFallback(): bool
 function callNpcTtsWithFallback($textString, $mood, $stringforhash)
 {
     $ttsOutput = callConfiguredTts($textString, $mood, $stringforhash);
-    if ($ttsOutput || !canRetryNpcTtsWithFallback()) {
+    if ($ttsOutput) {
+        return $ttsOutput;
+    }
+
+    if (!canRetryNpcTtsWithFallback()) {
         return $ttsOutput;
     }
 


### PR DESCRIPTION
## Summary
- treat TTSFUNCTION=none as an explicit no-audio mode
- return early before trying to resolve a TTS provider when TTS is disabled
- keep the NPC fallback path clean when no synthesis is expected

## Testing
- exercised the no-TTS subtitle-only flow together with the CHIM subtitle lifetime fix
- confirmed server-side subtitle-only output still reaches ScriptQueue
