### PR TITLE
Relationship system: preserve manual edits, narrator exclusion, extension character facts, hardening

### DIFF
--- a/ext/relationship_system/analyze_relationships.php
+++ b/ext/relationship_system/analyze_relationships.php
@@ -37,6 +37,7 @@ require_once $enginePath . "lib/core/api_badge.class.php";
 require_once $enginePath . "lib/core/npc_master.class.php";
 require_once $enginePath . "lib/core/core_profiles.class.php";
 require_once $enginePath . "lib/logger.php";
+require_once $enginePath . "lib/relationship_manager.php";
 require_once __DIR__ . "/event_baseline.php";
 
 // Get POST data
@@ -291,18 +292,7 @@ PROMPT;
             $type = 'neutral';
         }
 
-        // Normalize player name references to "Player"
-        // If target matches actual player name, #PLAYER_NAME#, or common variants, store as "Player"
-        $targetLower = strtolower(trim($target));
-        $playerLower = strtolower($playerName);
-        if ($targetLower === $playerLower ||
-            $targetLower === '#player_name#' ||
-            $targetLower === 'player' ||
-            $targetLower === 'the player' ||
-            $targetLower === 'dragonborn' ||
-            $targetLower === 'the dragonborn') {
-            $target = 'Player';
-        }
+        $target = RelationshipManager::normalizeTargetName($target);
 
         $relationships[$target] = [
             'aff' => $aff,

--- a/ext/relationship_system/npc_save_handler.php
+++ b/ext/relationship_system/npc_save_handler.php
@@ -18,6 +18,9 @@
 if (!class_exists('Logger')) {
     require_once $GLOBALS["ENGINE_PATH"] . "lib/logger.php";
 }
+if (!class_exists('RelationshipManager')) {
+    require_once $GLOBALS["ENGINE_PATH"] . "lib/relationship_manager.php";
+}
 
 // Only process if relationships_jsonb was submitted
 if (isset($_POST['relationships_jsonb']) && $_POST['relationships_jsonb'] !== '') {
@@ -25,6 +28,8 @@ if (isset($_POST['relationships_jsonb']) && $_POST['relationships_jsonb'] !== ''
     $relData = json_decode($relJsonbRaw, true);
 
     if (is_array($relData)) {
+        $relData = RelationshipManager::normalizeRelationshipMap($relData);
+
         // Get existing extended_data
         $extRaw = isset($_POST['extended_data']) ? (string)$_POST['extended_data'] : '{}';
         $extData = json_decode($extRaw, true);
@@ -37,6 +42,12 @@ if (isset($_POST['relationships_jsonb']) && $_POST['relationships_jsonb'] !== ''
 
         // Merge the new relationships
         $extData['relationships'] = $relData;
+
+        // RELATIONSHIP LOCK: persist the editor's lock checkbox (hidden field always submits 0/1) so the relationship
+        // model skips this NPC and stops overwriting manual edits.
+        if (isset($_POST['relationships_locked'])) {
+            $extData['relationships_locked'] = filter_var($_POST['relationships_locked'], FILTER_VALIDATE_BOOLEAN);
+        }
 
         // Log the changes
         $npcName = $_POST['npc_name'] ?? 'Unknown';
@@ -70,7 +81,10 @@ if (isset($_POST['relationships_jsonb']) && $_POST['relationships_jsonb'] !== ''
             Logger::info("[REL-UI] {$npcName}: {$changeCount} relationship change(s) saved via UI");
         }
 
-        // Update extended_data in POST
+        // Update extended_data in POST. The structured editor is authoritative;
+        // prevent the deprecated legacy textarea named "relationships" from
+        // being treated as a relationship seed later by NpcMaster normalization.
         $_POST['extended_data'] = json_encode($extData, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        unset($_POST['relationships'], $_POST['npc_relationships']);
     }
 }

--- a/ext/relationship_system/postrequest.php
+++ b/ext/relationship_system/postrequest.php
@@ -85,10 +85,9 @@ function _relIsValidNpcTarget($name) {
  * Helper: Get NPC ID by name
  */
 function _relGetNpcIdByName($npcName) {
-    $escapedName = $GLOBALS["db"]->escape($npcName);
-    $npcRow = $GLOBALS["db"]->fetchOne(
-        "SELECT id FROM core_npc_master WHERE npc_name = '" . $escapedName . "' LIMIT 1"
-    );
+    // Full ladder: dialogue-parsed names can drift from the row's spelling (rename mods).
+    require_once $GLOBALS["ENGINE_PATH"] . "lib/relationship_manager.php";
+    $npcRow = RelationshipManager::resolveNpcByName($npcName);
     return $npcRow ? intval($npcRow['id']) : null;
 }
 

--- a/ext/relationship_system/postrequest.php
+++ b/ext/relationship_system/postrequest.php
@@ -210,6 +210,20 @@ if (!empty($GLOBALS["HERIKA_ID"])) {
     }
 }
 
+// RELATIONSHIP LOCK: if this NPC's relationships are locked in the editor, the model must
+// NOT re-evaluate or overwrite them - manual edits are authoritative. This is why hand-edited relationships kept
+// reverting: the model re-classified them every interaction. Locked NPCs are skipped entirely.
+if ($npcId) {
+    $relLockRow = $GLOBALS["db"]->fetchOne("SELECT extended_data FROM core_npc_master WHERE id = " . (int)$npcId . " LIMIT 1");
+    if ($relLockRow && !empty($relLockRow['extended_data'])) {
+        $relLockExt = json_decode((string)$relLockRow['extended_data'], true);
+        if (is_array($relLockExt) && !empty($relLockExt['relationships_locked'])) {
+            Logger::info("[REL] {$npcName} relationships are LOCKED in the editor - skipping AI re-evaluation (manual edits preserved)");
+            return;
+        }
+    }
+}
+
 // Check if RelationshipLLM is configured
 $useRelLLM = !empty($GLOBALS['RELLLM_CONNECTOR']) && $GLOBALS['RELLLM_CONNECTOR'] > 0;
 
@@ -241,7 +255,7 @@ if ($useRelLLM && $npcId) {
     $playerInputTypes = ["inputtext", "inputtext_s", "ginputtext", "ginputtext_s"];
     if (isset($gameRequest[0]) && in_array($gameRequest[0], $playerInputTypes) && !empty($gameRequest[3])) {
         $playerAction = $gameRequest[3];
-        // Remove "PlayerName:" prefix if present (e.g., "Bannon:Hello" -> "Hello")
+        // Remove "PlayerName:" prefix if present (e.g., "PlayerName:Hello" -> "Hello")
         $playerAction = preg_replace('/^[A-Za-z]+:\s*/', '', $playerAction);
         // Also remove "(Talking to everyone)" or similar tags
         $playerAction = preg_replace('/\s*\(Talking to [^)]+\)\s*$/i', '', $playerAction);

--- a/ext/relationship_system/relationship_editor.php
+++ b/ext/relationship_system/relationship_editor.php
@@ -27,7 +27,7 @@ require_once $GLOBALS["ENGINE_PATH"] . "lib/relationship_manager.php";
 
 // Get existing JSONB relationships
 $extendedData = json_decode($editItem['extended_data'] ?? '{}', true) ?: [];
-$jsonbRelationships = $extendedData['relationships'] ?? [];
+$jsonbRelationships = RelationshipManager::normalizeRelationshipMap($extendedData['relationships'] ?? []);
 
 // Keep legacy text available as fallback input for AI analysis.
 $textRelationships = $editItem['relationships'] ?? '';
@@ -123,6 +123,12 @@ $typeIcons = array_merge($defaultTypes, $customTypes);
             <br><span style="color:#b8860b;">⚠️ Dynamic relationship data is subject to CHIM Paradox Prevention. Save your game to preserve changes.</span>
         </small>
 
+        <label style="display:flex; align-items:center; gap:8px; margin:4px 0 10px; color:#fcd34d; font-size:0.9em; cursor:pointer;">
+            <input type="checkbox" id="rel-lock-checkbox" <?= !empty($extendedData['relationships_locked']) ? 'checked' : '' ?>>
+            🔒 Lock these relationships — stop the AI relationship model from changing them (your manual edits stay put)
+        </label>
+        <input type="hidden" name="relationships_locked" id="relationships_locked_hidden" value="<?= !empty($extendedData['relationships_locked']) ? '1' : '0' ?>">
+
         <div id="rel-editor-container" style="margin-top:12px;">
             <?php if (empty($jsonbRelationships)): ?>
                 <p id="rel-empty-msg" style="color:#666; font-style:italic;">No relationships tracked yet. Use "Build with AI" or add manually below.</p>
@@ -134,6 +140,7 @@ $typeIcons = array_merge($defaultTypes, $customTypes);
                             <th style="text-align:center; padding:6px; color:#888;">Affinity</th>
                             <th style="text-align:center; padding:6px; color:#888;">Tier</th>
                             <th style="text-align:center; padding:6px; color:#888;">Type</th>
+                            <th style="text-align:left; padding:6px; color:#888;">Signals</th>
                             <th style="text-align:center; padding:6px; color:#888; width:70px;"></th>
                         </tr>
                     </thead>
@@ -178,6 +185,26 @@ $typeIcons = array_merge($defaultTypes, $customTypes);
                                         <option value="<?= $t ?>" <?= $t === $type ? 'selected' : '' ?>><?= $icon ?> <?= ucfirst($t) ?></option>
                                     <?php endforeach; ?>
                                 </select>
+                            </td>
+                            <td style="padding:8px;">
+                                <?php if (!empty($note)): ?>
+                                    <div style="color:#d1d5db; font-size:0.82em; margin-bottom:3px;" title="<?= htmlspecialchars($note) ?>">
+                                        Last: <?= htmlspecialchars(mb_strimwidth($note, 0, 56, '...')) ?>
+                                    </div>
+                                <?php endif; ?>
+                                <?php if (!empty($best)): ?>
+                                    <div style="color:#4ade80; font-size:0.82em; margin-bottom:3px;" title="<?= htmlspecialchars($best) ?>">
+                                        Best <?= $bestDelta > 0 ? '+' . intval($bestDelta) : intval($bestDelta) ?>: <?= htmlspecialchars(mb_strimwidth($best, 0, 48, '...')) ?>
+                                    </div>
+                                <?php endif; ?>
+                                <?php if (!empty($worst)): ?>
+                                    <div style="color:#f87171; font-size:0.82em;" title="<?= htmlspecialchars($worst) ?>">
+                                        Worst <?= intval($worstDelta) ?>: <?= htmlspecialchars(mb_strimwidth($worst, 0, 48, '...')) ?>
+                                    </div>
+                                <?php endif; ?>
+                                <?php if (empty($note) && empty($best) && empty($worst)): ?>
+                                    <span style="color:#666; font-size:0.82em;">No signals</span>
+                                <?php endif; ?>
                             </td>
                             <td style="padding:8px; text-align:center; white-space:nowrap;">
                                 <button type="button" class="rel-details" title="Edit details (relation, notes, events)"
@@ -592,6 +619,11 @@ function syncRelationshipsToHidden() {
     });
 
     document.getElementById('relationships_jsonb').value = JSON.stringify(relationships);
+
+    // Keep the relationship-lock hidden field in sync with the checkbox so it always submits 0/1 (even when unchecked).
+    const lockCb = document.getElementById('rel-lock-checkbox');
+    const lockHidden = document.getElementById('relationships_locked_hidden');
+    if (lockCb && lockHidden) { lockHidden.value = lockCb.checked ? '1' : '0'; }
 }
 
 function getCurrentRelationshipsFromHidden() {
@@ -867,6 +899,7 @@ function rebuildRelTable(relationships) {
                     <th style="text-align:center; padding:6px; color:#888;">Affinity</th>
                     <th style="text-align:center; padding:6px; color:#888;">Tier</th>
                     <th style="text-align:center; padding:6px; color:#888;">Type</th>
+                    <th style="text-align:left; padding:6px; color:#888;">Signals</th>
                     <th style="text-align:center; padding:6px; color:#888; width:70px;"></th>
                 </tr>
             </thead>
@@ -886,6 +919,7 @@ function rebuildRelTable(relationships) {
         const tierColor = tierColors[tier] || '#e5e7eb';
         const hasExtended = relation || note || best || worst;
         const detailsColor = hasExtended ? '#fde68a' : '#666';
+        const signalHtml = buildRelationshipSignalHtml(note, best, worst, bestDelta, worstDelta);
 
         html += `
             <tr class="rel-row" data-target="${escapeHtml(target)}"
@@ -914,6 +948,9 @@ function rebuildRelTable(relationships) {
                             `<option value="${t}" ${t === type ? 'selected' : ''}>${icon} ${t.charAt(0).toUpperCase() + t.slice(1)}</option>`
                         ).join('')}
                     </select>
+                </td>
+                <td style="padding:8px;">
+                    ${signalHtml}
                 </td>
                 <td style="padding:8px; text-align:center; white-space:nowrap;">
                     <button type="button" class="rel-details" title="Edit details (relation, notes, events)"
@@ -947,12 +984,42 @@ function escapeHtml(text) {
     return div.innerHTML;
 }
 
-// Sync on any change
-document.addEventListener('change', function(e) {
-    if (e.target.closest('#relationship-editor-section')) {
+function truncateSignal(text, maxLen) {
+    text = String(text || '');
+    return text.length > maxLen ? text.slice(0, Math.max(0, maxLen - 3)) + '...' : text;
+}
+
+function buildRelationshipSignalHtml(note, best, worst, bestDelta, worstDelta) {
+    const parts = [];
+    if (note) {
+        parts.push(`<div style="color:#d1d5db; font-size:0.82em; margin-bottom:3px;" title="${escapeHtml(note)}">Last: ${escapeHtml(truncateSignal(note, 56))}</div>`);
+    }
+    if (best) {
+        const bestNum = Number(bestDelta) || 0;
+        const bestSign = bestNum > 0 ? '+' + bestNum : String(bestNum);
+        parts.push(`<div style="color:#4ade80; font-size:0.82em; margin-bottom:3px;" title="${escapeHtml(best)}">Best ${bestSign}: ${escapeHtml(truncateSignal(best, 48))}</div>`);
+    }
+    if (worst) {
+        const worstNum = Number(worstDelta) || 0;
+        parts.push(`<div style="color:#f87171; font-size:0.82em;" title="${escapeHtml(worst)}">Worst ${worstNum}: ${escapeHtml(truncateSignal(worst, 48))}</div>`);
+    }
+    return parts.length ? parts.join('') : '<span style="color:#666; font-size:0.82em;">No signals</span>';
+}
+
+// Sync while editing and again at submit time so the hidden JSON cannot go stale.
+['input', 'change'].forEach(function(evtName) {
+    document.addEventListener(evtName, function(e) {
+        if (e.target.closest('#relationship-editor-section')) {
+            syncRelationshipsToHidden();
+        }
+    });
+});
+
+document.addEventListener('submit', function(e) {
+    if (e.target && e.target.querySelector && e.target.querySelector('#relationship-editor-section')) {
         syncRelationshipsToHidden();
     }
-});
+}, true);
 
 // Initial sync
 syncRelationshipsToHidden();

--- a/ext/relationship_system/relationship_llm.php
+++ b/ext/relationship_system/relationship_llm.php
@@ -266,13 +266,23 @@ class RelationshipLLM {
         $connectorLabel = $this->connector['label'] ?? 'RelationshipLLM';
         $model = $this->modelName ?? 'unknown';
 
+        // The audit viewer infers status from the result text: "OK|" prefix = success.
+        $resultText = is_string($response) ? $response : json_encode($response);
+        $ok = is_string($response) && trim($response) !== '';
+        if ($ok) {
+            $decoded = json_decode(trim($response), true);
+            if (is_array($decoded) && isset($decoded['error'])) {
+                $ok = false;
+            }
+        }
+
         $this->db->insert('audit_request', [
             'request' => json_encode([
                 'type' => $callType,
                 'model' => $model,
                 'messages' => $request
             ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
-            'result' => is_string($response) ? substr($response, 0, 2000) : json_encode($response),
+            'result' => ($ok ? 'OK|' : '') . substr((string)$resultText, 0, 2000),
             'connector' => "RelationshipLLM ({$connectorLabel})",
             'url' => "ext/relationship_system/{$callType}"
         ]);

--- a/ext/relationship_system/relationship_llm.php
+++ b/ext/relationship_system/relationship_llm.php
@@ -18,6 +18,7 @@
 
 // Ensure Logger is available
 require_once $GLOBALS["ENGINE_PATH"] . "lib/logger.php";
+require_once $GLOBALS["ENGINE_PATH"] . "lib/relationship_manager.php";
 
 class RelationshipLLM {
 
@@ -135,6 +136,53 @@ class RelationshipLLM {
      * NOTE: Does NOT call setOldGlobals() here - that happens in makeSafeRequest()
      * to avoid corrupting the main chat connector's globals
      */
+    // Extension-provided character facts. Extensions register fact sources in
+    // conf_opts id='chim_character_facts_sources' (JSON array of
+    // {table, name_column, facts:{label: sql_expression}, skip_values:{label:[values]}}).
+    // Data-driven (no code hooks) so the standalone worker daemon sees registrations too.
+    // No registrations -> empty string; unknown tables/columns fail silently per source.
+    private function extensionCharacterFacts($npcName) {
+        try {
+            if (empty($GLOBALS['db']) || (string)$npcName === '') { return ''; }
+            static $sources = null;
+            if ($sources === null) {
+                $sources = [];
+                $row = $GLOBALS['db']->fetchOne("SELECT value FROM conf_opts WHERE id = 'chim_character_facts_sources'");
+                if ($row && !empty($row['value'])) {
+                    $decoded = json_decode($row['value'], true);
+                    if (is_array($decoded)) { $sources = $decoded; }
+                }
+            }
+            if (empty($sources)) { return ''; }
+            $bits = [];
+            $e = $GLOBALS['db']->escape($npcName);
+            foreach ($sources as $src) {
+                $table = preg_replace('/[^a-zA-Z0-9_]/', '', (string)($src['table'] ?? ''));
+                $nameCol = preg_replace('/[^a-zA-Z0-9_]/', '', (string)($src['name_column'] ?? ''));
+                $facts = is_array($src['facts'] ?? null) ? $src['facts'] : [];
+                if ($table === '' || $nameCol === '' || empty($facts)) { continue; }
+                $selects = [];
+                $i = 0;
+                $aliasByLabel = [];
+                foreach ($facts as $label => $expr) {
+                    $alias = 'f' . $i++;
+                    $aliasByLabel[$label] = $alias;
+                    $selects[] = "({$expr}) AS {$alias}";
+                }
+                $frow = $GLOBALS['db']->fetchOne("SELECT " . implode(', ', $selects) . " FROM {$table} WHERE {$nameCol} = '{$e}'");
+                if (!$frow) { continue; }
+                $skip = is_array($src['skip_values'] ?? null) ? $src['skip_values'] : [];
+                foreach ($aliasByLabel as $label => $alias) {
+                    $val = trim((string)($frow[$alias] ?? ''));
+                    if ($val === '') { continue; }
+                    if (isset($skip[$label]) && in_array(strtolower($val), array_map('strtolower', (array)$skip[$label]), true)) { continue; }
+                    $bits[] = "{$label}: {$val}";
+                }
+            }
+            if (!$bits) { return ''; }
+            return "Character facts for {$npcName} (persistent profile - respect these when judging relationship changes): " . implode('; ', $bits) . "\n";
+        } catch (\Throwable $t) { return ''; }
+    }
     private function initConnector() {
         require_once $GLOBALS['ENGINE_PATH'] . "lib/core/llm_connector.class.php";
 
@@ -258,14 +306,15 @@ class RelationshipLLM {
             return ['ok' => true, 'skipped' => true, 'reason' => 'No text relationships'];
         }
 
-        // Build the analysis
-        return $this->runAnalysis($npc);
+        // Build the analysis. Forced rebuilds intentionally replace the map;
+        // lazy/gameplay initialization only merges missing targets.
+        return $this->runAnalysis($npc, $forceReanalyze);
     }
 
     /**
      * Run the actual LLM analysis for an NPC
      */
-    private function runAnalysis($npc) {
+    private function runAnalysis($npc, $replaceExisting = false) {
         if (!$this->isAvailable()) {
             return ['ok' => false, 'error' => 'LLM not available'];
         }
@@ -293,6 +342,7 @@ class RelationshipLLM {
         if (!empty($npc['race'])) {
             $npcContext .= "Race: " . $npc['race'] . "\n";
         }
+        $npcContext .= $this->extensionCharacterFacts($npcName); // extension character facts (see extensionCharacterFacts)
 
         // Build prompt
         $systemPrompt = $this->getAnalysisPrompt($playerName);
@@ -331,7 +381,7 @@ class RelationshipLLM {
         }
 
         // Save to NPC
-        $this->saveRelationships($npc['id'], $relationships);
+        $this->saveRelationships($npc['id'], $relationships, $replaceExisting);
 
         Logger::info("[REL-LLM] Saved " . count($relationships) . " relationships for {$npcName}");
 
@@ -436,9 +486,10 @@ PROMPT;
 
             // Normalize player references
             $targetLower = strtolower(trim($target));
-            if (in_array($targetLower, ['player', 'the player', 'dragonborn', 'the dragonborn', '#player_name#'])) {
-                $target = 'Player';
+            if (in_array($targetLower, ['narrator', 'the narrator'], true)) {
+                continue; // never track the narrator as a relationship target
             }
+            $target = RelationshipManager::normalizeTargetName($target);
 
             $rel = ['aff' => $aff, 'type' => $type];
             if (!empty($note)) {
@@ -453,7 +504,7 @@ PROMPT;
     /**
      * Save relationships to NPC's extended_data
      */
-    private function saveRelationships($npcId, $relationships) {
+    private function saveRelationships($npcId, $relationships, $replaceExisting = false) {
         require_once $GLOBALS['ENGINE_PATH'] . "lib/core/npc_master.class.php";
 
         // Advisory lock to prevent race conditions
@@ -475,15 +526,35 @@ PROMPT;
                 $this->releaseNpcLock($npcId);
                 return false;
             }
+            // USER LOCK: the editor lock checkbox was only honored by postrequest - this path
+            // kept overwriting manual UI edits. Locked NPCs are user-curated; never machine-write their map.
+            if (!empty($extended['relationships_locked'])) {
+                Logger::info("[REL-LLM] SKIP saveRelationships for {$npc['npc_name']} - relationships_locked (manual edits protected)");
+                $this->releaseNpcLock($npcId);
+                return false;
+            }
 
-            $extended['relationships'] = $relationships;
+            $incomingRelationships = RelationshipManager::normalizeRelationshipMap($relationships);
+            if ($replaceExisting) {
+                $extended['relationships'] = $incomingRelationships;
+            } else {
+                $existingRelationships = RelationshipManager::normalizeRelationshipMap($extended['relationships'] ?? []);
+                foreach ($incomingRelationships as $target => $relationship) {
+                    if (!isset($existingRelationships[$target])) {
+                        $existingRelationships[$target] = $relationship;
+                    }
+                }
+                $extended['relationships'] = $existingRelationships;
+            }
             $extended['relationships_analyzed'] = date('Y-m-d H:i:s');
             $extended['relationships_model'] = $this->modelName;
 
-            $result = $npcMaster->updateByArray([
-                'id' => $npcId,
-                'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
-            ]);
+            $result = chimRunWithRelationshipExtendedDataWrite(function () use ($npcMaster, $npcId, $extended) {
+                return $npcMaster->updateByArray([
+                    'id' => $npcId,
+                    'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+                ]);
+            });
 
             $this->releaseNpcLock($npcId);
             return $result;
@@ -651,10 +722,12 @@ PROMPT;
                 $extended['relationships'] = $myRels;
                 $extended['relationships_inferred'] = date('Y-m-d H:i:s');
 
-                $npcMaster->updateByArray([
-                    'id' => $npcId,
-                    'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
-                ]);
+                chimRunWithRelationshipExtendedDataWrite(function () use ($npcMaster, $npcId, $extended) {
+                    return $npcMaster->updateByArray([
+                        'id' => $npcId,
+                        'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+                    ]);
+                });
 
                 $this->releaseNpcLock($npcId);
                 Logger::info("[REL-LLM] Inferred " . count($inferred) . " relationships for " . $npc['npc_name']);
@@ -706,10 +779,11 @@ PROMPT;
         if ($extended === null) {
             return ['ok' => false, 'error' => 'Corrupted extended_data'];
         }
-        $currentRels = $extended['relationships'] ?? [];
+        $currentRels = RelationshipManager::normalizeRelationshipMap($extended['relationships'] ?? []);
 
         // Build context string
         $contextStr = "";
+        $contextStr .= $this->extensionCharacterFacts($npcName); // extension character facts
 
         // Director instruction context (rolemaster guidance)
         // This explains why an NPC might behave in ways that seem out of character
@@ -935,6 +1009,8 @@ PROMPT;
 
         // Build context string
         $contextStr = "";
+        $contextStr .= $this->extensionCharacterFacts($speakerName);  // extension character facts, both parties
+        $contextStr .= $this->extensionCharacterFacts($listenerName);
 
         // Director instruction context (rolemaster guidance)
         if (!empty($context['director_instruction'])) {
@@ -1200,15 +1276,20 @@ PROMPT;
             'hero', 'the hero',
             'champion', 'the champion',
             'chosen one', 'the chosen one',
-            'nightingale', 'the nightingale'
+            'nightingale', 'the nightingale',
+            'narrator', 'the narrator'
         ];
 
         foreach ($changes as $target => $change) {
             $delta = intval($change['delta'] ?? 0);
             $newType = $change['type'] ?? null;
+            if (is_string($newType)) {
+                $newType = strtolower(trim($newType));
+                if ($newType === '') {
+                    $newType = null;
+                }
+            }
             $reason = $change['reason'] ?? '';
-
-            if ($delta === 0 && $newType === null) continue;
 
             // Skip titles/roles (but allow factions/groups)
             if (in_array(strtolower(trim($target)), $blockedTitles)) {
@@ -1217,15 +1298,22 @@ PROMPT;
             }
 
             // Normalize player name references to canonical "Player"
-            $playerName = $this->getPlayerName();
-            $targetLower = strtolower(trim($target));
-            if ($targetLower === strtolower($playerName) ||
-                in_array($targetLower, ['player', 'the player', 'dragonborn', 'the dragonborn', '#player_name#'])) {
-                $target = 'Player';
+            $target = RelationshipManager::normalizeTargetName($target);
+
+            $targetExists = isset($currentRels[$target]);
+
+            // REL LLMs often emit {"delta":0,"type":"neutral"} as a generic
+            // "no meaningful change" shape. Do not let that create or downgrade
+            // Player/NPC rows to 0 neutral.
+            if ($delta === 0) {
+                if ($newType === null || $newType === 'neutral' || !$targetExists) {
+                    Logger::debug("[REL-LLM] Ignoring zero-delta/no-op relationship output for {$npc['npc_name']} -> {$target}");
+                    continue;
+                }
             }
 
             // Initialize if doesn't exist
-            if (!isset($currentRels[$target])) {
+            if (!$targetExists) {
                 $currentRels[$target] = ['aff' => 0, 'type' => 'neutral'];
             }
 
@@ -1237,22 +1325,34 @@ PROMPT;
             $typeChanged = false;
             $finalType = $oldType;
 
+            // ROMANTIC AUTO-PROMOTION GUARD (user directive): the relationship model must NOT unilaterally promote a
+            // non-romantic relationship INTO a romantic-leaning type (e.g. professional -> crush in one interaction,
+            //). Romantic types are earned / player-set in the relationship editor, never
+            // auto-assigned by the model. Affinity + notes still update; only the romantic TYPE jump is blocked.
+            // Downgrades OUT of romantic and moves between non-romantic types are unaffected.
+            $romanticTypes = ['romantic', 'crush', 'admirer', 'obsessed', 'infatuated', 'lover'];
+            $oldIsRomantic = in_array(strtolower((string)$oldType), $romanticTypes, true);
+
             if ($newType) {
                 // LLM explicitly set a type
                 $newTypeLower = strtolower($newType);
-                if ($oldType !== $newTypeLower) {
-                    Logger::info("[REL-LLM] TYPE CHANGE: {$npc['npc_name']} -> {$target}: {$oldType} => {$newTypeLower}");
-                    $typeChanged = true;
+                if (in_array($newTypeLower, $romanticTypes, true) && !$oldIsRomantic) {
+                    Logger::info("[REL-LLM] BLOCKED romantic auto-promotion: {$npc['npc_name']} -> {$target}: {$oldType} => {$newTypeLower} (kept '{$oldType}'; romantic types are player-set in the UI)");
+                } else {
+                    if ($oldType !== $newTypeLower) {
+                        Logger::info("[REL-LLM] TYPE CHANGE: {$npc['npc_name']} -> {$target}: {$oldType} => {$newTypeLower}");
+                        $typeChanged = true;
+                    }
+                    $currentRels[$target]['type'] = $newTypeLower;
+                    $finalType = $newTypeLower;
                 }
-                $currentRels[$target]['type'] = $newTypeLower;
-                $finalType = $newTypeLower;
             } else {
                 // Auto-evolve type ONLY when leaving neutral
                 // Once you've formed an opinion, you don't go back to neutral
                 $currentType = $currentRels[$target]['type'];
                 if ($currentType === 'neutral') {
                     $inferredType = $this->inferTypeFromAffinity($newAff);
-                    if ($inferredType !== 'neutral') {
+                    if ($inferredType !== 'neutral' && !in_array($inferredType, $romanticTypes, true)) {
                         Logger::info("[REL-LLM] AUTO TYPE CHANGE: {$npc['npc_name']} -> {$target}: neutral => {$inferredType} (affinity: {$newAff})");
                         $currentRels[$target]['type'] = $inferredType;
                         $finalType = $inferredType;
@@ -1309,6 +1409,9 @@ PROMPT;
                 'new' => $newAff,
                 'delta' => $delta,
                 'type' => $finalType,
+                'base_type' => $oldType,
+                'requested_type' => $newType,
+                'relation' => $change['relation'] ?? null,
                 'reason' => $reason
             ];
 
@@ -1336,11 +1439,33 @@ PROMPT;
                     $this->releaseNpcLock($npcId);
                     return []; // Return empty - changes not saved
                 }
+                // USER LOCK: honor the editor lock here too - this eval/rebase path was the
+                // writer clobbering manual UI edits minutes after they were saved.
+                if (!empty($extended['relationships_locked'])) {
+                    Logger::info("[REL-LLM] SKIP applyChanges for {$npc['npc_name']} - relationships_locked (manual edits protected)");
+                    $this->releaseNpcLock($npcId);
+                    return []; // Return empty - changes not saved
+                }
 
-                // Merge our changes with latest state
-                $existingRels = $extended['relationships'] ?? [];
-                foreach ($currentRels as $target => $data) {
-                    $existingRels[$target] = $data;
+                // Merge only the relationship targets changed by this evaluation,
+                // and rebase each delta onto the freshly fetched row. The evaluator
+                // may have started from an old snapshot while the UI or another
+                // worker changed the same target; copying the pre-eval target would
+                // clobber that newer state.
+                $existingRels = RelationshipManager::normalizeRelationshipMap($extended['relationships'] ?? []);
+                foreach ($applied as $target => $change) {
+                    $freshRel = $existingRels[$target] ?? [];
+                    $rebasedRel = $this->rebaseRelationshipChange(
+                        $freshRel,
+                        $currentRels[$target] ?? [],
+                        $change
+                    );
+                    $freshAff = (int)($freshRel['aff'] ?? 0);
+                    $staleAff = (int)($change['old'] ?? 0);
+                    if ($freshAff !== $staleAff) {
+                        Logger::info("[REL-LLM] Rebased {$npc['npc_name']} -> {$target}: fresh {$freshAff} + delta {$change['delta']} => {$rebasedRel['aff']}");
+                    }
+                    $existingRels[$target] = $rebasedRel;
                 }
 
                 $extended['relationships'] = $existingRels;
@@ -1348,13 +1473,15 @@ PROMPT;
 
                 $jsonData = json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
-                $result = $npcMaster->updateByArray([
-                    'id' => $npcId,
-                    'extended_data' => $jsonData
-                ]);
+                $result = chimRunWithRelationshipExtendedDataWrite(function () use ($npcMaster, $npcId, $jsonData) {
+                    return $npcMaster->updateByArray([
+                        'id' => $npcId,
+                        'extended_data' => $jsonData
+                    ]);
+                });
 
                 $this->releaseNpcLock($npcId);
-                Logger::debug("[REL-LLM] Database update for NPC {$npcId}: " . ($result ? "SUCCESS" : "FAILED") . " - relationships: " . json_encode($existingRels));
+                Logger::debug("[REL-LLM] Database update for NPC {$npcId}: " . ($result === false ? "FAILED" : "OK") . " - relationships: " . json_encode($existingRels));
             } catch (Exception $e) {
                 $this->releaseNpcLock($npcId);
                 throw $e;
@@ -1362,6 +1489,93 @@ PROMPT;
         }
 
         return $applied;
+    }
+
+    /**
+     * Apply an LLM relationship change to the latest DB value instead of the
+     * stale value captured when the evaluation was queued.
+     */
+    private function rebaseRelationshipChange($freshRel, $computedRel, $change) {
+        if (!is_array($freshRel)) {
+            $freshRel = [];
+        }
+        if (!is_array($computedRel)) {
+            $computedRel = [];
+        }
+
+        $rebased = $freshRel;
+        $freshAff = (int)($freshRel['aff'] ?? 0);
+        $delta = (int)($change['delta'] ?? 0);
+        $rebasedAff = max(-100, min(100, $freshAff + $delta));
+        $rebased['aff'] = $rebasedAff;
+
+        $freshType = strtolower(trim((string)($freshRel['type'] ?? 'neutral')));
+        if ($freshType === '') {
+            $freshType = 'neutral';
+        }
+
+        $requestedType = $change['requested_type'] ?? null;
+        if (is_string($requestedType)) {
+            $requestedType = strtolower(trim($requestedType));
+        }
+
+        // ROMANTIC AUTO-PROMOTION GUARD (mirrors the main apply path): never let the concurrent-rebase apply a
+        // romantic-leaning type on top of a non-romantic one. Romantic types are player-set, not model-assigned.
+        $romanticTypes = ['romantic', 'crush', 'admirer', 'obsessed', 'infatuated', 'lover'];
+        $freshIsRomantic = in_array($freshType, $romanticTypes, true);
+        if (!empty($requestedType)) {
+            // Never let a stale generic "neutral" response downgrade a newer UI
+            // or worker type. Non-neutral model type changes can still apply.
+            if (in_array($requestedType, $romanticTypes, true) && !$freshIsRomantic) {
+                // blocked romantic auto-promotion: keep the existing (fresh) type
+                $rebased['type'] = $freshType;
+            } elseif ($requestedType !== 'neutral' || $freshType === 'neutral') {
+                $rebased['type'] = $requestedType;
+            } else {
+                $rebased['type'] = $freshType;
+            }
+        } else {
+            $rebased['type'] = $freshType;
+            if ($freshType === 'neutral') {
+                $inferredType = $this->inferTypeFromAffinity($rebasedAff);
+                if ($inferredType !== 'neutral' && !in_array($inferredType, $romanticTypes, true)) {
+                    $rebased['type'] = $inferredType;
+                }
+            }
+        }
+
+        $reason = trim((string)($change['reason'] ?? ''));
+        if ($reason !== '') {
+            if (abs($delta) >= 3 || empty($rebased['note'] ?? '')) {
+                $rebased['note'] = $computedRel['note'] ?? $reason;
+            }
+
+            if ($delta >= 10) {
+                $existingBestDelta = (int)($rebased['best_delta'] ?? 0);
+                if ($delta >= $existingBestDelta) {
+                    $rebased['best'] = $computedRel['best'] ?? $reason;
+                    $rebased['best_delta'] = $delta;
+                }
+            }
+
+            if ($delta <= -10) {
+                $existingWorstDelta = (int)($rebased['worst_delta'] ?? 0);
+                if ($delta <= $existingWorstDelta) {
+                    $rebased['worst'] = $computedRel['worst'] ?? $reason;
+                    $rebased['worst_delta'] = $delta;
+                }
+            }
+        }
+
+        $requestedRelation = $change['relation'] ?? null;
+        if (is_string($requestedRelation)) {
+            $requestedRelation = strtolower(trim($requestedRelation));
+        }
+        if (!empty($requestedRelation) && empty($rebased['relation'])) {
+            $rebased['relation'] = $requestedRelation;
+        }
+
+        return $rebased;
     }
 
     /**

--- a/ext/relationship_system/worker.php
+++ b/ext/relationship_system/worker.php
@@ -116,6 +116,14 @@ try {
     // Set up minimal globals that LLM connector needs
     $GLOBALS['HERIKA_NAME'] = 'Worker';
     $GLOBALS['PLAYER_NAME'] = 'Player';
+    try {
+        $playerRow = $GLOBALS['db']->fetchOne("SELECT value FROM conf_opts WHERE id='PLAYER_NAME' LIMIT 1");
+        if ($playerRow && !empty($playerRow['value'])) {
+            $GLOBALS['PLAYER_NAME'] = trim((string)$playerRow['value']);
+        }
+    } catch (Exception $e) {
+        @file_put_contents($logFile, date('[Y-m-d H:i:s]') . " WARN: Failed to load PLAYER_NAME: " . $e->getMessage() . "\n", FILE_APPEND);
+    }
 
     Logger::info("[REL-WORKER] Starting relationship worker" . ($daemon ? " in daemon mode" : ""));
 } catch (Exception $e) {

--- a/lib/relationship_manager.php
+++ b/lib/relationship_manager.php
@@ -323,16 +323,86 @@ class RelationshipManager {
     }
 
     /**
+     * Resolve an NPC row by display name: exact -> suffix-stripped -> case-insensitive ->
+     * in-range actor bridge. Dialogue-parsed names can drift from the spelling that created
+     * the row (rename mods). Never similarity-guesses; logs closest names on a miss.
+     */
+    public static function resolveNpcByName($npcName) {
+        require_once __DIR__ . "/core/npc_master.class.php";
+        $npcMaster = new NpcMaster();
+
+        $raw = trim((string)$npcName);
+        if ($raw === '' || strcasecmp($raw, 'The Narrator') === 0) {
+            return null;
+        }
+
+        $npcData = $npcMaster->getByName($raw);
+        if ($npcData) { return $npcData; }
+
+        $clean = preg_replace('/\s*\((?:far away|too far away|busy|hostile|in combat|dead|disabled|unavailable)\)\s*$/iu', '', $raw);
+        $clean = trim(preg_replace('/\s+/u', ' ', (string)$clean));
+        if ($clean === '') { $clean = $raw; }
+        if ($clean !== $raw) {
+            $npcData = $npcMaster->getByName($clean);
+            if ($npcData) { return $npcData; }
+        }
+
+        $npcData = $npcMaster->getByName(ucfirst(strtolower($clean)));
+        if ($npcData) { return $npcData; }
+
+        $escaped = $GLOBALS["db"]->escape($clean);
+        $rows = $GLOBALS["db"]->fetchAll(
+            "SELECT * FROM core_npc_master WHERE LOWER(npc_name) = LOWER('{$escaped}') AND npc_name <> 'The Narrator'
+             ORDER BY gamets_last_updated DESC NULLS LAST, id DESC LIMIT 2"
+        );
+        if (!empty($rows)) {
+            if (count($rows) > 1) {
+                error_log("[REL] Name resolve: multiple case-insensitive matches for '{$clean}', using newest row '{$rows[0]['npc_name']}'");
+            }
+            return $rows[0];
+        }
+
+        // Bridge: compare against in-range actors ignoring case/punctuation/spacing drift
+        if (function_exists('DataBeingsInCloseRange')) {
+            try {
+                $squash = function ($s) { return preg_replace('/[^a-z0-9]+/', '', strtolower((string)$s)); };
+                $target = $squash($clean);
+                $inRange = DataBeingsInCloseRange(true);
+                $candidates = is_array($inRange) ? $inRange : explode('|', trim((string)$inRange, '| '));
+                foreach ($candidates as $candidate) {
+                    $candidate = trim((string)preg_replace('/\s*\([^)]*\)\s*$/u', '', (string)$candidate));
+                    if ($candidate === '' || $target === '' || $squash($candidate) !== $target) { continue; }
+                    $npcData = $npcMaster->getByName($candidate);
+                    if ($npcData) {
+                        error_log("[REL] Name resolve: matched '{$clean}' to in-range actor '{$candidate}'");
+                        return $npcData;
+                    }
+                }
+            } catch (Exception $e) {
+                // resolver must never break the turn
+            }
+        }
+
+        try {
+            $all = $GLOBALS["db"]->fetchAll("SELECT npc_name FROM core_npc_master WHERE npc_name <> 'The Narrator'");
+            $scored = [];
+            foreach ($all as $r) {
+                $scored[$r['npc_name']] = levenshtein(strtolower(substr($clean, 0, 60)), strtolower(substr((string)$r['npc_name'], 0, 60)));
+            }
+            asort($scored);
+            $closest = implode("', '", array_slice(array_keys($scored), 0, 3));
+            error_log("[REL] Name resolve FAILED for '{$clean}' - no row matches; closest names: '{$closest}'");
+        } catch (Exception $e) {
+            error_log("[REL] Name resolve FAILED for '{$clean}' - no row matches");
+        }
+        return null;
+    }
+
+    /**
      * Get NPC's relationship data from extended_data
      */
     public static function getRelationships($npcName) {
-        require_once __DIR__ . "/core/npc_master.class.php";
-        $npcMaster = new NpcMaster();
-        $npcData = $npcMaster->getByName($npcName);
-
-        if (!$npcData) {
-            $npcData = $npcMaster->getByName(ucfirst(strtolower($npcName)));
-        }
+        $npcData = self::resolveNpcByName($npcName);
 
         if (!$npcData) {
             return [];
@@ -562,11 +632,7 @@ class RelationshipManager {
     public static function parseChanges($aiResponse, $npcName) {
         require_once __DIR__ . "/core/npc_master.class.php";
         $npcMaster = new NpcMaster();
-        $npcData = $npcMaster->getByName($npcName);
-
-        if (!$npcData) {
-            $npcData = $npcMaster->getByName(ucfirst(strtolower($npcName)));
-        }
+        $npcData = self::resolveNpcByName($npcName);
 
         if (!$npcData) {
             // Can't update relationships for unknown NPC
@@ -643,11 +709,7 @@ class RelationshipManager {
         $targetName = self::normalizeTargetName($targetName);
         require_once __DIR__ . "/core/npc_master.class.php";
         $npcMaster = new NpcMaster();
-        $npcData = $npcMaster->getByName($npcName);
-
-        if (!$npcData) {
-            $npcData = $npcMaster->getByName(ucfirst(strtolower($npcName)));
-        }
+        $npcData = self::resolveNpcByName($npcName);
 
         if (!$npcData) {
             error_log("[REL] Cannot set relationship - NPC not found: $npcName");

--- a/lib/relationship_manager.php
+++ b/lib/relationship_manager.php
@@ -150,6 +150,89 @@ class RelationshipManager {
     ];
 
     /**
+     * Relationship storage uses the canonical key "Player" for the player route.
+     * UI/prompts may surface the actual character name, but reads/writes must not
+     * store that display name as a separate relationship target.
+     */
+    public static function normalizeTargetName($targetName) {
+        $target = trim((string)$targetName);
+        if ($target === '') {
+            return $target;
+        }
+
+        $aliases = [
+            'player',
+            'the player',
+            'player character',
+            'the player character',
+            'dragonborn',
+            'the dragonborn',
+            '#player_name#',
+            '{player_name}'
+        ];
+
+        $playerName = trim((string)($GLOBALS['PLAYER_NAME'] ?? ''));
+        if ($playerName !== '') {
+            $aliases[] = strtolower($playerName);
+        }
+
+        if (in_array(strtolower($target), $aliases, true)) {
+            return 'Player';
+        }
+
+        return $target;
+    }
+
+    public static function normalizeRelationshipMap($relationships) {
+        if (!is_array($relationships)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($relationships as $target => $rel) {
+            if (!is_array($rel)) {
+                continue;
+            }
+
+            $canonicalTarget = self::normalizeTargetName($target);
+            if ($canonicalTarget === '') {
+                continue;
+            }
+
+            if (!isset($normalized[$canonicalTarget])) {
+                $normalized[$canonicalTarget] = $rel;
+                continue;
+            }
+
+            $existing = $normalized[$canonicalTarget];
+            $existingWeight = self::relationshipDataWeight($existing);
+            $incomingWeight = self::relationshipDataWeight($rel);
+            if ($incomingWeight > $existingWeight) {
+                $normalized[$canonicalTarget] = $rel;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private static function relationshipDataWeight($rel) {
+        if (!is_array($rel)) {
+            return 0;
+        }
+
+        $weight = abs((int)($rel['aff'] ?? 0));
+        if (($rel['type'] ?? 'neutral') !== 'neutral') {
+            $weight += 5;
+        }
+        foreach (['relation', 'note', 'best', 'worst'] as $field) {
+            if (!empty($rel[$field])) {
+                $weight += 2;
+            }
+        }
+        return $weight;
+    }
+
+    /**
      * Get tier label from affinity score
      * PHP calculates this - AI never decides the label
      *
@@ -256,7 +339,7 @@ class RelationshipManager {
         }
 
         $extended = json_decode($npcData['extended_data'] ?? '{}', true) ?: [];
-        return $extended['relationships'] ?? [];
+        return self::normalizeRelationshipMap($extended['relationships'] ?? []);
     }
 
     /**
@@ -266,6 +349,7 @@ class RelationshipManager {
      */
     public static function getRelationship($npcName, $targetName) {
         $rels = self::getRelationships($npcName);
+        $targetName = self::normalizeTargetName($targetName);
 
         if (isset($rels[$targetName])) {
             $rel = $rels[$targetName];
@@ -490,13 +574,14 @@ class RelationshipManager {
         }
 
         $extended = json_decode($npcData['extended_data'] ?? '{}', true) ?: [];
-        $rels = $extended['relationships'] ?? [];
+        $rels = self::normalizeRelationshipMap($extended['relationships'] ?? []);
         $changed = false;
 
         // Parse affinity changes: #REL:Target=+5# or #REL:Target=-10#
         if (preg_match_all('/#REL:([^=]+)=([+-]?\d+)#/', $aiResponse, $matches)) {
             foreach ($matches[1] as $i => $target) {
-                $target = trim($target);
+                $target = self::normalizeTargetName($target);
+                if (in_array(strtolower($target), ['the narrator', 'narrator'], true)) continue; // never track the narrator as a relationship
                 $delta = (int)$matches[2][$i];
 
                 // Initialize if doesn't exist
@@ -518,7 +603,8 @@ class RelationshipManager {
         // Accepts both default types AND custom types (any single word)
         if (preg_match_all('/#TYPE:([^=]+)=([a-zA-Z]+)#/', $aiResponse, $matches)) {
             foreach ($matches[1] as $i => $target) {
-                $target = trim($target);
+                $target = self::normalizeTargetName($target);
+                if (in_array(strtolower($target), ['the narrator', 'narrator'], true)) continue; // never track the narrator as a relationship
                 $newType = strtolower(trim($matches[2][$i]));
 
                 // Accept any single-word type (allows custom types like "client", "mentor", etc.)
@@ -538,10 +624,12 @@ class RelationshipManager {
         // Save if changed
         if ($changed) {
             $extended['relationships'] = $rels;
-            $npcMaster->updateByArray([
-                'id' => $npcData['id'],
-                'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
-            ]);
+            chimRunWithRelationshipExtendedDataWrite(function () use ($npcMaster, $npcData, $extended) {
+                return $npcMaster->updateByArray([
+                    'id' => $npcData['id'],
+                    'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+                ]);
+            });
         }
 
         // Strip commands before TTS
@@ -552,6 +640,7 @@ class RelationshipManager {
      * Set relationship directly (for initialization or admin)
      */
     public static function setRelationship($npcName, $targetName, $affinity, $type = null) {
+        $targetName = self::normalizeTargetName($targetName);
         require_once __DIR__ . "/core/npc_master.class.php";
         $npcMaster = new NpcMaster();
         $npcData = $npcMaster->getByName($npcName);
@@ -566,7 +655,7 @@ class RelationshipManager {
         }
 
         $extended = json_decode($npcData['extended_data'] ?? '{}', true) ?: [];
-        $rels = $extended['relationships'] ?? [];
+        $rels = self::normalizeRelationshipMap($extended['relationships'] ?? []);
 
         // Initialize or update
         if (!isset($rels[$targetName])) {
@@ -582,10 +671,12 @@ class RelationshipManager {
         }
 
         $extended['relationships'] = $rels;
-        $npcMaster->updateByArray([
-            'id' => $npcData['id'],
-            'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
-        ]);
+        chimRunWithRelationshipExtendedDataWrite(function () use ($npcMaster, $npcData, $extended) {
+            return $npcMaster->updateByArray([
+                'id' => $npcData['id'],
+                'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+            ]);
+        });
 
         error_log("[REL] Set $npcName -> $targetName: " . $rels[$targetName]['aff'] .
                   " (" . $rels[$targetName]['type'] . ")");

--- a/ui/relationship_logs.php
+++ b/ui/relationship_logs.php
@@ -283,7 +283,9 @@ $results = $db->fetchAll($query);
     <tbody>
     <?php foreach ($results as $row):
         $reqData = json_decode($row['request'], true);
-        $resultData = json_decode($row['result'], true);
+        // Success rows carry an "OK|" status prefix (audit-viewer convention); strip before decoding
+        $resultRaw = preg_replace('/^OK\|/', '', (string)$row['result']);
+        $resultData = json_decode($resultRaw, true);
 
         // Parse type from request
         $type = $reqData['type'] ?? 'unknown';
@@ -328,7 +330,7 @@ $results = $db->fetchAll($query);
             $changes = $resultData['changes'];
         } elseif (is_string($row['result'])) {
             // Try to parse JSON from result string - handle both formats
-            $jsonContent = $row['result'];
+            $jsonContent = $resultRaw;
 
             // Extract JSON from markdown code block if present
             if (preg_match('/```(?:json)?\s*([\s\S]*?)```/', $jsonContent, $matches)) {


### PR DESCRIPTION
﻿This system started as my code before it passed to Rangroo and Tyler, so offering these back upstream with full context on why each change exists — all of it comes from running the system hard in long live sessions. Happy to rework any of it to your direction.

Scope: `ext/relationship_system/` + `lib/relationship_manager.php` only. (The core NPC-master write guards this pairs with are split into their own PR for easier review.)

- Manual relationship edits survive AI analysis passes: the per-NPC lock is now honored on *every* write path, including the eval/rebase path that previously bypassed it.
- "The Narrator" is never tracked as a relationship target (parse, apply, and init all skip it).
- Evaluations (init and both arbiters) can consume per-NPC character facts through a neutral, data-driven registration (`conf_opts` `chim_character_facts_sources`: table + labeled SQL expressions). Any extension can register facts; with nothing registered it's a silent no-op — vanilla installs are unaffected.
- Editor and save-handler hardening (validation, lock plumbing, worker resilience).

Tested across weeks of live play including multi-NPC scenes, save rollbacks, and concurrent worker/editor writes.

- Name resolution: NPC lookups now go through a small normalization ladder (exact match, state-suffix strip, case-insensitive, in-range actor check) instead of byte-exact string equality. Names parsed from dialogue text can differ in case/spacing from the spelling that created the row (common with rename mods), which silently dropped relationship updates. No similarity guessing; unresolved names are logged with the closest existing rows.


- Audit rows: successful relationship LLM calls now store the standard OK result prefix, so the request-log viewer stops flagging every successful eval as an error (the relationship logs page strips the prefix before parsing changes).


- Type changes: the per-turn eval can now propose a relationship type change for defining moments (the previous output format was delta-only, so types could never evolve in play). Promotion into romantic types is gated in code behind fond-tier affinity (56+) plus an explicit reason, so a single flirty line cannot flip a stranger to romantic.
