### PR TITLE
Store item keyword metadata

### DIFF
--- a/gamedata.php
+++ b/gamedata.php
@@ -353,9 +353,32 @@ function buildEquipmentMetadataValue(array $equipment): array
     foreach ($equipment as $slot => $item) {
         $equipmentData[$slot] = isset($item['name']) ? $item['name'] : '';
         $equipmentData[$slot . '_baseid'] = isset($item['baseid']) ? $item['baseid'] : '';
+        $equipmentData[$slot . '_keywords'] = isset($item['keywords'])
+            ? sanitizeItemKeywordList($item['keywords'])
+            : [];
     }
 
     return $equipmentData;
+}
+
+function sanitizeItemKeywordList($keywords): array
+{
+    if (!is_array($keywords)) {
+        return [];
+    }
+
+    $clean = [];
+    foreach ($keywords as $keyword) {
+        $keyword = trim((string)$keyword);
+        if ($keyword === '') {
+            continue;
+        }
+        if (!in_array($keyword, $clean, true)) {
+            $clean[] = $keyword;
+        }
+    }
+
+    return $clean;
 }
 
 function buildInventoryMetadataValue(array $items): array
@@ -367,6 +390,7 @@ function buildInventoryMetadataValue(array $items): array
                 'name' => $item['name'],
                 'baseid' => $item['baseid'],
                 'count' => intval($item['count']),
+                'keywords' => isset($item['keywords']) ? sanitizeItemKeywordList($item['keywords']) : [],
             ];
         }
     }


### PR DESCRIPTION
## What

- Preserve item keyword arrays from CHIM equipment payloads as `<slot>_keywords` metadata.
- Preserve item keyword arrays from CHIM inventory payloads as per-row `keywords` metadata.
- Sanitize keyword lists by keeping unique non-empty string values.

## Screenshot

Not applicable; storage-only backend change.

## Why

CHIM can now send raw runtime item keywords for player/NPC equipment and inventory. HerikaServer needs to store that metadata for future use without rendering it into prompts yet.

## Maintainer Discussion

- [x] I discussed this PR with RANGROO or tyler.maister in Discord.

## Related PRs

- CHIM: https://github.com/Dwemer-Dynamics/CHIM/pull/53

## Notes

- This PR does not add prompt rendering.
- No DB schema change is needed because the existing player/NPC metadata storage is JSON-backed.
- Tested with an in-game drop/pickup flow; `core_player.equipment` and `core_player.inventory` stored keyword arrays.