### PR TITLE
Quest engine: hold instruction generation while a scene marker is active

### DIFF
--- a/service/processors/snqe/cmd/main.php
+++ b/service/processors/snqe/cmd/main.php
@@ -34,9 +34,7 @@ if (($lastEvent[0]["n"] - $lastChat[0]["m"]) > 20) { // 20 seconds of silence
 }
 
 // An active sex scene reads as "silence" here (scene events are not chat/prechat/rechat), so the
-// quest agent would keep pushing story instructions into NPCs who must stay on the SexLab/OStim
-// cue. Hold quest progression while the scene marker is fresh; it resumes on the next tick after
-// the scene ends.
+// quest agent would keep pushing story instructions into NPCs who must stay on the SexLab/OStim.
 $sceneActiveFile = sys_get_temp_dir() . "/nsfw_scene_active.txt";
 $sceneEndedFile  = sys_get_temp_dir() . "/nsfw_scene_ended.txt";
 $sceneActiveTs = is_file($sceneActiveFile) ? (int)(file_get_contents($sceneActiveFile) ?: 0) : 0;

--- a/service/processors/snqe/cmd/main.php
+++ b/service/processors/snqe/cmd/main.php
@@ -33,6 +33,19 @@ if (($lastEvent[0]["n"] - $lastChat[0]["m"]) > 20) { // 20 seconds of silence
     $GLOBALS["NPCS_ARE_NOT_TALKING"] = 0;
 }
 
+// An active sex scene reads as "silence" here (scene events are not chat/prechat/rechat), so the
+// quest agent would keep pushing story instructions into NPCs who must stay on the SexLab/OStim
+// cue. Hold quest progression while the scene marker is fresh; it resumes on the next tick after
+// the scene ends.
+$sceneActiveFile = sys_get_temp_dir() . "/nsfw_scene_active.txt";
+$sceneEndedFile  = sys_get_temp_dir() . "/nsfw_scene_ended.txt";
+$sceneActiveTs = is_file($sceneActiveFile) ? (int)(file_get_contents($sceneActiveFile) ?: 0) : 0;
+$sceneEndedTs  = is_file($sceneEndedFile) ? (int)(file_get_contents($sceneEndedFile) ?: 0) : 0;
+if ($sceneActiveTs > 0 && (time() - $sceneActiveTs) < 300 && $sceneActiveTs >= $sceneEndedTs) {
+    error_log("[SNQE MAIN] Active scene - holding quest instruction generation");
+    return;
+}
+
 $quests = $GLOBALS["db"]->fetchAll("select * from sneq_quests where quest_run_state IN ('not_running','not started','running')");
 
 foreach ($quests as $questRow) {


### PR DESCRIPTION
The snqe idle check treats any gap in chat/prechat/rechat events as "NPCs are not talking" and pushes the next story instruction. Scripted scenes (SexLab/OStim and similar) produce no chat-type events, so an active scene reads as permanent silence: the quest director keeps landing "X should do Y" instructions on the scene participants and pulls them out of the scene context (log-observed at roughly one instruction per 30s for the duration of a scene). So I put in stops only when an NSFW scene is occurring...so that NPCs don't start talking about random quest during scenes. 

This adds a hold: scene-aware extensions stamp a temp-file marker while a scene runs, and the quest engine skips instruction generation while the marker is fresh (5-minute staleness cap, end-latch aware- can reduce if you'd like). If no extension stamps the marker, the file never exists and behavior is unchanged.
