### PR TITLE
NPC master: relationship write guards, save-load rollback for relationship keys, editor plumbing

### DIFF
--- a/lib/core/npc_master.class.php
+++ b/lib/core/npc_master.class.php
@@ -150,6 +150,25 @@ if (!function_exists('herikaResolveNpcRolemasterState')) {
     }
 }
 
+if (!function_exists('chimRunWithRelationshipExtendedDataWrite')) {
+    function chimRunWithRelationshipExtendedDataWrite($callback)
+    {
+        $hadPrevious = array_key_exists('CHIM_ALLOW_RELATIONSHIP_EXTENDED_DATA_WRITE', $GLOBALS);
+        $previous = $hadPrevious ? $GLOBALS['CHIM_ALLOW_RELATIONSHIP_EXTENDED_DATA_WRITE'] : null;
+        $GLOBALS['CHIM_ALLOW_RELATIONSHIP_EXTENDED_DATA_WRITE'] = true;
+
+        try {
+            return $callback();
+        } finally {
+            if ($hadPrevious) {
+                $GLOBALS['CHIM_ALLOW_RELATIONSHIP_EXTENDED_DATA_WRITE'] = $previous;
+            } else {
+                unset($GLOBALS['CHIM_ALLOW_RELATIONSHIP_EXTENDED_DATA_WRITE']);
+            }
+        }
+    }
+}
+
 class NpcMaster
 {
     private $table = "core_npc_master";
@@ -323,6 +342,8 @@ class NpcMaster
             }
         }
 
+        $data = $this->preserveRelationshipExtendedDataOnGenericUpdate($data, $existing);
+
         foreach ($data as $k => $v) {
             // Preserve explicit 0/false values; only treat empty-string/null as unset.
             if ($v === '' || $v === null) {
@@ -348,6 +369,67 @@ class NpcMaster
         unset($data['id']); // Remove 'id' from the data array to avoid updating it
 
         return $this->update($id, $data);
+    }
+
+    private function preserveRelationshipExtendedDataOnGenericUpdate($data, $existing)
+    {
+        if (!is_array($data) || !array_key_exists('extended_data', $data)) {
+            return $data;
+        }
+
+        if (!empty($GLOBALS['CHIM_ALLOW_RELATIONSHIP_EXTENDED_DATA_WRITE'])) {
+            return $data;
+        }
+
+        if (!is_array($existing) || !array_key_exists('extended_data', $existing)) {
+            return $data;
+        }
+
+        $incoming = $this->decodeExtendedDataForRelationshipGuard($data['extended_data']);
+        $current = $this->decodeExtendedDataForRelationshipGuard($existing['extended_data'] ?? null);
+        if (!is_array($incoming) || !is_array($current)) {
+            return $data;
+        }
+
+        $relationshipKeys = [
+            'relationships',
+            'relationships_analyzed',
+            'relationships_inferred',
+            'relationships_last_eval',
+            'relationships_model',
+            'relationships_updated',
+        ];
+
+        $changed = false;
+        foreach ($relationshipKeys as $key) {
+            if (array_key_exists($key, $current)) {
+                $incoming[$key] = $current[$key];
+                $changed = true;
+            } elseif (array_key_exists($key, $incoming)) {
+                unset($incoming[$key]);
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            $data['extended_data'] = json_encode($incoming, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        }
+
+        return $data;
+    }
+
+    private function decodeExtendedDataForRelationshipGuard($value)
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+        return is_array($decoded) ? $decoded : null;
     }
 
     // Delete NPC by ID
@@ -734,43 +816,27 @@ class NpcMaster
             $GLOBALS['PROMPT_HEAD'] = $currentNpcData['prompt_head'];
         }
 
-        if (isset($currentNpcData['npc_static_bio'])) {
-            $GLOBALS['HERIKA_BACKGROUND'] = $currentNpcData['npc_static_bio'];
-        }
-
-        if (isset($currentNpcData['oghma_knowledge_tags'])) {
-            $GLOBALS['OGHMA_KNOWLEDGE'] = $currentNpcData['oghma_knowledge_tags'];
-        }
-
-        if (isset($currentNpcData['personality'])) {
-            $GLOBALS['HERIKA_PERSONALITY'] = $currentNpcData['personality'];
-        }
+        // ALWAYS reset identity/bio globals from THIS NPC's own row (coalesce NULL -> ''), never leave the
+        // previous NPC's value in place. A generic/bio-less NPC (e.g. an unnamed "Breton") has NULL profile
+        // fields; the old `if (isset())` guards skipped the assignment on NULL, so the global retained the
+        // last-processed NPC's data and the bio-less NPC spoke as them (the cross-NPC identity bleed
+        // bleed). Mirrors the per-NPC reset already done for HERIKA_RELATIONSHIPS below.
+        $GLOBALS['HERIKA_BACKGROUND']  = $currentNpcData['npc_static_bio'] ?? '';
+        $GLOBALS['OGHMA_KNOWLEDGE']    = $currentNpcData['oghma_knowledge_tags'] ?? '';
+        $GLOBALS['HERIKA_PERSONALITY'] = $currentNpcData['personality'] ?? '';
 
         unset($GLOBALS['HERIKA_RELATIONSHIPS']);
 
-        if (isset($currentNpcData['occupation'])) {
-            $GLOBALS['HERIKA_OCCUPATION'] = $currentNpcData['occupation'];
-        }
-
-        if (isset($currentNpcData['appearance'])) {
-            $GLOBALS['HERIKA_APPEARANCE'] = $currentNpcData['appearance'];
-        }
-
-        if (isset($currentNpcData['skills'])) {
-            $GLOBALS['HERIKA_SKILLS'] = $currentNpcData['skills'];
-        }
-
-        if (isset($currentNpcData['speechstyle'])) {
-            $GLOBALS['HERIKA_SPEECHSTYLE'] = $currentNpcData['speechstyle'];
-        }
+        $GLOBALS['HERIKA_OCCUPATION']  = $currentNpcData['occupation'] ?? '';
+        $GLOBALS['HERIKA_APPEARANCE']  = $currentNpcData['appearance'] ?? '';
+        $GLOBALS['HERIKA_SKILLS']      = $currentNpcData['skills'] ?? '';
+        $GLOBALS['HERIKA_SPEECHSTYLE'] = $currentNpcData['speechstyle'] ?? '';
 
         if (isset($currentNpcData['emote_moods']) && ! empty(trim($currentNpcData['emote_moods']))) {
             $GLOBALS['EMOTEMOODS'] = $currentNpcData['emote_moods'];
         }
 
-        if (isset($currentNpcData['goals'])) {
-            $GLOBALS['HERIKA_GOALS'] = $currentNpcData['goals'];
-        }
+        $GLOBALS['HERIKA_GOALS']       = $currentNpcData['goals'] ?? '';
 
         if (isset($currentNpcData['core'])) {
             $GLOBALS['HERIKA_PERS'] = "Roleplay as {$GLOBALS['HERIKA_NAME']}.\n{$currentNpcData['core']}";
@@ -979,6 +1045,11 @@ class NpcMaster
         // Add the current timestamp for tracking purposes (optional)
         $npc['created'] = date('Y-m-d H:i:s');
 
+        $npc['extended_data'] = $this->markHistoryExtendedData(
+            $npc['extended_data'] ?? null,
+            'manual'
+        );
+
         // Insert the data into the history table
         return $this->db->insert('core_npc_master_history', $npc);
     }
@@ -1010,7 +1081,8 @@ class NpcMaster
                 id, npc_name, npc_favorite, lock_profile, prompt_head, npc_static_bio,
                 oghma_knowledge_tags, emote_moods, personality, relationships,
                 occupation, skills, speechstyle, goals, voiceid, metadata,
-                gender, race, refid, profile_id, dynamic_profile, extended_data,
+                gender, race, refid, profile_id, dynamic_profile,
+                COALESCE(extended_data, '{}'::jsonb) || jsonb_build_object('_chim_history_source', 'infosave'),
                 md5, $timestamp, core, base, tags, appearance, '{$createdTimestamp}'
             FROM core_npc_master
         ";
@@ -1056,7 +1128,10 @@ restore AS (
         h.refid,
         h.profile_id,
         h.dynamic_profile,
-        h.extended_data,
+        CASE
+            WHEN h.extended_data IS NULL THEN NULL
+            ELSE h.extended_data - '_chim_history_source'
+        END AS extended_data,
         h.md5,
         h.gamets_last_updated,
         h.core,
@@ -1066,7 +1141,11 @@ restore AS (
     FROM core_npc_master_history h
     JOIN deleted d ON h.npc_id = d.id
     WHERE h.gamets_last_updated <= $timestamp OR h.gamets_last_updated IS NULL
-    ORDER BY h.npc_id, h.gamets_last_updated DESC NULLS LAST,h.created DESC
+    ORDER BY
+        h.npc_id,
+        h.gamets_last_updated DESC NULLS LAST,
+        CASE WHEN h.extended_data ->> '_chim_history_source' = 'infosave' THEN 1 ELSE 0 END DESC,
+        h.created DESC
 )
 INSERT INTO core_npc_master (
     id, npc_name, npc_favorite, lock_profile, prompt_head, npc_static_bio,
@@ -1087,6 +1166,55 @@ FROM restore
         error_log("[NPC RESTORE] using gamets: $timestamp.. " . date('Y-m-d H:i:s'));
         $GLOBALS["db"]->query($query);
 
+        // Locked profiles keep their bio/profile fields, but relationship state is timeline data.
+        // Roll only relationship keys back to the loaded save snapshot so locked NPCs do not
+        // carry future affinity changes into the past.
+        $lockedRelRestoreQ = "WITH restore AS (
+            SELECT DISTINCT ON (h.npc_id)
+                h.npc_id,
+                h.extended_data
+            FROM core_npc_master_history h
+            JOIN core_npc_master c ON c.id = h.npc_id
+            WHERE c.npc_name <> 'The Narrator'
+              AND COALESCE(c.lock_profile, 0) = 1
+              AND (h.gamets_last_updated <= $timestamp OR h.gamets_last_updated IS NULL)
+            ORDER BY
+                h.npc_id,
+                h.gamets_last_updated DESC NULLS LAST,
+                CASE WHEN h.extended_data ->> '_chim_history_source' = 'infosave' THEN 1 ELSE 0 END DESC,
+                h.created DESC
+        )
+        UPDATE core_npc_master c
+        SET extended_data = (
+            (
+                COALESCE(c.extended_data, '{}'::jsonb)
+                - 'relationships'
+                - 'relationships_analyzed'
+                - 'relationships_inferred'
+                - 'relationships_last_eval'
+                - 'relationships_model'
+                - 'relationships_updated'
+                - '_chim_history_source'
+            )
+            || jsonb_strip_nulls(jsonb_build_object(
+                'relationships', restore.extended_data -> 'relationships',
+                'relationships_analyzed', restore.extended_data -> 'relationships_analyzed',
+                'relationships_inferred', restore.extended_data -> 'relationships_inferred',
+                'relationships_last_eval', restore.extended_data -> 'relationships_last_eval',
+                'relationships_model', restore.extended_data -> 'relationships_model',
+                'relationships_updated', restore.extended_data -> 'relationships_updated'
+            ))
+        )
+        FROM restore
+        WHERE c.id = restore.npc_id";
+
+        try {
+            $GLOBALS["db"]->execQuery($lockedRelRestoreQ);
+            error_log("[NPC RESTORE] Restored relationship timeline data for locked NPCs at gamets $timestamp");
+        } catch (Exception $e) {
+            error_log("[NPC RESTORE] Failed to restore locked NPC relationships: " . $e->getMessage());
+        }
+
         $bglife_q="UPDATE public.core_npc_master
         SET extended_data = jsonb_set(
             extended_data,
@@ -1102,7 +1230,14 @@ FROM restore
         // NPCs added AFTER the save timestamp don't have history entries, so they keep their
         // current (future) state. We need to clear their relationship data to prevent paradoxes.
         $rel_reset_q = "UPDATE public.core_npc_master
-            SET extended_data = extended_data - 'relationships' - 'relationships_updated' - 'relationships_model' - 'relationships_inferred'
+            SET extended_data = extended_data
+                - 'relationships'
+                - 'relationships_analyzed'
+                - 'relationships_inferred'
+                - 'relationships_last_eval'
+                - 'relationships_model'
+                - 'relationships_updated'
+                - '_chim_history_source'
             WHERE npc_name <> 'The Narrator'
               AND (gamets_last_updated > $timestamp OR gamets_last_updated IS NULL)
               AND extended_data IS NOT NULL
@@ -1117,6 +1252,24 @@ FROM restore
 
         error_log("[NPC RESTORE] " . date('Y-m-d H:i:s') . ", NPCs restore made in " . (time() - $startTime) . " secs ");
         return true;
+    }
+
+    private function markHistoryExtendedData($extendedData, $source)
+    {
+        $decoded = null;
+        if (is_array($extendedData)) {
+            $decoded = $extendedData;
+        } elseif (is_string($extendedData) && trim($extendedData) !== '') {
+            $decoded = json_decode($extendedData, true);
+        }
+
+        if (!is_array($decoded)) {
+            $decoded = [];
+        }
+
+        $decoded['_chim_history_source'] = $source;
+
+        return json_encode($decoded, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     public function renameNPC($oldname, $newname)

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -483,10 +483,45 @@ if (!function_exists('chimMergeRelationshipSeedIntoExtendedData')) {
     }
 }
 
+if (!function_exists('chimNpcRelationshipSaveNeedsLock')) {
+    function chimNpcRelationshipSaveNeedsLock(): bool
+    {
+        return isset($_POST['relationships_jsonb']) && trim((string)$_POST['relationships_jsonb']) !== '';
+    }
+}
+
+if (!function_exists('chimAcquireNpcRelationshipLock')) {
+    function chimAcquireNpcRelationshipLock($npcId): ?int
+    {
+        $npcId = (int)$npcId;
+        if ($npcId <= 0 || !chimNpcRelationshipSaveNeedsLock()) {
+            return null;
+        }
+
+        $lockId = 1001000000 + $npcId;
+        $GLOBALS['db']->execQuery("SELECT pg_advisory_lock({$lockId})");
+        return $lockId;
+    }
+}
+
+if (!function_exists('chimReleaseNpcRelationshipLock')) {
+    function chimReleaseNpcRelationshipLock($lockId): void
+    {
+        if ($lockId === null) {
+            return;
+        }
+
+        $GLOBALS['db']->execQuery("SELECT pg_advisory_unlock(" . (int)$lockId . ")");
+    }
+}
+
 // Handle Create
 if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["create"])) {
     if (chimUiAutoLockProfileEnabled()) {
         $_POST['lock_profile'] = 1;
+    }
+    if (file_exists(__DIR__."/../../ext/relationship_system/npc_save_handler.php")) {
+        include(__DIR__."/../../ext/relationship_system/npc_save_handler.php");
     }
     $npc->create($_POST);
     header("Location: npc_master.php");
@@ -495,11 +530,26 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["create"])) {
 
 // Handle Update
 if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["update"])) {
-    if (chimUiAutoLockProfileEnabled()) {
-        $_POST['lock_profile'] = 1;
+    $relationshipLockId = chimAcquireNpcRelationshipLock($_POST["id"] ?? 0);
+    try {
+        if (chimUiAutoLockProfileEnabled()) {
+            $_POST['lock_profile'] = 1;
+        }
+        if (file_exists(__DIR__."/../../ext/relationship_system/npc_save_handler.php")) {
+            include(__DIR__."/../../ext/relationship_system/npc_save_handler.php");
+        }
+        $_POST["md5"]=md5($_POST["npc_name"]);
+        $saveNpc = function () use ($npc) {
+            return $npc->update($_POST["id"], $_POST);
+        };
+        if (chimNpcRelationshipSaveNeedsLock()) {
+            chimRunWithRelationshipExtendedDataWrite($saveNpc);
+        } else {
+            $saveNpc();
+        }
+    } finally {
+        chimReleaseNpcRelationshipLock($relationshipLockId);
     }
-    $_POST["md5"]=md5($_POST["npc_name"]);
-    $npc->update($_POST["id"], $_POST);
     header("Location: npc_master.php");
     exit;
 }
@@ -508,13 +558,10 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["update"])) {
 if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["inline_update_npc"])) {
     try { while (ob_get_level() > 0) { ob_end_clean(); } } catch (Throwable $e) {}
     header('Content-Type: application/json');
+    $relationshipLockId = null;
     try {
         $id = intval($_POST['id'] ?? 0);
-
-        // Merge relationship editor data into extended_data BEFORE processing
-        if (file_exists(__DIR__."/../../ext/relationship_system/npc_save_handler.php")) {
-            include(__DIR__."/../../ext/relationship_system/npc_save_handler.php");
-        }
+        $relationshipLockId = chimAcquireNpcRelationshipLock($id);
 
         // Server-side: extended_data already has feature toggles synced by JS, just ensure it's valid JSON
         // The client-side JS only includes values that differ from profile defaults
@@ -574,6 +621,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["inline_update_npc"]))
         } catch (Throwable $e) {
             $_POST['extended_data'] = '{}';
         }
+
+        // Merge relationship editor data after all other extended_data processing.
+        // The structured relationship editor must be the last writer for relationships.
+        if (file_exists(__DIR__."/../../ext/relationship_system/npc_save_handler.php")) {
+            include(__DIR__."/../../ext/relationship_system/npc_save_handler.php");
+        }
         
         // Handle dynamic_profile: if empty string sent, set to NULL (inherit from profile)
         if (array_key_exists('dynamic_profile', $_POST)) {
@@ -593,7 +646,14 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["inline_update_npc"]))
             echo json_encode(["ok"=>true, "id"=>$newId]);
         } else {
             $_POST["md5"]=md5($_POST["npc_name"]);
-            $ok = $npc->update($id, $_POST);
+            $saveNpc = function () use ($npc, $id) {
+                return $npc->update($id, $_POST);
+            };
+            if (chimNpcRelationshipSaveNeedsLock()) {
+                $ok = chimRunWithRelationshipExtendedDataWrite($saveNpc);
+            } else {
+                $ok = $saveNpc();
+            }
             $npc->backupNpcById($id);// We also make a backup of manually edited NPCs, so when loading a save, will load this record
             if ($ok === false) {
                 echo json_encode(["ok"=>false, "error"=>($npc->getLastError() ?? 'Update failed')]);
@@ -603,6 +663,8 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["inline_update_npc"]))
         }
     } catch (Throwable $e) {
         echo json_encode(["ok"=>false, "error"=>$e->getMessage()]);
+    } finally {
+        chimReleaseNpcRelationshipLock($relationshipLockId);
     }
     exit;
 }
@@ -1446,6 +1508,15 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["restore_from_history"
             exit;
         }
         
+        $historyExtendedData = $histRow['extended_data'] ?? '';
+        if (is_string($historyExtendedData) && trim($historyExtendedData) !== '') {
+            $decodedHistoryExtendedData = json_decode($historyExtendedData, true);
+            if (is_array($decodedHistoryExtendedData)) {
+                unset($decodedHistoryExtendedData['_chim_history_source']);
+                $historyExtendedData = json_encode($decodedHistoryExtendedData, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            }
+        }
+
         // Prepare data for update (copy relevant fields from history)
         $updateData = [
             'npc_name' => $histRow['npc_name'] ?? '',
@@ -1470,12 +1541,14 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["restore_from_history"
             'dynamic_profile' => !empty($histRow['dynamic_profile']) ? 1 : 0,
             'tags' => $histRow['tags'] ?? '',
             'metadata' => $histRow['metadata'] ?? '',
-            'extended_data' => $histRow['extended_data'] ?? '',
+            'extended_data' => $historyExtendedData,
             'md5' => $histRow['md5'] ?? md5($histRow['npc_name'] ?? '')
         ];
         
         // Update the NPC
-        $ok = $npc->update($npcId, $updateData);
+        $ok = chimRunWithRelationshipExtendedDataWrite(function () use ($npc, $npcId, $updateData) {
+            return $npc->update($npcId, $updateData);
+        });
         if ($ok === false) {
             echo json_encode(["ok"=>false, "error"=>($npc->getLastError() ?? 'Restore failed')]);
         } else {
@@ -2468,7 +2541,20 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
             <small class="hint">Override global and profile settings for this specific NPC. Changes here take precedence over all other configurations.</small>
             <?php
             // Configure override editor for NPC mode
-            $reservedKeys = [ 'middle_term_enabled', 'individual_memory_enabled', 'auto_diary_enabled', 'auto_diary_wait_enabled', 'chim_core_migrated', 'salutation_after_a_while'];
+            $reservedKeys = [
+                'middle_term_enabled',
+                'individual_memory_enabled',
+                'auto_diary_enabled',
+                'auto_diary_wait_enabled',
+                'chim_core_migrated',
+                'salutation_after_a_while',
+                'relationships',
+                'relationships_updated',
+                'relationships_model',
+                'relationships_inferred',
+                'relationships_last_eval',
+                'relationships_analyzed'
+            ];
             $extendedDataRaw = isset($editItem["extended_data"]) ? $editItem["extended_data"] : '{}';
             $extendedDataObj = json_decode($extendedDataRaw, true) ?: [];
             $npcOverrideCatalog = chimGetOverrideableGeneralSettingsCatalog();
@@ -2623,6 +2709,10 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                   } catch (idontcare) {}
         
                   // allow empty metadata without confirmation
+                }
+
+                if (typeof syncRelationshipsToHidden === 'function') {
+                  syncRelationshipsToHidden();
                 }
 
                 const fd = new FormData(form);
@@ -5285,6 +5375,3 @@ $title = $TITLE;
 $buffer = preg_replace('/(<title>)(.*?)(<\/title>)/i', '$1' . $title . '$3', $buffer);
 echo $buffer;
 ?>
-
-
-

--- a/ui/core/tmpl/metadata_json_editor.php
+++ b/ui/core/tmpl/metadata_json_editor.php
@@ -484,6 +484,12 @@ function consolidation() {
         } catch(_e) {}
     }
 
+    try {
+        if (typeof syncRelationshipsToHidden === 'function') {
+            syncRelationshipsToHidden()
+        }
+    } catch(_e) {}
+
     return true;
 }
 

--- a/ui/global_settings.php
+++ b/ui/global_settings.php
@@ -69,6 +69,7 @@ $gsSections = [
         [ 'name' => 'CORE_CONNECTOR_PROFILES', 'type' => 'foreign:core_llm_connector:id:label' ],
         [ 'name' => 'CORE_CONNECTOR_DIRECTOR', 'type' => 'foreign:core_llm_connector:id:label' ],
         [ 'name' => 'RELLLM_CONNECTOR', 'type' => 'foreign:core_llm_connector:id:label' ],
+        [ 'name' => 'PLAYER_WORST_MEMORY_GAME_DAYS', 'type' => 'integer', 'min' => 0, 'max' => 365, 'default' => 7, 'help' => 'How long the player\'s worst memory of an NPC lingers before it fades, in in-game days (0 = never forget). Default 7 (one game-week). NPC-to-NPC worst memories are always permanent.' ],
         [ 'name' => 'CORE_CONNECTOR_OGHMA_CUSTOM', 'type' => 'foreign:core_llm_connector:id:label' ],
     ],
     'Context' => [
@@ -143,6 +144,7 @@ function pretty_label(string $flatName): string
         'CORE_CONNECTOR_DIRECTOR' => 'Director Mode',
         'CORE_CONNECTOR_OGHMA_CUSTOM' => 'Custom Oghma LLM',
         'RELLLM_CONNECTOR' => 'Relationship Management',
+        'PLAYER_WORST_MEMORY_GAME_DAYS' => 'Worst Memory Lifespan',
         'EMOTEMOODS' => 'Emote Moods',
         'ENFORCE_STRICT_RECHAT_RESPONSE' => 'Strict Rechat Targeting',
         'BGL_TRIGGER_DAYS' => 'Background Life Days Cooldown',
@@ -166,6 +168,7 @@ function pretty_label(string $flatName): string
 function icon_for_field(string $flatName): string
 {
     $u = strtoupper($flatName);
+    if ($u === 'PLAYER_WORST_MEMORY_GAME_DAYS') return '💔';
     if (strpos($u, 'FEATURES@MEMORY_EMBEDDING@') === 0 || strpos($u, 'MEMORY_') !== false) return '💭';
     if ($u === 'PLAYER_NAME') return '🏷️';
     if ($u === 'PROMPT_HEAD') return '🔝';
@@ -370,12 +373,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_all'])) {
         if (!chimSetGeneralSetting($name, $value, $description)) {
             $didSave = false;
         }
-    }
-
-    // Worst-memory lifespan: rendered inline on the Relationship Management card (not in $gsSections), so save it here.
-    $worstMemDays = normalize_posted_value('integer', $_POST['PLAYER_WORST_MEMORY_GAME_DAYS'] ?? '');
-    if (!chimSetGeneralSetting('PLAYER_WORST_MEMORY_GAME_DAYS', $worstMemDays, current_description('PLAYER_WORST_MEMORY_GAME_DAYS', $generalSettingRowMap))) {
-        $didSave = false;
     }
 
     $postedPromptContextRaw = [];
@@ -1317,8 +1314,14 @@ h1.gs-title {
 
                             $fieldType = strval($field['type']);
                             $current = current_value($fieldName);
+                            if (($current === '' || $current === null) && isset($field['default'])) {
+                                $current = $field['default'];
+                            }
                             $label = pretty_label($fieldName);
                             $help = current_description($fieldName, $generalSettingRowMap);
+                            if ($help === '' && isset($field['help'])) {
+                                $help = strval($field['help']);
+                            }
                             $schemaDefinition = chimGetSchemaDefinition($fieldName);
                             $isReadonly = isset($schemaDefinition['readonly']) && $schemaDefinition['readonly'] === true;
                             $readonlyAttr = $isReadonly ? 'readonly' : '';
@@ -1412,14 +1415,6 @@ h1.gs-title {
                                         </select>
                                     <?php else: ?>
                                         <input type="text" name="<?php echo htmlspecialchars($fieldName); ?>" value="<?php echo htmlspecialchars(strval($current)); ?>" <?php echo $readonlyAttr; ?>>
-                                    <?php endif; ?>
-                                    <?php if ($fieldName === 'RELLLM_CONNECTOR'): ?>
-                                        <?php $worstMemValue = current_value('PLAYER_WORST_MEMORY_GAME_DAYS'); if ($worstMemValue === '' || $worstMemValue === null) { $worstMemValue = 7; } ?>
-                                        <div style="margin-top:12px; border-top:1px solid #4a3d6a; padding-top:10px;">
-                                            <label style="display:block; font-size:12px; color:#bbb; margin-bottom:4px;">💔 Worst Memory Lifespan (in-game days, 0 = never forget)</label>
-                                            <input type="number" name="PLAYER_WORST_MEMORY_GAME_DAYS" value="<?php echo htmlspecialchars(strval($worstMemValue)); ?>" min="0" max="365" step="1">
-                                            <div style="font-size:11px; color:#888; margin-top:4px;">How long the player's worst memory of an NPC lingers before it fades. Default 7 (one game-week). NPC&harr;NPC worst memories are always permanent.</div>
-                                        </div>
                                     <?php endif; ?>
                                 </div>
                                 <?php if ($help !== ''): ?>

--- a/ui/global_settings.php
+++ b/ui/global_settings.php
@@ -372,6 +372,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_all'])) {
         }
     }
 
+    // Worst-memory lifespan: rendered inline on the Relationship Management card (not in $gsSections), so save it here.
+    $worstMemDays = normalize_posted_value('integer', $_POST['PLAYER_WORST_MEMORY_GAME_DAYS'] ?? '');
+    if (!chimSetGeneralSetting('PLAYER_WORST_MEMORY_GAME_DAYS', $worstMemDays, current_description('PLAYER_WORST_MEMORY_GAME_DAYS', $generalSettingRowMap))) {
+        $didSave = false;
+    }
+
     $postedPromptContextRaw = [];
     foreach ($promptContextCatalog as $bucket => $_options) {
         $postedPromptContextRaw[$bucket] = array_values(array_map('strval', $_POST['prompt_context_' . $bucket] ?? []));
@@ -1406,6 +1412,14 @@ h1.gs-title {
                                         </select>
                                     <?php else: ?>
                                         <input type="text" name="<?php echo htmlspecialchars($fieldName); ?>" value="<?php echo htmlspecialchars(strval($current)); ?>" <?php echo $readonlyAttr; ?>>
+                                    <?php endif; ?>
+                                    <?php if ($fieldName === 'RELLLM_CONNECTOR'): ?>
+                                        <?php $worstMemValue = current_value('PLAYER_WORST_MEMORY_GAME_DAYS'); if ($worstMemValue === '' || $worstMemValue === null) { $worstMemValue = 7; } ?>
+                                        <div style="margin-top:12px; border-top:1px solid #4a3d6a; padding-top:10px;">
+                                            <label style="display:block; font-size:12px; color:#bbb; margin-bottom:4px;">💔 Worst Memory Lifespan (in-game days, 0 = never forget)</label>
+                                            <input type="number" name="PLAYER_WORST_MEMORY_GAME_DAYS" value="<?php echo htmlspecialchars(strval($worstMemValue)); ?>" min="0" max="365" step="1">
+                                            <div style="font-size:11px; color:#888; margin-top:4px;">How long the player's worst memory of an NPC lingers before it fades. Default 7 (one game-week). NPC&harr;NPC worst memories are always permanent.</div>
+                                        </div>
                                     <?php endif; ?>
                                 </div>
                                 <?php if ($help !== ''): ?>


### PR DESCRIPTION
﻿Companion to #559 (reviewable independently; neither breaks without the other, together they close the data-loss window).

**Why:** generic NPC saves (profile updates, bulk passes, the AI bio generator) write the whole `extended_data` blob — racing the relationship worker, they can clobber the `relationships` key with a stale copy. This is observable data loss in live use: an NPC's relationship map silently reverts or empties.

- `lib/core/npc_master.class.php`: write guards — generic updates preserve the `relationships` key unless the write explicitly carries relationship data; relationship keys roll back with save loads (a reloaded earlier save shouldn't keep future-timeline relationship changes); history marking for recovery.
- `ui/core/npc_master.php` + `ui/core/tmpl/metadata_json_editor.php`: matching editor-side plumbing (lock checkbox always submits, safe JSON round-trips).
- `ui/global_settings.php`: adds the worst-memory lifespan setting as its own field (was briefly embedded in the connector card; that cramped the connector dropdown, so it now renders as a standalone setting with generic default/help support).

Happy to adjust to your direction.
