### PR TITLE
Fix AddNPC profile resolution for distributed names

### DIFF
--- a/processor/comm.php
+++ b/processor/comm.php
@@ -1407,8 +1407,6 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
     
     $splitNameBase=explode("@",$gameRequest[3]);
     $incomingDisplayName = trim($splitNameBase[0] ?? "");
-    $incomingBase = trim($splitNameBase[1] ?? "");
-    $incomingRefId = trim($splitNameBase[4] ?? "");
     if (sizeof($splitNameBase)>1) {
         $localName=$splitNameBase[0];
         $baseProfile=$splitNameBase[1];
@@ -1421,46 +1419,11 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
         $baseProfile="";
 
     $npcMaster=new NpcMaster();
-    $currentNpcData = null;
-    $retVal = 2;
-    $resolvedByRefId = false;
-
-    if ($incomingRefId !== "") {
-        $refIdCandidates = array_unique(array_filter([
-            $incomingRefId,
-            preg_replace('/^0x/i', '', $incomingRefId),
-            (stripos($incomingRefId, '0x') === 0 ? strtoupper(substr($incomingRefId, 2)) : strtoupper($incomingRefId)),
-            (stripos($incomingRefId, '0x') === 0 ? strtolower(substr($incomingRefId, 2)) : strtolower($incomingRefId)),
-        ], static function ($value) {
-            return $value !== null && $value !== "";
-        }));
-
-        foreach ($refIdCandidates as $refIdCandidate) {
-            $refNpcData = $npcMaster->getByRefId($refIdCandidate);
-            if (!$refNpcData) {
-                continue;
-            }
-
-            $existingBase = trim((string)($refNpcData["base"] ?? ""));
-            $sameBase = ($incomingBase === "" || $existingBase === "" || strcasecmp($incomingBase, $existingBase) === 0);
-            $looksLikeDistributedName = preg_match('/\[[^\]]+\]\s*$/', $incomingDisplayName) === 1;
-
-            if ($sameBase && ($looksLikeDistributedName || strcasecmp((string)$refNpcData["npc_name"], $incomingDisplayName) === 0)) {
-                $currentNpcData = $refNpcData;
-                $resolvedByRefId = true;
-                if (strcasecmp((string)$currentNpcData["npc_name"], $incomingDisplayName) !== 0) {
-                    error_log("[ADDNPC] resolved display name '{$incomingDisplayName}' to existing NPC '{$currentNpcData["npc_name"]}' by refid {$incomingRefId}");
-                }
-                $localName = $currentNpcData["npc_name"];
-                break;
-            }
-        }
-    }
-
-    if (!$currentNpcData) {
-        $retVal=createProfile($localName,[],false,$baseProfile); //1-NEW PROFILE, 2-PROFILE ALREADY EXISTS
-        $currentNpcData=$npcMaster->getByName($localName);
-    }
+    // Refids are not stable identity for profile creation: spawned actors, recycled refs,
+    // and modlist changes can make a new visible actor collide with an old profile row.
+    // Always create/resolve by the incoming visible name, then store refid as metadata below.
+    $retVal=createProfile($localName,[],false,$baseProfile); //1-NEW PROFILE, 2-PROFILE ALREADY EXISTS
+    $currentNpcData=$npcMaster->getByName($localName);
     audit_log("comm.php addnpc $localName");
 
      if ($retVal==1)
@@ -1469,7 +1432,7 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
 
     // Update new data
     
-    if (!$resolvedByRefId && isset($splitNameBase[4]) && $retVal==1) {
+    if (isset($splitNameBase[4]) && $retVal==1) {
         $currentNpcDataAlt=$npcMaster->getByRefId($splitNameBase[4]);
         if ($currentNpcDataAlt && $currentNpcDataAlt["npc_name"]!=$currentNpcData["npc_name"] ) {
             // Seems an NPC has changed name.


### PR DESCRIPTION
## What

- Removes the AddNPC pre-create lookup that resolved incoming actors by `refid`.
- Restores profile creation/resolution by the incoming visible actor name.
- Keeps refid as stored metadata and leaves the existing name-change diagnostic in place.

## Screenshot

Not applicable; backend AddNPC routing fix.

## Why

`refid` is not stable enough to decide NPC profile identity. Spawned actors, recycled refs, modlist/load-order changes, and name distributor mods can cause a new visible actor to collide with an old row. This caused cases like `Gudling [Solitude Guard]` being resolved to `Geimund [Solitude Guard]`, preventing Gudling from getting a profile and making conversation fall back to narrator behavior.

## Maintainer Discussion

- [x] I discussed this PR with `RANGROO` or `tyler.maister` in Discord.

## Related PRs

None.

## Notes

- Fixes regression from `b2069bbc9d9b1b4213457052405500691a275184`.
- Refid remains stored on the profile after creation; it is no longer used as the identity resolver for AddNPC.
- Validation: `php -l processor\\comm.php`, `git diff --check`.