### PR TITLE
Fix cross-NPC context bleed, dialogue misattribution, and scene notes bleeding across saves

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -2435,6 +2435,16 @@ function buildHistoricContext($actor, $lastNelements = -10,$sqlfilter="") {
      or people like '%|$actorEscaped (in combat)|%'
      or people like '%|$actorEscaped (restrained)|%'
      or type='info_timeforward'
+    )
+    AND (
+     -- Cross-NPC bleed fix: 'people' is proximity-stamped (every nearby NPC), so without this an NPC's
+     -- context pulled in every bystander's verbatim dialogue and they echoed each other. For actual NPC
+     -- dialogue (chat/prechat) keep ONLY this NPC's own lines or lines addressed TO it; non-dialogue rows
+     -- (infoaction/itemfound/etc.) stay broad so situational awareness is preserved. Player input is its
+     -- own type and is unaffected.
+     type not in ('chat','prechat')
+     or data ilike '$actorEscaped:%'
+     or data ilike '%(talking to $actorEscaped)%'
     )" : " ").
     //((false)?" and gamets>".($currentGameTs-(60*60*60*60)):"").
     " {$ext_sqlfilter2} 
@@ -2549,7 +2559,10 @@ function buildHistoricContext($actor, $lastNelements = -10,$sqlfilter="") {
         } else if ($row["subtype"]=="MEMORY") {
             $speaker = "memory";
             
-        } else if ((strpos($rowData, "{$GLOBALS["HERIKA_NAME"]}:") !== false) && (strpos($rowData, "The Narrator:") === false)) {
+        } else if ((strpos($rowData, "{$GLOBALS["HERIKA_NAME"]}:") === 0) && (strpos($rowData, "The Narrator:") === false)) {
+            // Only a line that STARTS with "<thisNPC>:" is this NPC's own turn (assistant). Using !== false
+            // here matched the name ANYWHERE, so another NPC's line that merely contained "<thisNPC>:" was
+            // mis-claimed as this NPC's own line -> cross-NPC identity bleed. Mirrors the player/narrator checks below.
             $speaker = "assistant";
             
         } else if ((strpos($rowData, "{$GLOBALS["PLAYER_NAME"]}:") === 0)) {

--- a/main.php
+++ b/main.php
@@ -223,6 +223,16 @@ if (in_array($gameRequest[0],["addnpc"])) {
 
 if (($gameRequest[0]=="playerinfo")||(($gameRequest[0]=="newgame"))) {
     sleep(1);   // Give time to populate data
+
+    // Load/newgame is a hard scene boundary. Rolemaster scene notes are transient
+    // director state; do not let them bleed across save/load into normal chat.
+    try {
+        $db->delete("rolemaster", "type='scenenote'");
+        $db->delete("responselog", "sent=0 and actor='rolemaster' and (action like 'rolecommand|Instruction@%' or action like 'rolecommand|Suggestion@%')");
+        Logger::info("[main] Cleared transient rolemaster scene state on {$gameRequest[0]}");
+    } catch (Exception $e) {
+        Logger::warn("[main] Failed to clear transient rolemaster scene state on {$gameRequest[0]}: " . $e->getMessage());
+    }
 }
 
 // Misc events, some of them can terminate the request


### PR DESCRIPTION
Three small, unrelated-to-each-other correctness fixes from extended live use, batched because they're each a few lines:

1. **Cross-NPC context bleed** (`lib/data_functions.php`): the `people` column is proximity-stamped, so an NPC's context query pulled in every nearby bystander's verbatim dialogue — NPCs would echo each other's lines. For `chat`/`prechat` rows the query now keeps only the NPC's own lines or lines addressed to it; non-dialogue rows stay broad so situational awareness is unchanged.

2. **Dialogue misattribution** (`lib/data_functions.php`): a history row counted as this NPC's own turn if `"Name:"` matched *anywhere* in it, so another NPC's line that merely mentioned the name was misfiled as assistant history. Now requires the match at position 0.

3. **Scene notes bleeding across saves** (`main.php`): rolemaster scene notes and undelivered role instructions are transient director state, but they survived load/newgame and leaked into normal chat on a different timeline. Cleared at the load boundary.

Happy to split further or adjust if you'd prefer.