### PR TITLE
Show modded equipment slots

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -362,6 +362,90 @@ function chimLookupItemDescriptionForContext(string $itemName, ?string $baseid =
     return null;
 }
 
+function chimEquipmentVanillaSlotLabels(): array
+{
+    return [
+        'helmet' => 'Helmet',
+        'armor' => 'Armor',
+        'boots' => 'Boots',
+        'gloves' => 'Gloves',
+        'amulet' => 'Amulet',
+        'ring' => 'Ring',
+        'left_hand' => 'Left Hand',
+        'right_hand' => 'Right Hand',
+    ];
+}
+
+function chimEquipmentModdedSlotLabels(): array
+{
+    return [
+        'mod_mouth' => 'Face/Mouth',
+        'mod_neck' => 'Neck',
+        'cape' => 'Cape/Chest Outer',
+        'backpack' => 'Back/Backpack',
+        'mod_misc1' => 'Misc Slot 48',
+        'mod_pelvis_primary' => 'Pelvis Outer',
+        'mod_pelvis_secondary' => 'Pelvis Secondary',
+        'mod_leg_right' => 'Right Leg',
+        'mod_leg_left' => 'Left Leg',
+        'mod_face_jewelry' => 'Face Jewelry',
+        'shirt' => 'Chest Under',
+        'mod_shoulder' => 'Shoulder',
+        'mod_arm_left' => 'Left Arm',
+        'mod_arm_right' => 'Right Arm',
+        'mod_misc2' => 'Misc Slot 60',
+    ];
+}
+
+function chimEquipmentAllSlotLabels(): array
+{
+    return chimEquipmentVanillaSlotLabels() + chimEquipmentModdedSlotLabels();
+}
+
+function chimEquipmentProfileSlotKeys(): array
+{
+    return array_keys(chimEquipmentAllSlotLabels());
+}
+
+function chimFormatEquipmentPromptLines(array $equipmentData, array $slotLabels, callable $getItemDescription = null, array &$describedBaseids = []): array
+{
+    $equipmentParts = [];
+
+    foreach ($slotLabels as $slot => $label) {
+        if (empty($equipmentData[$slot])) {
+            continue;
+        }
+
+        $itemName = trim((string) $equipmentData[$slot]);
+        if ($itemName === '' || isItemBlacklisted($itemName) || stripos($itemName, 'Missing Name') !== false) {
+            continue;
+        }
+
+        $baseid = isset($equipmentData[$slot . '_baseid']) ? trim((string) $equipmentData[$slot . '_baseid']) : '';
+        $itemLine = "  - {$label}: {$itemName}";
+
+        if ($getItemDescription !== null) {
+            $baseidKey = $baseid !== '' ? strtoupper($baseid) : '';
+            if ($baseidKey !== '' && in_array($baseidKey, $describedBaseids, true)) {
+                $equipmentParts[] = $itemLine;
+                continue;
+            }
+
+            $description = $getItemDescription($itemName, $baseid !== '' ? $baseid : null);
+            if ($description) {
+                $itemLine .= " - {$description}";
+                if ($baseidKey !== '') {
+                    $describedBaseids[] = $baseidKey;
+                }
+            }
+        }
+
+        $equipmentParts[] = $itemLine;
+    }
+
+    return $equipmentParts;
+}
+
 function chimFormatProfileEquipmentParts(array $equipmentData, array $slots): array {
     $equipmentParts = [];
     $describedBaseids = [];
@@ -681,7 +765,7 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                     // Add equipment if available
                     $equipmentData = $player->getJson('equipment');
                     if (is_array($equipmentData) && !empty($equipmentData)) {
-                        $slots = ['helmet', 'armor', 'boots', 'gloves', 'amulet', 'ring', 'left_hand', 'right_hand'];
+                        $slots = chimEquipmentProfileSlotKeys();
                         $equipmentParts = chimFormatProfileEquipmentParts($equipmentData, $slots);
                         if (!empty($equipmentParts)) {
                             $profileString .= ". Equipment: " . implode(", ", $equipmentParts);
@@ -797,7 +881,7 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                     
                     // Add equipment if available
                     if (isset($metaData["equipment"]) && is_array($metaData["equipment"])) {
-                        $slots = ['helmet', 'armor', 'boots', 'gloves', 'amulet', 'ring', 'left_hand', 'right_hand'];
+                        $slots = chimEquipmentProfileSlotKeys();
                         $equipmentParts = chimFormatProfileEquipmentParts($metaData["equipment"], $slots);
                         if (!empty($equipmentParts)) {
                             $profileString .= ". Equipment: " . implode(", ", $equipmentParts);
@@ -6704,55 +6788,21 @@ function buildDynamicBiography(array $FOLLOWER_CONF, bool $forLetter = false, bo
     
     // Add NPC's own equipment (skip for The Narrator - they don't need equipment context)
     if ($FOLLOWER_CONF["HERIKA_NAME"] !== "The Narrator" && isset($metaData["equipment"]) && is_array($metaData["equipment"])) {
-        $equipmentParts = [];
         $describedBaseids = []; // Track which baseids we've already described
-        $slots = [
-            'helmet' => 'Helmet',
-            'armor' => 'Armor', 
-            'boots' => 'Boots',
-            'gloves' => 'Gloves',
-            'amulet' => 'Amulet',
-            'ring' => 'Ring',
-            'cape' => 'Cape',
-            'backpack' => 'Backpack',
-            'left_hand' => 'Left Hand',
-            'right_hand' => 'Right Hand'
-        ];
-        
-        foreach ($slots as $slot => $label) {
-            if (!empty($metaData["equipment"][$slot])) {
-                $itemName = $metaData["equipment"][$slot];
-                
-                // Skip blacklisted items
-                if (isItemBlacklisted($itemName)) {
-                    continue;
-                }
-                
-                $baseid = isset($metaData["equipment"][$slot . '_baseid']) ? $metaData["equipment"][$slot . '_baseid'] : null;
-                
-                $itemLine = "  • {$label}: {$itemName}";
-                
-                // Try to add item description only if we haven't described this baseid yet
-                if (!empty($baseid) && !in_array($baseid, $describedBaseids)) {
-                    $description = $getItemDescription($itemName, $baseid);
-                    if ($description) {
-                        $itemLine .= " - {$description}";
-                        $describedBaseids[] = $baseid; // Mark this baseid as described
-                    }
-                } elseif (empty($baseid)) {
-                    // No baseid, try name-based (won't dedupe without baseid)
-                    $description = $getItemDescription($itemName, null);
-                    if ($description) {
-                        $itemLine .= " - {$description}";
-                    }
-                }
-                
-                $equipmentParts[] = $itemLine;
-            }
+        $vanillaEquipmentParts = chimFormatEquipmentPromptLines($metaData["equipment"], chimEquipmentVanillaSlotLabels(), $getItemDescription, $describedBaseids);
+        $moddedEquipmentParts = chimFormatEquipmentPromptLines($metaData["equipment"], chimEquipmentModdedSlotLabels(), $getItemDescription, $describedBaseids);
+        $equipmentSections = [];
+
+        if (!empty($vanillaEquipmentParts)) {
+            $equipmentSections[] = "Vanilla Slots:\n" . implode("\n", $vanillaEquipmentParts);
+        }
+
+        if (!empty($moddedEquipmentParts)) {
+            $equipmentSections[] = "Modded Slots:\n" . implode("\n", $moddedEquipmentParts);
         }
         
-        if (!empty($equipmentParts)) {
-            $EQUIPMENT_ADD = "\n<equipment>\n#Current Equipment\nYou are currently wearing/wielding:\n" . implode("\n", $equipmentParts);
+        if (!empty($equipmentSections)) {
+            $EQUIPMENT_ADD = "\n<equipment>\n#Current Equipment\nYou are currently wearing/wielding:\n" . implode("\n", $equipmentSections);
             
             // Check if humanoid NPC has no body armor - if so, note they're naked
             $humanoidRaces = ['nord', 'imperial', 'breton', 'redguard', 'orc', 'orsimer', 
@@ -6947,26 +6997,20 @@ function buildDynamicBiography(array $FOLLOWER_CONF, bool $forLetter = false, bo
             $targetMetaData = $npcMaster->getMetaData($targetNpcData);
             
             if (isset($targetMetaData["equipment"]) && is_array($targetMetaData["equipment"])) {
-                $targetEquipmentParts = [];
-                $slots = [
-                    'helmet' => 'Helmet',
-                    'armor' => 'Armor',
-                    'boots' => 'Boots', 
-                    'gloves' => 'Gloves',
-                    'amulet' => 'Amulet',
-                    'ring' => 'Ring',
-                    'left_hand' => 'Left Hand',
-                    'right_hand' => 'Right Hand'
-                ];
-                
-                foreach ($slots as $slot => $label) {
-                    if (!empty($targetMetaData["equipment"][$slot])) {
-                        $targetEquipmentParts[] = "  • {$label}: {$targetMetaData["equipment"][$slot]}";
-                    }
+                $targetVanillaEquipmentParts = chimFormatEquipmentPromptLines($targetMetaData["equipment"], chimEquipmentVanillaSlotLabels());
+                $targetModdedEquipmentParts = chimFormatEquipmentPromptLines($targetMetaData["equipment"], chimEquipmentModdedSlotLabels());
+                $targetEquipmentSections = [];
+
+                if (!empty($targetVanillaEquipmentParts)) {
+                    $targetEquipmentSections[] = "Vanilla Slots:\n" . implode("\n", $targetVanillaEquipmentParts);
+                }
+
+                if (!empty($targetModdedEquipmentParts)) {
+                    $targetEquipmentSections[] = "Modded Slots:\n" . implode("\n", $targetModdedEquipmentParts);
                 }
                 
-                if (!empty($targetEquipmentParts)) {
-                    $TARGET_EQUIPMENT_ADD = "\n<target_equipment>\n#{$targetName}'s Equipment\n{$targetName} is currently wearing/wielding:\n" . implode("\n", $targetEquipmentParts);
+                if (!empty($targetEquipmentSections)) {
+                    $TARGET_EQUIPMENT_ADD = "\n<target_equipment>\n#{$targetName}'s Equipment\n{$targetName} is currently wearing/wielding:\n" . implode("\n", $targetEquipmentSections);
                     
                     // Check if humanoid NPC has no body armor - if so, note they're naked
                     $humanoidRaces = ['nord', 'imperial', 'breton', 'redguard', 'orc', 'orsimer', 

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -407,6 +407,27 @@ function chimEquipmentProfileSlotKeys(): array
     return array_keys(chimEquipmentAllSlotLabels());
 }
 
+function chimEquipmentSlotHasVisibleItem(array $equipmentData, string $slot): bool
+{
+    if (empty($equipmentData[$slot])) {
+        return false;
+    }
+
+    $itemName = trim((string) $equipmentData[$slot]);
+    return $itemName !== '' && !isItemBlacklisted($itemName) && stripos($itemName, 'Missing Name') === false;
+}
+
+function chimEquipmentHasBodyCoverage(array $equipmentData): bool
+{
+    foreach (['armor', 'shirt', 'cape'] as $slot) {
+        if (chimEquipmentSlotHasVisibleItem($equipmentData, $slot)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function chimFormatEquipmentPromptLines(array $equipmentData, array $slotLabels, callable $getItemDescription = null, array &$describedBaseids = []): array
 {
     $equipmentParts = [];
@@ -893,7 +914,7 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                                         'argonian', 'khajiit', 'khajit'];
                         $npcRace = isset($currentNpcData["race"]) ? strtolower(trim($currentNpcData["race"])) : '';
                         
-                        if ($npcRace && in_array($npcRace, $humanoidRaces) && empty($metaData["equipment"]["armor"])) {
+                        if ($npcRace && in_array($npcRace, $humanoidRaces) && !chimEquipmentHasBodyCoverage($metaData["equipment"])) {
                             $profileString .= ". Naked (no body armor/clothing worn)";
                         }
                     }
@@ -6810,7 +6831,7 @@ function buildDynamicBiography(array $FOLLOWER_CONF, bool $forLetter = false, bo
                             'argonian', 'khajiit', 'khajit'];
             $npcRace = isset($currentNpcData["race"]) ? strtolower(trim($currentNpcData["race"])) : '';
             
-            if ($npcRace && in_array($npcRace, $humanoidRaces) && empty($metaData["equipment"]["armor"])) {
+            if ($npcRace && in_array($npcRace, $humanoidRaces) && !chimEquipmentHasBodyCoverage($metaData["equipment"])) {
                 $EQUIPMENT_ADD .= "\nNote: You are naked (no body armor/clothing worn).";
             }
             
@@ -7018,7 +7039,7 @@ function buildDynamicBiography(array $FOLLOWER_CONF, bool $forLetter = false, bo
                                     'argonian', 'khajiit', 'khajit'];
                     $targetRace = isset($targetNpcData["race"]) ? strtolower(trim($targetNpcData["race"])) : '';
                     
-                    if ($targetRace && in_array($targetRace, $humanoidRaces) && empty($targetMetaData["equipment"]["armor"])) {
+                    if ($targetRace && in_array($targetRace, $humanoidRaces) && !chimEquipmentHasBodyCoverage($targetMetaData["equipment"])) {
                         $TARGET_EQUIPMENT_ADD .= "\nNote: {$targetName} is naked (no body armor/clothing worn).";
                     }
                     

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -2226,17 +2226,19 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                         ];
                         ?>
                         <?php foreach ($equipmentGroups as $groupLabel => $equipmentSlots): ?>
-                            <div style="margin:10px 0 6px; color:#f27c11; font-weight:700;"><?= htmlspecialchars($groupLabel) ?></div>
-                            <div style="display:grid; grid-template-columns: 180px 1fr; gap:8px;">
-                                <?php foreach ($equipmentSlots as $slot => $label):
-                                    $item = isset($metadataEquipment[$slot]) ? trim((string)$metadataEquipment[$slot]) : '';
-                                    $display = ($item !== '') ? htmlspecialchars($item) : '<span style="color:#666">None</span>';
-                                ?>
-                                    <div style="color:rgb(242, 124, 17); font-weight:600;"><?= htmlspecialchars($label) ?></div>
-                                    <div style="border:1px solid #4a4a4a; border-radius:6px; padding:4px 8px;"><?= $display ?></div>
-                                <?php endforeach; ?>
+                            <div style="border:1px solid #3d4654; border-radius:8px; background:#20242b; padding:10px; margin:10px 0;">
+                                <div style="color:#f27c11; font-weight:700; margin-bottom:8px;"><?= htmlspecialchars($groupLabel) ?></div>
+                                <div style="display:grid; grid-template-columns: 180px 1fr; gap:8px;">
+                                    <?php foreach ($equipmentSlots as $slot => $label):
+                                        $item = isset($metadataEquipment[$slot]) ? trim((string)$metadataEquipment[$slot]) : '';
+                                        $display = ($item !== '') ? htmlspecialchars($item) : '<span style="color:#666">None</span>';
+                                    ?>
+                                        <div style="color:rgb(242, 124, 17); font-weight:600;"><?= htmlspecialchars($label) ?></div>
+                                        <div style="border:1px solid #4a4a4a; border-radius:6px; padding:4px 8px; background:#262626;"><?= $display ?></div>
+                                    <?php endforeach; ?>
+                                </div>
                             </div>
-                            <?php endforeach; ?>
+                        <?php endforeach; ?>
                     <?php else: ?>
                         <div style="color:#9fb1c9;">No equipment data found in metadata.</div>
                     <?php endif; ?>

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -2220,28 +2220,23 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                 <div style="margin-top:8px; color:#cfd9ea;">
                     <?php if (!empty($metadataEquipment)): ?>
                         <?php 
-                        $equipmentSlots = [
-                            'helmet' => '🪖 Helmet',
-                            'armor' => '🛡️ Armor',
-                            'boots' => '👢 Boots',
-                            'gloves' => '🧤 Gloves',
-                            'amulet' => '📿 Amulet',
-                            'ring' => '💍 Ring',
-                            'cape' => '🧣 Cape',
-                            'backpack' => '🎒 Backpack',
-                            'left_hand' => '🤚 Left Hand',
-                            'right_hand' => '👉 Right Hand'
+                        $equipmentGroups = [
+                            'Vanilla Slots' => chimEquipmentVanillaSlotLabels(),
+                            'Modded Slots' => chimEquipmentModdedSlotLabels(),
                         ];
                         ?>
-                        <div style="display:grid; grid-template-columns: 160px 1fr; gap:8px;">
-                            <?php foreach ($equipmentSlots as $slot => $label): 
-                                $item = isset($metadataEquipment[$slot]) ? trim((string)$metadataEquipment[$slot]) : '';
-                                $display = ($item !== '') ? htmlspecialchars($item) : '<span style="color:#666">None</span>';
-                            ?>
-                                <div style="color:rgb(242, 124, 17); font-weight:600;"><?= $label ?></div>
-                                <div style="border:1px solid #4a4a4a; border-radius:6px; padding:4px 8px;"><?= $display ?></div>
+                        <?php foreach ($equipmentGroups as $groupLabel => $equipmentSlots): ?>
+                            <div style="margin:10px 0 6px; color:#f27c11; font-weight:700;"><?= htmlspecialchars($groupLabel) ?></div>
+                            <div style="display:grid; grid-template-columns: 180px 1fr; gap:8px;">
+                                <?php foreach ($equipmentSlots as $slot => $label):
+                                    $item = isset($metadataEquipment[$slot]) ? trim((string)$metadataEquipment[$slot]) : '';
+                                    $display = ($item !== '') ? htmlspecialchars($item) : '<span style="color:#666">None</span>';
+                                ?>
+                                    <div style="color:rgb(242, 124, 17); font-weight:600;"><?= htmlspecialchars($label) ?></div>
+                                    <div style="border:1px solid #4a4a4a; border-radius:6px; padding:4px 8px;"><?= $display ?></div>
+                                <?php endforeach; ?>
+                            </div>
                             <?php endforeach; ?>
-                        </div>
                     <?php else: ?>
                         <div style="color:#9fb1c9;">No equipment data found in metadata.</div>
                     <?php endif; ?>

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -2226,8 +2226,8 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                         ];
                         ?>
                         <?php foreach ($equipmentGroups as $groupLabel => $equipmentSlots): ?>
-                            <div style="border:1px solid #3d4654; border-radius:8px; background:#20242b; padding:10px; margin:10px 0;">
-                                <div style="color:#f27c11; font-weight:700; margin-bottom:8px;"><?= htmlspecialchars($groupLabel) ?></div>
+                            <div style="color:#f27c11; font-weight:700; margin:10px 0 6px;"><?= htmlspecialchars($groupLabel) ?></div>
+                            <div style="border:1px solid #3d4654; border-radius:8px; background:#20242b; padding:10px; margin-bottom:10px;">
                                 <div style="display:grid; grid-template-columns: 180px 1fr; gap:8px;">
                                     <?php foreach ($equipmentSlots as $slot => $label):
                                         $item = isset($metadataEquipment[$slot]) ? trim((string)$metadataEquipment[$slot]) : '';

--- a/ui/core/player_management.php
+++ b/ui/core/player_management.php
@@ -780,6 +780,20 @@ if (!$isEmbed) {
         margin: 0 auto;
     }
 
+    .equipment-group {
+        border: 1px solid #3d4654;
+        border-radius: 8px;
+        background: #20242b;
+        padding: 12px;
+        margin: 12px 0;
+    }
+
+    .equipment-group-title {
+        color: #f27c11;
+        font-weight: 700;
+        margin-bottom: 10px;
+    }
+
     .equipment-slot { 
         padding: 12px;
         background: linear-gradient(135deg, rgba(26, 26, 26, 0.9), rgba(20, 20, 20, 0.95));
@@ -1369,20 +1383,22 @@ if (!$isEmbed) {
             <?php if (!empty($equipment)): ?>
                 <?php if ($hasEquipment): ?>
                     <?php foreach ($equipmentGroups as $groupLabel => $equipmentSlots): ?>
-                        <div class="section-subtitle" style="margin-top:12px;"><?php echo htmlspecialchars($groupLabel); ?></div>
-                        <div class="equipment-grid">
-                            <?php foreach ($equipmentSlots as $slot => $label):
-                                $itemName = isset($equipment[$slot]) && !empty($equipment[$slot]) ? $equipment[$slot] : null;
-                            ?>
-                            <div class="equipment-slot">
-                                <div class="equipment-slot-name"><?php echo htmlspecialchars($label); ?></div>
-                                <?php if ($itemName): ?>
-                                    <div class="equipment-item-name"><?php echo htmlspecialchars($itemName); ?></div>
-                                <?php else: ?>
-                                    <div class="equipment-empty">Empty</div>
-                                <?php endif; ?>
+                        <div class="equipment-group">
+                            <div class="equipment-group-title"><?php echo htmlspecialchars($groupLabel); ?></div>
+                            <div class="equipment-grid">
+                                <?php foreach ($equipmentSlots as $slot => $label):
+                                    $itemName = isset($equipment[$slot]) && !empty($equipment[$slot]) ? $equipment[$slot] : null;
+                                ?>
+                                <div class="equipment-slot">
+                                    <div class="equipment-slot-name"><?php echo htmlspecialchars($label); ?></div>
+                                    <?php if ($itemName): ?>
+                                        <div class="equipment-item-name"><?php echo htmlspecialchars($itemName); ?></div>
+                                    <?php else: ?>
+                                        <div class="equipment-empty">Empty</div>
+                                    <?php endif; ?>
+                                </div>
+                                <?php endforeach; ?>
                             </div>
-                            <?php endforeach; ?>
                         </div>
                     <?php endforeach; ?>
                 <?php else: ?>

--- a/ui/core/player_management.php
+++ b/ui/core/player_management.php
@@ -14,6 +14,7 @@ require_once($enginePath . "lib" . DIRECTORY_SEPARATOR . "core" . DIRECTORY_SEPA
 require_once($enginePath . "lib" . DIRECTORY_SEPARATOR . "core" . DIRECTORY_SEPARATOR . "llm_connector.class.php");
 require_once($enginePath . "lib" . DIRECTORY_SEPARATOR . "core" . DIRECTORY_SEPARATOR . "player.class.php");
 require_once($enginePath . "lib" . DIRECTORY_SEPARATOR . "core" . DIRECTORY_SEPARATOR . "tts_connector.class.php");
+require_once($enginePath . "lib" . DIRECTORY_SEPARATOR . "data_functions.php");
 require_once($enginePath . "lib" . DIRECTORY_SEPARATOR . "player_diary_connector.php");
 
 // Determine web root
@@ -1347,25 +1348,19 @@ if (!$isEmbed) {
 
         <!-- Equipment Card -->
         <?php
-        $equipmentSlots = [
-            'helmet' => 'Helmet',
-            'armor' => 'Armor',
-            'boots' => 'Boots',
-            'gloves' => 'Gloves',
-            'amulet' => 'Amulet',
-            'ring' => 'Ring',
-            'cape' => 'Cape',
-            'backpack' => 'Backpack',
-            'left_hand' => 'Left Hand',
-            'right_hand' => 'Right Hand'
+        $equipmentGroups = [
+            'Vanilla Slots' => chimEquipmentVanillaSlotLabels(),
+            'Modded Slots' => chimEquipmentModdedSlotLabels(),
         ];
 
         $hasEquipment = false;
-        foreach ($equipmentSlots as $slot => $label) {
-            $itemName = isset($equipment[$slot]) && !empty($equipment[$slot]) ? $equipment[$slot] : null;
-            if ($itemName) {
-                $hasEquipment = true;
-                break;
+        foreach ($equipmentGroups as $equipmentSlots) {
+            foreach ($equipmentSlots as $slot => $label) {
+                $itemName = isset($equipment[$slot]) && !empty($equipment[$slot]) ? $equipment[$slot] : null;
+                if ($itemName) {
+                    $hasEquipment = true;
+                    break 2;
+                }
             }
         }
         ?>
@@ -1373,20 +1368,23 @@ if (!$isEmbed) {
             <h2>Equipment</h2>
             <?php if (!empty($equipment)): ?>
                 <?php if ($hasEquipment): ?>
-                    <div class="equipment-grid">
-                        <?php foreach ($equipmentSlots as $slot => $label):
-                            $itemName = isset($equipment[$slot]) && !empty($equipment[$slot]) ? $equipment[$slot] : null;
-                        ?>
-                        <div class="equipment-slot">
-                            <div class="equipment-slot-name"><?php echo $label; ?></div>
-                            <?php if ($itemName): ?>
-                                <div class="equipment-item-name"><?php echo htmlspecialchars($itemName); ?></div>
-                            <?php else: ?>
-                                <div class="equipment-empty">Empty</div>
-                            <?php endif; ?>
+                    <?php foreach ($equipmentGroups as $groupLabel => $equipmentSlots): ?>
+                        <div class="section-subtitle" style="margin-top:12px;"><?php echo htmlspecialchars($groupLabel); ?></div>
+                        <div class="equipment-grid">
+                            <?php foreach ($equipmentSlots as $slot => $label):
+                                $itemName = isset($equipment[$slot]) && !empty($equipment[$slot]) ? $equipment[$slot] : null;
+                            ?>
+                            <div class="equipment-slot">
+                                <div class="equipment-slot-name"><?php echo htmlspecialchars($label); ?></div>
+                                <?php if ($itemName): ?>
+                                    <div class="equipment-item-name"><?php echo htmlspecialchars($itemName); ?></div>
+                                <?php else: ?>
+                                    <div class="equipment-empty">Empty</div>
+                                <?php endif; ?>
+                            </div>
+                            <?php endforeach; ?>
                         </div>
-                        <?php endforeach; ?>
-                    </div>
+                    <?php endforeach; ?>
                 <?php else: ?>
                     <div class="no-data">
                         <p><strong>No equipment currently equipped.</strong></p>


### PR DESCRIPTION
# ⚠️ ALL PR'S MUST BE SUBMITTED TO THE `UNSTABLE` BRANCH ⚠️

---

## What

- Adds shared equipment slot labels for vanilla and common modded biped slots.
- Includes modded equipment in compact profile context and full equipment prompt context.
- Separates equipment prompt output into Vanilla Slots and Modded Slots.
- Updates NPC Master and Player Management equipment views to display Vanilla Slots and Modded Slots.

## Screenshot

Not included.

## Why

CHIM only surfaced the standard Skyrim equipment slots plus a couple of existing special cases. This makes equipment context and UI aware of popular modded biped slots such as face/mouth, neck, cape/chest outer, back/backpack, pelvis, legs, face jewelry, chest under, shoulders, arms, and misc slots.

## Maintainer Discussion

- [x] I discussed this PR with `RANGROO` or `tyler.maister` in Discord.

## Related PRs

- CHIM plugin support: https://github.com/Dwemer-Dynamics/CHIM/pull/52

## Notes

Pairs with the CHIM plugin change that sends these slot keys through `gamedata.php` equipment updates.

Validation:
- `php -l .\lib\data_functions.php; php -l .\ui\core\npc_master.php; php -l .\ui\core\player_management.php`
- `git diff --check`