### PR TITLE
Widen memory.localts to bigint (only int4 timestamp column; Y2038)

### DIFF
--- a/data/database_default.sql
+++ b/data/database_default.sql
@@ -1179,7 +1179,7 @@ CREATE TABLE public.memory (
     session text,
     uid integer NOT NULL,
     listener text,
-    localts integer,
+    localts bigint,
     gamets bigint NOT NULL,
     momentum text,
     rowid bigint NOT NULL,

--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -6746,6 +6746,15 @@ if ($relationshipMetadataNeedsRefresh) {
     }
 }
 
+if ($checkVersion("memory") < 20260617001) {
+    Logger::debug("Applying memory 20260617001 - widen localts to bigint (avoids int4 overflow on long-running games / Y2038)");
+
+    $db->execQuery("ALTER TABLE public.memory ALTER COLUMN localts TYPE bigint");
+
+    $updateVersion("memory", 20260617001);
+    Logger::info("Applied patch memory 20260617001");
+}
+
 Logger::info(__FILE__." update file processed");
 
 //----------------------------------------------------


### PR DESCRIPTION
## Problem

`public.memory.localts` is declared `integer` (int4) — it is the **only** `localts`/`gamets` timestamp column in the schema not declared `bigint`. Every other table (`speech`, `eventlog`, `memory_summary`, `diarylog`, …) uses `bigint` for these.

`localts` holds a Unix epoch timestamp (currently ~1.78e9). `int4`'s max is `2,147,483,647`, which the epoch crosses on **2038-01-19** — after which inserts/reads on `memory.localts` break (Y2038). Any int4 arithmetic on the value can overflow earlier.

## Fix

- **`data/database_default.sql`** — `memory.localts` `integer` → `bigint` (fresh installs).
- **`debug/db_updates.php`** — add versioned migration `memory` `20260617001`:
  ```sql
  ALTER TABLE public.memory ALTER COLUMN localts TYPE bigint
  ```
  so existing installs upgrade on next run.

Widening `int4 → bigint` is lossless, and brings `memory.localts` in line with every other timestamp column in the schema.
