### PR TITLE
Scope rechat targets to previous event people

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -3094,92 +3094,6 @@ function chimParseServerSideRechatPayload($rawData)
     return $payload;
 }
 
-function chimLookupPreviousRechatPeopleScope($speakerName, $originLine, $maxAgeSeconds = 300)
-{
-    global $db;
-
-    $speakerName = normalizeDialogueListenerName($speakerName);
-    $empty = [
-        "audience" => [],
-        "people_pipe" => "",
-        "source" => "eventlog_none",
-        "rowid" => 0,
-        "matched_origin" => false,
-    ];
-
-    if ($speakerName === "") {
-        $empty["source"] = "eventlog_missing_speaker";
-        return $empty;
-    }
-
-    $speakerNormalized = normalizeActorNameForComparison($speakerName);
-    if ($speakerNormalized === "") {
-        $empty["source"] = "eventlog_invalid_speaker";
-        return $empty;
-    }
-
-    $originNormalized = normalizeDialogTextForComparison($originLine);
-    $ageSeconds = max(30, intval($maxAgeSeconds));
-    $cutoff = time() - $ageSeconds;
-
-    $rows = $db->fetchAll(
-        "SELECT rowid, data, people
-         FROM eventlog
-         WHERE localts > {$cutoff}
-           AND type = 'chat'
-           AND people IS NOT NULL
-           AND TRIM(people) <> ''
-         ORDER BY rowid DESC
-         LIMIT 120"
-    );
-
-    if (!is_array($rows) || empty($rows)) {
-        return $empty;
-    }
-
-    $latestSpeakerMatch = null;
-    foreach ($rows as $row) {
-        $rowData = (string)($row["data"] ?? "");
-        $rowSpeaker = normalizeDialogueListenerName(extractSpeakerNameFromChatEvent($rowData));
-        if (normalizeActorNameForComparison($rowSpeaker) !== $speakerNormalized) {
-            continue;
-        }
-
-        $audience = chimExtractPeopleListFromPipeString($row["people"] ?? "");
-        if (empty($audience)) {
-            continue;
-        }
-
-        $peoplePipe = normalizePeoplePipeList($audience);
-        if ($peoplePipe === "") {
-            continue;
-        }
-
-        $candidate = [
-            "audience" => $audience,
-            "people_pipe" => $peoplePipe,
-            "source" => "eventlog_latest_speaker",
-            "rowid" => intval($row["rowid"] ?? 0),
-            "matched_origin" => false,
-        ];
-
-        if ($latestSpeakerMatch === null) {
-            $latestSpeakerMatch = $candidate;
-        }
-
-        if ($originNormalized !== "") {
-            $rowOriginNormalized = normalizeDialogTextForComparison(extractCoreUtteranceFromChatEvent($rowData));
-            if ($rowOriginNormalized === $originNormalized) {
-                $candidate["source"] = "eventlog_origin";
-                $candidate["matched_origin"] = true;
-                return $candidate;
-            }
-        }
-    }
-
-    return ($latestSpeakerMatch !== null) ? $latestSpeakerMatch : $empty;
-}
-
 function chimResolveServerSideRechatTarget(array $payload)
 {
     $speakerName = normalizeDialogueListenerName($payload["speaker"] ?? ($GLOBALS["HERIKA_NAME"] ?? ""));
@@ -3187,10 +3101,17 @@ function chimResolveServerSideRechatTarget(array $payload)
     $rechatTargetHint = normalizeDialogueListenerName($payload["rechat_target_hint"] ?? "");
     $configuredRechatMode = chimGetRechatMode();
 
-    $peopleScope = chimLookupPreviousRechatPeopleScope($speakerName, $payload["origin_line"] ?? "");
-    $audience = $peopleScope["audience"] ?? [];
-    $candidateSource = $peopleScope["source"] ?? "eventlog_none";
-    $peoplePipe = $peopleScope["people_pipe"] ?? "";
+    $peoplePipe = "";
+    foreach ([$rechatTargetHint, $listenerHint] as $scopeTarget) {
+        if ($scopeTarget === "") {
+            continue;
+        }
+        $peoplePipe = lookupConversationPeopleSourceOfTruth($speakerName, $scopeTarget);
+        if ($peoplePipe !== "") {
+            break;
+        }
+    }
+    $audience = chimExtractPeopleListFromPipeString($peoplePipe);
 
     $rechatMode = chimResolveEffectiveRechatMode($configuredRechatMode, array_merge(
         [$speakerName, $listenerHint, $rechatTargetHint],
@@ -3198,22 +3119,16 @@ function chimResolveServerSideRechatTarget(array $payload)
     ));
 
     $candidates = [];
-    $isInAudience = function ($candidateName) use ($audience) {
+    $addCandidate = function ($candidateName) use (&$candidates, $audience) {
         $candidateName = normalizeDialogueListenerName($candidateName);
         if ($candidateName === "") {
-            return false;
+            return;
         }
         foreach ($audience as $audienceName) {
             if (strcasecmp($candidateName, $audienceName) === 0) {
-                return true;
+                $candidates[] = $candidateName;
+                return;
             }
-        }
-        return false;
-    };
-    $addCandidate = function ($candidateName) use (&$candidates, $isInAudience) {
-        $candidateName = normalizeDialogueListenerName($candidateName);
-        if ($candidateName !== "" && $isInAudience($candidateName)) {
-            $candidates[] = $candidateName;
         }
     };
 
@@ -3242,12 +3157,11 @@ function chimResolveServerSideRechatTarget(array $payload)
         }
     }
 
-    $rawCandidates = chimNormalizeRechatActorList($candidates);
+    $candidates = chimNormalizeRechatActorList($candidates);
     $npcMaster = new NpcMaster();
-    $validCandidates = [];
     $selected = "";
 
-    foreach ($rawCandidates as $candidate) {
+    foreach ($candidates as $candidate) {
         if ($candidate === "") {
             continue;
         }
@@ -3264,18 +3178,9 @@ function chimResolveServerSideRechatTarget(array $payload)
             continue;
         }
 
-        $validCandidates[] = $candidate;
-        if ($selected === "") {
-            $selected = $candidate;
-        }
+        $selected = $candidate;
+        break;
     }
-
-    Logger::info(
-        "[RECHAT_SELECT] speaker={$speakerName} listener_hint={$listenerHint} target_hint={$rechatTargetHint} mode={$rechatMode} configured_mode={$configuredRechatMode} source={$candidateSource} people_rowid=" .
-        intval($peopleScope["rowid"] ?? 0) . " matched_origin=" . (!empty($peopleScope["matched_origin"]) ? "true" : "false") . " source_companions=" .
-        implode(",", $audience) . " raw_candidates=" . implode(",", $rawCandidates) . " candidates=" .
-        implode(",", $validCandidates) . " selected={$selected}"
-    );
 
     return [
         "speaker" => $speakerName,
@@ -3283,11 +3188,7 @@ function chimResolveServerSideRechatTarget(array $payload)
         "rechat_target_hint" => $rechatTargetHint,
         "audience" => $audience,
         "people_pipe" => $peoplePipe,
-        "candidate_source" => $candidateSource,
-        "people_rowid" => intval($peopleScope["rowid"] ?? 0),
-        "matched_origin" => !empty($peopleScope["matched_origin"]),
-        "raw_candidates" => $rawCandidates,
-        "candidates" => $validCandidates,
+        "candidates" => $candidates,
         "selected" => $selected,
         "mode" => $rechatMode,
         "configured_mode" => $configuredRechatMode,

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -3058,8 +3058,6 @@ function chimParseServerSideRechatPayload($rawData)
         "listener_hint" => "",
         "rechat_target_hint" => "",
         "origin_line" => trim((string)$rawData),
-        "audience" => [],
-        "chain_members" => [],
         "rechat_depth" => 0,
         "chain_id" => "",
     ];
@@ -3089,12 +3087,6 @@ function chimParseServerSideRechatPayload($rawData)
     if (!empty($decoded["rechat_depth"])) {
         $payload["rechat_depth"] = max(0, intval($decoded["rechat_depth"]));
     }
-    if (!empty($decoded["audience"]) && is_array($decoded["audience"])) {
-        $payload["audience"] = chimNormalizeRechatActorList($decoded["audience"]);
-    }
-    if (!empty($decoded["chain_members"]) && is_array($decoded["chain_members"])) {
-        $payload["chain_members"] = chimNormalizeRechatActorList($decoded["chain_members"]);
-    }
     if (!empty($decoded["chain_id"])) {
         $payload["chain_id"] = trim((string)$decoded["chain_id"]);
     }
@@ -3102,38 +3094,90 @@ function chimParseServerSideRechatPayload($rawData)
     return $payload;
 }
 
-function chimGetLatestSpeechRechatContext($speakerName)
+function chimLookupPreviousRechatPeopleScope($speakerName, $originLine, $maxAgeSeconds = 300)
 {
     global $db;
 
     $speakerName = normalizeDialogueListenerName($speakerName);
+    $empty = [
+        "audience" => [],
+        "people_pipe" => "",
+        "source" => "eventlog_none",
+        "rowid" => 0,
+        "matched_origin" => false,
+    ];
+
     if ($speakerName === "") {
-        return [
-            "listener" => "",
-            "audience" => [],
-        ];
+        $empty["source"] = "eventlog_missing_speaker";
+        return $empty;
     }
 
-    $escapedSpeaker = $db->escape($speakerName);
-    $row = $db->fetchOne(
-        "SELECT listener, companions
-         FROM speech
-         WHERE speaker = '{$escapedSpeaker}'
+    $speakerNormalized = normalizeActorNameForComparison($speakerName);
+    if ($speakerNormalized === "") {
+        $empty["source"] = "eventlog_invalid_speaker";
+        return $empty;
+    }
+
+    $originNormalized = normalizeDialogTextForComparison($originLine);
+    $ageSeconds = max(30, intval($maxAgeSeconds));
+    $cutoff = time() - $ageSeconds;
+
+    $rows = $db->fetchAll(
+        "SELECT rowid, data, people
+         FROM eventlog
+         WHERE localts > {$cutoff}
+           AND type = 'chat'
+           AND people IS NOT NULL
+           AND TRIM(people) <> ''
          ORDER BY rowid DESC
-         LIMIT 1"
+         LIMIT 120"
     );
 
-    if (!$row) {
-        return [
-            "listener" => "",
-            "audience" => [],
-        ];
+    if (!is_array($rows) || empty($rows)) {
+        return $empty;
     }
 
-    return [
-        "listener" => normalizeDialogueListenerName($row["listener"] ?? ""),
-        "audience" => chimExtractPeopleListFromPipeString($row["companions"] ?? ""),
-    ];
+    $latestSpeakerMatch = null;
+    foreach ($rows as $row) {
+        $rowData = (string)($row["data"] ?? "");
+        $rowSpeaker = normalizeDialogueListenerName(extractSpeakerNameFromChatEvent($rowData));
+        if (normalizeActorNameForComparison($rowSpeaker) !== $speakerNormalized) {
+            continue;
+        }
+
+        $audience = chimExtractPeopleListFromPipeString($row["people"] ?? "");
+        if (empty($audience)) {
+            continue;
+        }
+
+        $peoplePipe = normalizePeoplePipeList($audience);
+        if ($peoplePipe === "") {
+            continue;
+        }
+
+        $candidate = [
+            "audience" => $audience,
+            "people_pipe" => $peoplePipe,
+            "source" => "eventlog_latest_speaker",
+            "rowid" => intval($row["rowid"] ?? 0),
+            "matched_origin" => false,
+        ];
+
+        if ($latestSpeakerMatch === null) {
+            $latestSpeakerMatch = $candidate;
+        }
+
+        if ($originNormalized !== "") {
+            $rowOriginNormalized = normalizeDialogTextForComparison(extractCoreUtteranceFromChatEvent($rowData));
+            if ($rowOriginNormalized === $originNormalized) {
+                $candidate["source"] = "eventlog_origin";
+                $candidate["matched_origin"] = true;
+                return $candidate;
+            }
+        }
+    }
+
+    return ($latestSpeakerMatch !== null) ? $latestSpeakerMatch : $empty;
 }
 
 function chimResolveServerSideRechatTarget(array $payload)
@@ -3142,36 +3186,44 @@ function chimResolveServerSideRechatTarget(array $payload)
     $listenerHint = normalizeDialogueListenerName($payload["listener_hint"] ?? "");
     $rechatTargetHint = normalizeDialogueListenerName($payload["rechat_target_hint"] ?? "");
     $configuredRechatMode = chimGetRechatMode();
-    $speechContext = chimGetLatestSpeechRechatContext($speakerName);
 
-    if ($listenerHint === "" && !empty($speechContext["listener"])) {
-        $listenerHint = $speechContext["listener"];
-    }
+    $peopleScope = chimLookupPreviousRechatPeopleScope($speakerName, $payload["origin_line"] ?? "");
+    $audience = $peopleScope["audience"] ?? [];
+    $candidateSource = $peopleScope["source"] ?? "eventlog_none";
+    $peoplePipe = $peopleScope["people_pipe"] ?? "";
 
-    $audience = chimNormalizeRechatActorList(array_merge(
-        $payload["audience"] ?? [],
-        $payload["chain_members"] ?? [],
-        $speechContext["audience"] ?? []
-    ));
     $rechatMode = chimResolveEffectiveRechatMode($configuredRechatMode, array_merge(
         [$speakerName, $listenerHint, $rechatTargetHint],
         $audience
     ));
 
     $candidates = [];
-    if ($rechatMode === "tight") {
-        if ($listenerHint !== "") {
-            $candidates[] = $listenerHint;
-        }
-    } elseif ($rechatMode === "conversational") {
-        if ($rechatTargetHint !== "") {
-            $candidates[] = $rechatTargetHint;
-        }
-        if ($listenerHint !== "") {
-            $candidates[] = $listenerHint;
+    $isInAudience = function ($candidateName) use ($audience) {
+        $candidateName = normalizeDialogueListenerName($candidateName);
+        if ($candidateName === "") {
+            return false;
         }
         foreach ($audience as $audienceName) {
-            $candidates[] = $audienceName;
+            if (strcasecmp($candidateName, $audienceName) === 0) {
+                return true;
+            }
+        }
+        return false;
+    };
+    $addCandidate = function ($candidateName) use (&$candidates, $isInAudience) {
+        $candidateName = normalizeDialogueListenerName($candidateName);
+        if ($candidateName !== "" && $isInAudience($candidateName)) {
+            $candidates[] = $candidateName;
+        }
+    };
+
+    if ($rechatMode === "tight") {
+        $addCandidate($listenerHint);
+    } elseif ($rechatMode === "conversational") {
+        $addCandidate($rechatTargetHint);
+        $addCandidate($listenerHint);
+        foreach ($audience as $audienceName) {
+            $addCandidate($audienceName);
         }
     } else {
         foreach ($audience as $audienceName) {
@@ -3181,24 +3233,21 @@ function chimResolveServerSideRechatTarget(array $payload)
             if ($listenerHint !== "" && strcasecmp($audienceName, $listenerHint) === 0) {
                 continue;
             }
-            $candidates[] = $audienceName;
+            $addCandidate($audienceName);
         }
-        if ($rechatTargetHint !== "") {
-            $candidates[] = $rechatTargetHint;
-        }
-        if ($listenerHint !== "") {
-            $candidates[] = $listenerHint;
-        }
+        $addCandidate($rechatTargetHint);
+        $addCandidate($listenerHint);
         foreach ($audience as $audienceName) {
-            $candidates[] = $audienceName;
+            $addCandidate($audienceName);
         }
     }
 
-    $candidates = chimNormalizeRechatActorList($candidates);
+    $rawCandidates = chimNormalizeRechatActorList($candidates);
     $npcMaster = new NpcMaster();
+    $validCandidates = [];
     $selected = "";
 
-    foreach ($candidates as $candidate) {
+    foreach ($rawCandidates as $candidate) {
         if ($candidate === "") {
             continue;
         }
@@ -3215,17 +3264,30 @@ function chimResolveServerSideRechatTarget(array $payload)
             continue;
         }
 
-        $selected = $candidate;
-        break;
+        $validCandidates[] = $candidate;
+        if ($selected === "") {
+            $selected = $candidate;
+        }
     }
+
+    Logger::info(
+        "[RECHAT_SELECT] speaker={$speakerName} listener_hint={$listenerHint} target_hint={$rechatTargetHint} mode={$rechatMode} configured_mode={$configuredRechatMode} source={$candidateSource} people_rowid=" .
+        intval($peopleScope["rowid"] ?? 0) . " matched_origin=" . (!empty($peopleScope["matched_origin"]) ? "true" : "false") . " source_companions=" .
+        implode(",", $audience) . " raw_candidates=" . implode(",", $rawCandidates) . " candidates=" .
+        implode(",", $validCandidates) . " selected={$selected}"
+    );
 
     return [
         "speaker" => $speakerName,
         "listener_hint" => $listenerHint,
         "rechat_target_hint" => $rechatTargetHint,
         "audience" => $audience,
-        "chain_members" => chimNormalizeRechatActorList($payload["chain_members"] ?? []),
-        "candidates" => $candidates,
+        "people_pipe" => $peoplePipe,
+        "candidate_source" => $candidateSource,
+        "people_rowid" => intval($peopleScope["rowid"] ?? 0),
+        "matched_origin" => !empty($peopleScope["matched_origin"]),
+        "raw_candidates" => $rawCandidates,
+        "candidates" => $validCandidates,
         "selected" => $selected,
         "mode" => $rechatMode,
         "configured_mode" => $configuredRechatMode,
@@ -3241,13 +3303,10 @@ function chimBuildServerSideRechatSessionKey(array $resolvedTarget)
         return md5("chain_" . $chainId);
     }
 
-    $members = $resolvedTarget["chain_members"] ?? [];
-    if (empty($members)) {
-        $members = array_merge(
-            [$resolvedTarget["speaker"] ?? "", $resolvedTarget["listener_hint"] ?? "", $resolvedTarget["rechat_target_hint"] ?? ""],
-            $resolvedTarget["audience"] ?? []
-        );
-    }
+    $members = array_merge(
+        [$resolvedTarget["speaker"] ?? "", $resolvedTarget["listener_hint"] ?? "", $resolvedTarget["rechat_target_hint"] ?? ""],
+        $resolvedTarget["audience"] ?? []
+    );
 
     $members = chimNormalizeRechatActorList($members);
     sort($members, SORT_NATURAL | SORT_FLAG_CASE);

--- a/main.php
+++ b/main.php
@@ -1669,17 +1669,13 @@ $hasAuthoritativeRequestAudience = (
 );
 $resolvedRechatPeople = "";
 if (($gameRequest[0] ?? "") === "rechat" && isset($GLOBALS["RECHAT_RESOLVED_TARGET"])) {
-    $resolvedRechatPeople = normalizePeoplePipeList(
-        parsePeoplePipeList($GLOBALS["RECHAT_RESOLVED_TARGET"]["people_pipe"] ?? "")
-    );
+    $resolvedRechatPeople = (string)($GLOBALS["RECHAT_RESOLVED_TARGET"]["people_pipe"] ?? "");
 }
+$authoritativePeople = $hasAuthoritativeRequestAudience ? $requestAudienceSnapshot : $resolvedRechatPeople;
 
-if ($hasAuthoritativeRequestAudience) {
-    $GLOBALS["CACHE_PEOPLE"] = $requestAudienceSnapshot;
-    Logger::info("Scoped CACHE_PEOPLE for {$gameRequest[0]} from request audience snapshot: " . $GLOBALS["CACHE_PEOPLE"]);
-} elseif ($resolvedRechatPeople !== "") {
-    $GLOBALS["CACHE_PEOPLE"] = $resolvedRechatPeople;
-    Logger::info("Scoped CACHE_PEOPLE for rechat from previous eventlog people: " . $GLOBALS["CACHE_PEOPLE"]);
+if ($authoritativePeople !== "") {
+    $GLOBALS["CACHE_PEOPLE"] = $authoritativePeople;
+    Logger::info("Scoped CACHE_PEOPLE for {$gameRequest[0]}: " . $GLOBALS["CACHE_PEOPLE"]);
 } else {
     $scopedPeople = buildScopedPeopleForEvent(
         $gameRequest[0] ?? "",
@@ -1740,12 +1736,9 @@ if ($gameRequest[0] != "diary" && $gameRequest[0] != "cheatmode") {
     }
     
     if ($shouldLog) {
-        if ($hasAuthoritativeRequestAudience) {
-            $eventPeople = $requestAudienceSnapshot;
-            $GLOBALS["CACHE_PEOPLE"] = $requestAudienceSnapshot;
-        } elseif ($resolvedRechatPeople !== "") {
-            $eventPeople = $resolvedRechatPeople;
-            $GLOBALS["CACHE_PEOPLE"] = $resolvedRechatPeople;
+        if ($authoritativePeople !== "") {
+            $eventPeople = $authoritativePeople;
+            $GLOBALS["CACHE_PEOPLE"] = $authoritativePeople;
         } else {
             $eventPeople = buildScopedPeopleForEvent(
                 $gameRequest[0] ?? "",

--- a/main.php
+++ b/main.php
@@ -1667,10 +1667,19 @@ $hasAuthoritativeRequestAudience = (
     in_array($gameRequest[0] ?? "", $playerInputEventTypes, true) &&
     $requestAudienceSnapshot !== ""
 );
+$resolvedRechatPeople = "";
+if (($gameRequest[0] ?? "") === "rechat" && isset($GLOBALS["RECHAT_RESOLVED_TARGET"])) {
+    $resolvedRechatPeople = normalizePeoplePipeList(
+        parsePeoplePipeList($GLOBALS["RECHAT_RESOLVED_TARGET"]["people_pipe"] ?? "")
+    );
+}
 
 if ($hasAuthoritativeRequestAudience) {
     $GLOBALS["CACHE_PEOPLE"] = $requestAudienceSnapshot;
     Logger::info("Scoped CACHE_PEOPLE for {$gameRequest[0]} from request audience snapshot: " . $GLOBALS["CACHE_PEOPLE"]);
+} elseif ($resolvedRechatPeople !== "") {
+    $GLOBALS["CACHE_PEOPLE"] = $resolvedRechatPeople;
+    Logger::info("Scoped CACHE_PEOPLE for rechat from previous eventlog people: " . $GLOBALS["CACHE_PEOPLE"]);
 } else {
     $scopedPeople = buildScopedPeopleForEvent(
         $gameRequest[0] ?? "",
@@ -1734,6 +1743,9 @@ if ($gameRequest[0] != "diary" && $gameRequest[0] != "cheatmode") {
         if ($hasAuthoritativeRequestAudience) {
             $eventPeople = $requestAudienceSnapshot;
             $GLOBALS["CACHE_PEOPLE"] = $requestAudienceSnapshot;
+        } elseif ($resolvedRechatPeople !== "") {
+            $eventPeople = $resolvedRechatPeople;
+            $GLOBALS["CACHE_PEOPLE"] = $resolvedRechatPeople;
         } else {
             $eventPeople = buildScopedPeopleForEvent(
                 $gameRequest[0] ?? "",


### PR DESCRIPTION
## What

- Make server-side rechat select only from the previous conversation people scope.
- Reuse the existing `lookupConversationPeopleSourceOfTruth()` helper instead of carrying a separate rechat audience scanner.
- Stop parsing plugin-provided rechat `audience` / `chain_members`; the CHIM PR no longer needs the server to trust those payload fields.
- Keep rechat `CACHE_PEOPLE` aligned with the resolved previous people scope using the same authoritative-people path as plugin request audience snapshots.
- Simplify the PR to be net-negative code overall: final diff is 47 insertions / 82 deletions across `lib/chat_helper_functions.php` and `main.php`.

## Screenshot

Not applicable.

## Why

The matching CHIM PR now makes the plugin/eventlog people list the source of truth. HerikaServer only needs to keep rechat target selection and eventlog people display inside that same scope. Reusing the existing conversation source-of-truth lookup removes the extra rechat-specific metadata and avoids another parallel audience system.

## Related PRs

- Dwemer-Dynamics/CHIM#37: https://github.com/Dwemer-Dynamics/CHIM/pull/37

## Notes

Validation run:

- `php -l lib/chat_helper_functions.php`
- `php -l main.php`

This remains a draft PR and is intended to pair with the CHIM listener-routing/audience cleanup.