### PR TITLE
Configurable Prompt Context Detail Policies

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -469,7 +469,7 @@ function chimFormatEquipmentPromptLines(array $equipmentData, array $slotLabels,
     return $equipmentParts;
 }
 
-function chimFormatProfileEquipmentParts(array $equipmentData, array $slots): array {
+function chimFormatProfileEquipmentParts(array $equipmentData, array $slots, bool $includeDescriptions = true): array {
     $equipmentParts = [];
     $describedBaseids = [];
 
@@ -489,7 +489,7 @@ function chimFormatProfileEquipmentParts(array $equipmentData, array $slots): ar
         $description = null;
         $baseidKey = $baseid !== '' ? strtoupper($baseid) : '';
 
-        if ($baseidKey === '' || !in_array($baseidKey, $describedBaseids, true)) {
+        if ($includeDescriptions && ($baseidKey === '' || !in_array($baseidKey, $describedBaseids, true))) {
             $description = chimLookupItemDescriptionForContext($itemName, $baseid);
             if ($description !== null && $baseidKey !== '') {
                 $describedBaseids[] = $baseidKey;
@@ -846,6 +846,21 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
     // Not always the same order
     shuffle($actorDetailedList);
     // error_log("[DataLastInfoFor] $actorsInRangeList");
+
+    $nearbyContextOptionEnabled = function (string $bucket, string $id, bool $default = true): bool {
+        if (function_exists('chimPromptContextOptionEnabled')) {
+            return chimPromptContextOptionEnabled($bucket, $id);
+        }
+        return $default;
+    };
+    $nearbyActorsIncludeBasicSummary = $nearbyContextOptionEnabled('enabled_nearby_actor_subsections', 'basic_summary');
+    $nearbyActorsIncludeAppearance = $nearbyContextOptionEnabled('enabled_nearby_actor_subsections', 'appearance');
+    $nearbyActorsIncludeEquipment = $nearbyContextOptionEnabled('enabled_nearby_actor_subsections', 'equipment');
+    $nearbyActorsEquipmentDescriptions = $nearbyContextOptionEnabled('enabled_nearby_actor_subsections', 'equipment_descriptions');
+    $nearbyActorsIncludeActivity = $nearbyContextOptionEnabled('enabled_nearby_actor_subsections', 'current_activity');
+    $nearbyActorsIncludePower = $nearbyContextOptionEnabled('enabled_nearby_actor_subsections', 'power_awareness');
+    $nearbyActorsIncludeFactions = $nearbyContextOptionEnabled('enabled_nearby_actor_subsections', 'factions');
+    $nearbyActorsIncludeCustomState = $nearbyContextOptionEnabled('enabled_nearby_actor_subsections', 'custom_state');
     
     // Track seen faction descriptions to avoid duplicates
     $seenFactionFormIDs = [];
@@ -895,14 +910,14 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                     $playerBio = chimNormalizePlayerProfileBio(ResolvePlayerBackstory($player), $actor);
                     $bioKnownByAll = filter_var((string)($player->get('bio_known_by_all') ?? ''), FILTER_VALIDATE_BOOLEAN);
                     $isNarrator = isset($GLOBALS["HERIKA_NAME"]) && strcasecmp((string)$GLOBALS["HERIKA_NAME"], "The Narrator") === 0;
-                    if ($playerBio !== "" && ($bioKnownByAll || $isNarrator)) {
+                    if ($nearbyActorsIncludeBasicSummary && $playerBio !== "" && ($bioKnownByAll || $isNarrator)) {
                         $profileString .= ": " . trim($playerBio);
                         $hasProfileBody = true;
                     }
 
                     // Add appearance if available
                     $appearance = $player->get('appearance');
-                    if (!empty($appearance)) {
+                    if ($nearbyActorsIncludeAppearance && !empty($appearance)) {
                         if ($hasProfileBody) {
                             $profileString .= ". Appearance: " . trim($appearance);
                         } else {
@@ -913,10 +928,10 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                     
                     // Add equipment if available
                     $equipmentData = $player->getJson('equipment');
-                    if (is_array($equipmentData) && !empty($equipmentData)) {
+                    if ($nearbyActorsIncludeEquipment && is_array($equipmentData) && !empty($equipmentData)) {
                         $slots = chimEquipmentProfileSlotKeys();
                         $slots = chimProfileEquipmentSlotsFromData($equipmentData, $slots);
-                        $equipmentParts = chimFormatProfileEquipmentParts($equipmentData, $slots);
+                        $equipmentParts = chimFormatProfileEquipmentParts($equipmentData, $slots, $nearbyActorsEquipmentDescriptions);
                         if (!empty($equipmentParts)) {
                             if ($hasProfileBody) {
                                 $profileString .= ". Equipment: " . implode(", ", $equipmentParts);
@@ -927,20 +942,22 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                         }
                     }
 
-                    $profileExtra = chimBuildActorProfileEnrichmentText($actor, "player", [
-                        "source" => "nearby_actors",
-                    ]);
-                    if ($profileExtra !== "") {
-                        if ($hasProfileBody) {
-                            $profileString .= ". " . $profileExtra;
-                        } else {
-                            $profileString .= ": " . $profileExtra;
-                            $hasProfileBody = true;
+                    if ($nearbyActorsIncludeCustomState) {
+                        $profileExtra = chimBuildActorProfileEnrichmentText($actor, "player", [
+                            "source" => "nearby_actors",
+                        ]);
+                        if ($profileExtra !== "") {
+                            if ($hasProfileBody) {
+                                $profileString .= ". " . $profileExtra;
+                            } else {
+                                $profileString .= ": " . $profileExtra;
+                                $hasProfileBody = true;
+                            }
                         }
                     }
                     
                     // Power Awareness: Add relative power assessment for player
-                    if (isset($GLOBALS["POWER_AWARENESS_ENABLED"]) && $GLOBALS["POWER_AWARENESS_ENABLED"]) {
+                    if ($nearbyActorsIncludePower && isset($GLOBALS["POWER_AWARENESS_ENABLED"]) && $GLOBALS["POWER_AWARENESS_ENABLED"]) {
                         require_once(__DIR__ . DIRECTORY_SEPARATOR . "power_awareness.php");
                         
                         // Get player's level
@@ -995,15 +1012,17 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                         $reanimationText = " This person has been reanimated from death as a zombie.";
                     }
                     
-                    $profileString = "{$nameWithRaceGender}: " . trim("{$currentNpcData["core"]}{$reanimationText}");
+                    $profileString = $nearbyActorsIncludeBasicSummary
+                        ? "{$nameWithRaceGender}: " . trim("{$currentNpcData["core"]}{$reanimationText}")
+                        : "{$nameWithRaceGender}";
                     
                     // Add appearance if available
-                    if (!empty($currentNpcData["appearance"])) {
+                    if ($nearbyActorsIncludeAppearance && !empty($currentNpcData["appearance"])) {
                         $profileString .= ". Appearance: " . trim($currentNpcData["appearance"]);
                     }
                     
                     // Add zombie appearance if reanimated
-                    if (empty($GLOBALS["DISABLE_REANIMATION_TRACKING"]) && isset($extendedData["reanimated"]) && $extendedData["reanimated"] === true) {
+                    if ($nearbyActorsIncludeAppearance && empty($GLOBALS["DISABLE_REANIMATION_TRACKING"]) && isset($extendedData["reanimated"]) && $extendedData["reanimated"] === true) {
                         $zombieAppearance = "Their skin has a deathly pale, greyish pallor with a corpse-like appearance. Their eyes are glazed and lifeless, and their movements are stiff and unnatural";
                         if (!empty($currentNpcData["appearance"])) {
                             $profileString .= ". " . $zombieAppearance;
@@ -1024,7 +1043,7 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                     }
                     
                     // Power Awareness: Add relative power assessment
-                    if (isset($GLOBALS["POWER_AWARENESS_ENABLED"]) && $GLOBALS["POWER_AWARENESS_ENABLED"]) {
+                    if ($nearbyActorsIncludePower && isset($GLOBALS["POWER_AWARENESS_ENABLED"]) && $GLOBALS["POWER_AWARENESS_ENABLED"]) {
                         require_once(__DIR__ . DIRECTORY_SEPARATOR . "power_awareness.php");
                         
                         // Get current NPC's level
@@ -1042,14 +1061,14 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                     }
 
                     $activityStatus = chimNormalizeActivityStatus($metaData);
-                    if (!empty($activityStatus['fresh']) && !empty($activityStatus['summary'])) {
+                    if ($nearbyActorsIncludeActivity && !empty($activityStatus['fresh']) && !empty($activityStatus['summary'])) {
                         $profileString .= ". Current activity: " . $activityStatus['summary'];
                     }
                     
                     // Add equipment if available
-                    if (isset($metaData["equipment"]) && is_array($metaData["equipment"])) {
+                    if ($nearbyActorsIncludeEquipment && isset($metaData["equipment"]) && is_array($metaData["equipment"])) {
                         $slots = chimEquipmentProfileSlotKeys();
-                        $equipmentParts = chimFormatProfileEquipmentParts($metaData["equipment"], $slots);
+                        $equipmentParts = chimFormatProfileEquipmentParts($metaData["equipment"], $slots, $nearbyActorsEquipmentDescriptions);
                         if (!empty($equipmentParts)) {
                             $profileString .= ". Equipment: " . implode(", ", $equipmentParts);
                         }
@@ -1065,18 +1084,20 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                         }
                     }
 
-                    $profileExtra = chimBuildActorProfileEnrichmentText($npcName, "npc", [
-                        "source" => "nearby_actors",
-                        "metadata" => $metaData,
-                        "npc_data" => $currentNpcData,
-                    ]);
-                    if ($profileExtra !== "") {
-                        $profileString .= ". " . $profileExtra;
+                    if ($nearbyActorsIncludeCustomState) {
+                        $profileExtra = chimBuildActorProfileEnrichmentText($npcName, "npc", [
+                            "source" => "nearby_actors",
+                            "metadata" => $metaData,
+                            "npc_data" => $currentNpcData,
+                        ]);
+                        if ($profileExtra !== "") {
+                            $profileString .= ". " . $profileExtra;
+                        }
                     }
                     
                     // Add faction information after equipment
                     $extendedData = $npcMaster->getExtendedData($currentNpcData);
-                    if (isset($extendedData['factions']) && is_array($extendedData['factions']) && count($extendedData['factions']) > 0) {
+                    if ($nearbyActorsIncludeFactions && isset($extendedData['factions']) && is_array($extendedData['factions']) && count($extendedData['factions']) > 0) {
                         $factionNames = [];
                         foreach ($extendedData['factions'] as $faction) {
                             if (isset($faction['formid'])) {
@@ -1164,6 +1185,8 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
     }
     
     // Add nearby items to context if available
+    $nearbyItemsIncludeDescriptions = $nearbyContextOptionEnabled('enabled_nearby_item_subsections', 'item_descriptions');
+    $nearbyItemsGroupDuplicates = $nearbyContextOptionEnabled('enabled_nearby_item_subsections', 'group_duplicates', false);
     $itemsInRange = DataItemsInCloseRange();
     
     if (!empty($itemsInRange)) {
@@ -1174,7 +1197,7 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
         $groupedItems = [];
         $playerName = $GLOBALS["PLAYER_NAME"] ?? "Player";
         $playerLookingTag = " ({$playerName} is looking at this)";
-        $shorterNearbyItemList = !empty($GLOBALS["SHORTER_NEARBY_ITEM_LIST"]);
+        $shorterNearbyItemList = $nearbyItemsGroupDuplicates;
         
         foreach ($itemsList as $item) {
             $trimmedItem = trim($item);
@@ -1207,7 +1230,9 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                     
                     if ($descRecord && !empty($descRecord['description'])) {
                         // Store description under clean name (without STEALING tag)
-                        $itemDescriptions[$itemNameClean] = $descRecord['description'];
+                        if ($nearbyItemsIncludeDescriptions) {
+                            $itemDescriptions[$itemNameClean] = $descRecord['description'];
+                        }
                         $hasDescription = true;
                     }
                 }
@@ -1224,11 +1249,11 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                             'count' => 0,
                             'sample_refid' => $refID,
                             'sample_item_name' => $itemName,
-                            'description' => $itemDescriptions[$itemNameClean] ?? '',
+                        'description' => $nearbyItemsIncludeDescriptions ? ($itemDescriptions[$itemNameClean] ?? '') : '',
                         ];
                     }
                     $groupedItems[$groupKey]['count']++;
-                    if (empty($groupedItems[$groupKey]['description']) && !empty($itemDescriptions[$itemNameClean])) {
+                    if ($nearbyItemsIncludeDescriptions && empty($groupedItems[$groupKey]['description']) && !empty($itemDescriptions[$itemNameClean])) {
                         $groupedItems[$groupKey]['description'] = $itemDescriptions[$itemNameClean];
                     }
                 } else {
@@ -1279,7 +1304,7 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
             
             // Add descriptions for unique items if available
             $descriptionText = "";
-            if ($shorterNearbyItemList) {
+            if ($nearbyItemsIncludeDescriptions && $shorterNearbyItemList) {
                 $descParts = [];
                 foreach ($groupedItems as $group) {
                     if (!empty($group['description'])) {
@@ -1289,7 +1314,7 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                 if (!empty($descParts)) {
                     $descriptionText = "\n\n# ITEM DESCRIPTIONS\n## " . implode("\n## ", $descParts);
                 }
-            } elseif (!empty($itemDescriptions)) {
+            } elseif ($nearbyItemsIncludeDescriptions && !empty($itemDescriptions)) {
                 $descParts = [];
                 foreach ($itemDescriptions as $name => $desc) {
                     $descParts[] = "{$name}: {$desc}";

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -614,6 +614,51 @@ if (!function_exists('chimGetPromptContextOptionCatalog')) {
                     'description' => 'Current and recent plan/task summary.',
                 ],
             ],
+            'enabled_nearby_actor_subsections' => [
+                'basic_summary' => [
+                    'label' => 'Basic summary',
+                    'description' => 'Nearby actor profile summary or short biography.',
+                ],
+                'appearance' => [
+                    'label' => 'Appearance',
+                    'description' => 'Nearby actor physical appearance and visible traits.',
+                ],
+                'equipment' => [
+                    'label' => 'Equipment',
+                    'description' => 'Nearby actor currently equipped gear and worn items.',
+                ],
+                'equipment_descriptions' => [
+                    'label' => 'Equipment descriptions',
+                    'description' => 'Adds item descriptions to nearby actor equipment when available.',
+                ],
+                'current_activity' => [
+                    'label' => 'Current activity',
+                    'description' => 'What nearby actors are currently doing.',
+                ],
+                'power_awareness' => [
+                    'label' => 'Power awareness',
+                    'description' => 'Relative strength assessment for nearby actors when power awareness is enabled.',
+                ],
+                'factions' => [
+                    'label' => 'Factions',
+                    'description' => 'Faction names and group descriptions for nearby actors.',
+                ],
+                'custom_state' => [
+                    'label' => 'Custom state',
+                    'description' => 'Custom plugin state attached to nearby actor profile lines.',
+                ],
+            ],
+            'enabled_nearby_item_subsections' => [
+                'group_duplicates' => [
+                    'label' => 'Group duplicates',
+                    'description' => 'Groups duplicate nearby ground items into counted entries.',
+                    'default_enabled' => false,
+                ],
+                'item_descriptions' => [
+                    'label' => 'Item descriptions',
+                    'description' => 'Adds item descriptions for nearby ground items when available.',
+                ],
+            ],
         ];
     }
 }
@@ -624,7 +669,12 @@ if (!function_exists('chimGetDefaultPromptContextOptions')) {
         $catalog = chimGetPromptContextOptionCatalog();
         $defaults = [];
         foreach ($catalog as $bucket => $options) {
-            $defaults[$bucket] = array_keys($options);
+            $defaults[$bucket] = [];
+            foreach ($options as $id => $meta) {
+                if (!isset($meta['default_enabled']) || $meta['default_enabled'] !== false) {
+                    $defaults[$bucket][] = $id;
+                }
+            }
         }
 
         return $defaults;

--- a/ui/global_settings.php
+++ b/ui/global_settings.php
@@ -35,17 +35,18 @@ include(__DIR__ . DIRECTORY_SEPARATOR . "tmpl" . DIRECTORY_SEPARATOR . "head.htm
 $saveSuccess = isset($_GET['_saved']) && $_GET['_saved'] === '1';
 $clearReanimationResult = null;
 $promptContextSectionTitle = 'Context Selections';
+$promptContextOptionFields = [
+    [ 'name' => 'MAGIC_EVENT_BLACKLIST', 'type' => 'longstring' ],
+    [ 'name' => 'LOCATION_BLACKLIST', 'type' => 'longstring' ],
+    [ 'name' => 'ITEM_BLACKLIST', 'type' => 'longstring' ],
+    [ 'name' => 'EVENT_TYPE_FILTER', 'type' => 'longstring' ],
+];
 
 $gsSections = [
     'Prompt' => [
         [ 'name' => 'PROMPT_HEAD', 'type' => 'longstring' ],
         [ 'name' => 'EMOTEMOODS', 'type' => 'longstring' ],
         [ 'name' => 'DETECT_MAGIC_EVENT', 'type' => 'boolean' ],
-        [ 'name' => 'MAGIC_EVENT_BLACKLIST', 'type' => 'longstring' ],
-        [ 'name' => 'LOCATION_BLACKLIST', 'type' => 'longstring' ],
-        [ 'name' => 'ITEM_BLACKLIST', 'type' => 'longstring' ],
-        [ 'name' => 'SHORTER_NEARBY_ITEM_LIST', 'type' => 'boolean' ],
-        [ 'name' => 'EVENT_TYPE_FILTER', 'type' => 'longstring' ],
     ],
     'Rechat' => [
         [ 'name' => 'RECHAT_MODE', 'type' => 'select', 'values' => ['tight', 'conversational', 'group', 'random'] ],
@@ -78,7 +79,7 @@ $gsSections = [
         [ 'name' => 'TRANSFORMATION_DETECTION', 'type' => 'boolean' ],
         [ 'name' => 'PROMPT_TIMESTAMP', 'type' => 'boolean' ],
     ],
-    $promptContextSectionTitle => [],
+    $promptContextSectionTitle => $promptContextOptionFields,
     'Misc' => [
         [ 'name' => 'AUTO_LOCK_PROFILE', 'type' => 'boolean' ],
         [ 'name' => 'AUTOFILL_CUSTOM_PROFILES', 'type' => 'boolean' ],
@@ -142,7 +143,6 @@ function pretty_label(string $flatName): string
         'RELLLM_CONNECTOR' => 'Relationship Management',
         'EMOTEMOODS' => 'Emote Moods',
         'ENFORCE_STRICT_RECHAT_RESPONSE' => 'Strict Rechat Targeting',
-        'SHORTER_NEARBY_ITEM_LIST' => 'Shorter Nearby Item List',
         'BGL_TRIGGER_DAYS' => 'Background Life Days Cooldown',
         'CLEAN_CONTEXT_FOCUS_CHAT_HISTORY' => 'Focus Chat Context',
         'CHIM_AI_QUEST_PROGRESSION' => 'CHIM AI Quest Progression (Beta)',
@@ -240,6 +240,8 @@ function prompt_context_bucket_title(string $bucket): string
         'enabled_character_subsections' => 'Character Subsections',
         'enabled_appearance_subsections' => 'Appearance / State Subsections',
         'enabled_general_subsections' => 'General Instruction Subsections',
+        'enabled_nearby_actor_subsections' => 'Nearby Actor Details',
+        'enabled_nearby_item_subsections' => 'Nearby Item Details',
     ];
 
     return $labels[$bucket] ?? $bucket;
@@ -367,12 +369,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_all'])) {
         }
     }
 
-    $postedPromptContextOptions = chimNormalizePromptContextOptions([
-        'enabled_sections' => array_values(array_map('strval', $_POST['prompt_context_enabled_sections'] ?? [])),
-        'enabled_character_subsections' => array_values(array_map('strval', $_POST['prompt_context_enabled_character_subsections'] ?? [])),
-        'enabled_appearance_subsections' => array_values(array_map('strval', $_POST['prompt_context_enabled_appearance_subsections'] ?? [])),
-        'enabled_general_subsections' => array_values(array_map('strval', $_POST['prompt_context_enabled_general_subsections'] ?? [])),
-    ]);
+    $postedPromptContextRaw = [];
+    foreach ($promptContextCatalog as $bucket => $_options) {
+        $postedPromptContextRaw[$bucket] = array_values(array_map('strval', $_POST['prompt_context_' . $bucket] ?? []));
+    }
+    $postedPromptContextOptions = chimNormalizePromptContextOptions($postedPromptContextRaw);
     $promptContextDescription = current_description('PROMPT_CONTEXT_OPTIONS', $generalSettingRowMap);
     if (!chimSetGeneralSetting('PROMPT_CONTEXT_OPTIONS', $postedPromptContextOptions, $promptContextDescription)) {
         $didSave = false;
@@ -1231,6 +1232,61 @@ h1.gs-title {
                                         </div>
                                     </div>
                                 <?php endforeach; ?>
+                                <div class="prompt-context-group">
+                                    <h3>Context Options</h3>
+                                    <div class="provider-grid">
+                                        <?php foreach ($fields as $field): ?>
+                                            <?php
+                                            $fieldName = $field['name'];
+                                            $fieldType = strval($field['type']);
+                                            $current = current_value($fieldName);
+                                            $label = pretty_label($fieldName);
+                                            $help = current_description($fieldName, $generalSettingRowMap);
+                                            $schemaDefinition = chimGetSchemaDefinition($fieldName);
+                                            $isReadonly = isset($schemaDefinition['readonly']) && $schemaDefinition['readonly'] === true;
+                                            $readonlyAttr = $isReadonly ? 'readonly' : '';
+                                            ?>
+                                            <div class="provider-card">
+                                                <div class="provider-head">
+                                                    <div class="provider-title">
+                                                        <div class="provider-icon"><?php echo icon_for_field($fieldName); ?></div>
+                                                        <div><?php echo htmlspecialchars($label); ?></div>
+                                                        <?php if ($fieldType === 'boolean'): ?>
+                                                            <div class="provider-toggle">
+                                                                <input type="hidden" name="<?php echo htmlspecialchars($fieldName); ?>" value="false">
+                                                                <input type="checkbox" name="<?php echo htmlspecialchars($fieldName); ?>" value="true" <?php echo ($current ? 'checked' : ''); ?> <?php echo $isReadonly ? 'disabled' : ''; ?>>
+                                                            </div>
+                                                        <?php endif; ?>
+                                                    </div>
+                                                </div>
+                                                <div class="provider-body">
+                                                    <?php if ($fieldType === 'longstring'): ?>
+                                                        <?php if (isset($filterBrowseFieldConfigs[$fieldName])): ?>
+                                                            <?php $browseConfig = $filterBrowseFieldConfigs[$fieldName]; ?>
+                                                            <div class="filter-browse-wrap">
+                                                                <textarea name="<?php echo htmlspecialchars($fieldName); ?>" rows="4" <?php echo $readonlyAttr; ?>><?php echo htmlspecialchars(strval($current)); ?></textarea>
+                                                                <?php if (!$isReadonly): ?>
+                                                                    <button
+                                                                        type="button"
+                                                                        class="btn-filter-browse js-filter-browse"
+                                                                        data-field="<?php echo htmlspecialchars($fieldName); ?>"
+                                                                    >
+                                                                        <?php echo htmlspecialchars(strval($browseConfig['button_label'] ?? 'Recent...')); ?>
+                                                                    </button>
+                                                                <?php endif; ?>
+                                                            </div>
+                                                        <?php else: ?>
+                                                            <textarea name="<?php echo htmlspecialchars($fieldName); ?>" rows="4" <?php echo $readonlyAttr; ?>><?php echo htmlspecialchars(strval($current)); ?></textarea>
+                                                        <?php endif; ?>
+                                                    <?php endif; ?>
+                                                    <?php if (!empty($help)): ?>
+                                                        <p class="provider-help"><?php echo render_provider_help($fieldName, $help, $webRoot); ?></p>
+                                                    <?php endif; ?>
+                                                </div>
+                                            </div>
+                                        <?php endforeach; ?>
+                                    </div>
+                                </div>
                             </div>
                             <?php continue; ?>
                         <?php endif; ?>


### PR DESCRIPTION
## What

- Extends the existing Context Selections checkbox system with new `Nearby Actor Details` and `Nearby Item Details` groups.
- Nearby Actor Details controls which parts of `<nearby_actors>` are rendered: basic summary, appearance, equipment, equipment descriptions, current activity, power awareness, factions, and custom state.
- Nearby Item Details controls duplicate grouping and item descriptions for `<nearby_items>`.
- Moves context-related filters into Context Selections under Context Options: magic event blacklist, location blacklist, item blacklist, and event type filter.

## Screenshot

N/A

## Why

Nearby actor and item context can consume a lot of tokens when every actor includes full profile, equipment, item descriptions, factions, and custom state. This keeps configuration simple by using the same checkbox model as the rest of Context Selections instead of a separate detail-policy system.

## Maintainer Discussion

- [x] I discussed this PR with `RANGROO` or `tyler.maister` in Discord.

## Related PRs

N/A

## Notes

- Defaults preserve current behavior for nearby actors and item descriptions.
- Nearby item duplicate grouping defaults off and replaces the old Shorter Nearby Item List UI control.
- Verified with PHP syntax checks for touched PHP files and JSON validation for `conf_schema.json`.
- Deployed locally successfully earlier in the branch; latest rework was syntax-checked after simplification.