### PR TITLE
Fix int4 overflow in middleterm companions backfill (stalls MTM past gamets ~2.146B)

### DIFF
--- a/debug/util_memory_subsystem.php
+++ b/debug/util_memory_subsystem.php
@@ -120,7 +120,7 @@ function resyncMemorySummaries($db, $forceAll = false, $onlyFix = false)
     $missingCompanions = $db->fetchAll("SELECT * FROM memory_summary WHERE (companions IS NULL OR companions = '') and classifier<>'diary' ORDER BY gamets_truncated ASC");
     $n=0;
     foreach ($missingCompanions as $row) {
-        $peopleRows = $db->fetchAll("SELECT CASE WHEN party='[]' THEN people ELSE COALESCE(people, party) END AS people FROM eventlog WHERE gamets > {$row["gamets_truncated"]} - $pfi AND gamets <= {$row["gamets_truncated"]} + $pfi");
+        $peopleRows = $db->fetchAll("SELECT CASE WHEN party='[]' THEN people ELSE COALESCE(people, party) END AS people FROM eventlog WHERE gamets > {$row["gamets_truncated"]}::bigint - $pfi AND gamets <= {$row["gamets_truncated"]}::bigint + $pfi");
         $npcs       = [];
         foreach ($peopleRows as $p) {
             if (! empty($p["people"])) {
@@ -159,7 +159,7 @@ function resyncMemorySummaries($db, $forceAll = false, $onlyFix = false)
     $n=0;
     $missingCompanions2 = $db->fetchAll("SELECT * FROM memory_summary WHERE (companions IS NULL OR companions = '') and classifier<>'diary' ORDER BY gamets_truncated ASC");
     foreach ($missingCompanions2 as $row) {
-        $peopleRow = $db->fetchOne("SELECT STRING_AGG(DISTINCT speaker || '|' || listener, '|') AS people FROM public.memory_v WHERE gamets > {$row["gamets_truncated"]} - $pfi AND gamets <= {$row["gamets_truncated"]} + $pfi");
+        $peopleRow = $db->fetchOne("SELECT STRING_AGG(DISTINCT speaker || '|' || listener, '|') AS people FROM public.memory_v WHERE gamets > {$row["gamets_truncated"]}::bigint - $pfi AND gamets <= {$row["gamets_truncated"]}::bigint + $pfi");
         $npcs      = [];
         if (! empty($peopleRow["people"])) {
             foreach (explode("|", $peopleRow["people"]) as $npc) {


### PR DESCRIPTION
## Problem

`resyncMemorySummaries()` in `debug/util_memory_subsystem.php` backfills the `companions` field on `memory_summary` rows using a per-row ±`$pfi` game-time window. Two of those queries interpolate `gamets_truncated` as a bare integer literal:

```php
WHERE gamets > {$row["gamets_truncated"]} - $pfi AND gamets <= {$row["gamets_truncated"]} + $pfi
```

PostgreSQL parses both operands as `int4`, so `{$gamets_truncated} + $pfi` is evaluated as **int4 addition**. Once `gamets_truncated` exceeds `int4_max (2,147,483,647) − $pfi ≈ 2.146e9`, the addition overflows:

```
ERROR:  integer out of range
```

The uncaught exception aborts the whole backfill loop (and the `fixcomp` command).

## Impact

On a long-running playthrough, once game-time (`gamets`) passes ~2.146B, `companions` silently stops being written on new `memory_summary` rows. Because middle-term memory generation (`service/processors/middleterm/cmd/generate.php`) selects an NPC's memories via `companions LIKE '%|<name>|%'`, it then matches nothing and **middle-term memory generation stalls cast-wide**, with no error surfaced in normal operation. Any playthrough that runs long enough will hit this.

## Fix

Cast the interpolated value to `::bigint` so the window arithmetic is 64-bit:

```php
WHERE gamets > {$row["gamets_truncated"]}::bigint - $pfi AND gamets <= {$row["gamets_truncated"]}::bigint + $pfi
```

Both occurrences (the `eventlog` query and the `memory_v` query). The later `ms.gamets_truncated ± $pfi` variants in the same file operate on the `bigint` column directly (not an interpolated literal), so they already promote to bigint and need no change.

## Testing

Reproduced on a live DB whose game-time had passed 2.146B: `fixcomp` threw `integer out of range` and bailed mid-rebuild, leaving recent dialogue rows with empty `companions` and MTM stalled. With the cast applied, `fixcomp` runs to completion, all dialogue rows are re-tagged, and middle-term memory generation resumes.
