### PR TITLE
Relationship eval: earned type changes, romance gate, timeline stamping

### DIFF
--- a/ext/relationship_system/relationship_llm.php
+++ b/ext/relationship_system/relationship_llm.php
@@ -565,6 +565,7 @@ PROMPT;
                     'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
                 ]);
             });
+            if (function_exists('chimRelationshipTimelineStamp')) { chimRelationshipTimelineStamp($npcId); }
 
             $this->releaseNpcLock($npcId);
             return $result;
@@ -738,6 +739,7 @@ PROMPT;
                         'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
                     ]);
                 });
+                if (function_exists('chimRelationshipTimelineStamp')) { chimRelationshipTimelineStamp($npcId); }
 
                 $this->releaseNpcLock($npcId);
                 Logger::info("[REL-LLM] Inferred " . count($inferred) . " relationships for " . $npc['npc_name']);
@@ -930,6 +932,12 @@ Only suggest changes for SIGNIFICANT moments - not every interaction needs a cha
 {$outputKeyInstruction}
 
 Return JSON: {"changes": {"{$listenerKey}": {"delta": X, "reason": "brief"}}}
+If (and ONLY if) this exchange changed the relationship's NATURE - romance, betrayal,
+marriage, becoming enemies - also include "type", e.g.
+{"changes": {"{$listenerKey}": {"delta": X, "type": "crush", "reason": "brief"}}}
+Be conservative: one passing line never flips a type. The change must be backed by sustained
+energy or real/implied history, and it must come from {$npcName}'s own expressed feelings -
+{$listenerKey} pushing or flirting is not grounds for it.
 Or if no changes: {"changes": {}}
 PROMPT;
 
@@ -1214,17 +1222,30 @@ REASON FORMAT - Keep it SHORT (under 15 words):
 ✓ "Protective action builds trust"
 ✗ NOT: Long clinical explanations
 
-TYPE CHANGES (rare - only for defining moments):
-- Only change type for: romance confession, betrayal, violence, marriage, family reveal
-- Most interactions just adjust affinity, not type
+TYPE CHANGES (rare - only for DEFINING moments):
+- Add "type" ONLY when this exchange visibly changed the NATURE of the relationship:
+  romance, betrayal, marriage, family reveal, becoming enemies.
+- Be conservative. One passing compliment, joke, or flirty line NEVER flips a type.
+  A type change must be backed by sustained energy in this exchange or by the history
+  between them - repeated warmth, declarations, a shared past, stated or clearly implied.
+- The evidence must come from the SPEAKER's own expressed feelings. The other party
+  flirting, pushing, or asking is never grounds to flip a type.
+- When in doubt, omit "type". Most interactions only adjust affinity.
 
 OUTPUT (JSON only):
 {"changes": {"Player": {"delta": 1, "reason": "brief insight"}}}
+Defining type change: {"changes": {"Player": {"delta": 5, "type": "crush", "reason": "confessed her crush"}}}
 
 No changes? Return: {"changes": {}}
 PROMPT;
 
-        return $this->loadPrompt('rel_llm_evaluation', $fallback);
+        $prompt = $this->loadPrompt('rel_llm_evaluation', $fallback);
+        // Seeded defaults from before the type-change syntax existed teach a delta-only output;
+        // upgrade them in place. Custom prompts that already know "type" are left alone.
+        if (strpos($prompt, 'only for defining moments') !== false && strpos($prompt, '"type"') === false) {
+            return $fallback;
+        }
+        return $prompt;
     }
 
     /**
@@ -1335,10 +1356,9 @@ PROMPT;
             $typeChanged = false;
             $finalType = $oldType;
 
-            // ROMANTIC AUTO-PROMOTION GUARD (user directive): the relationship model must NOT unilaterally promote a
-            // non-romantic relationship INTO a romantic-leaning type (e.g. professional -> crush in one interaction,
-            //). Romantic types are earned / player-set in the relationship editor, never
-            // auto-assigned by the model. Affinity + notes still update; only the romantic TYPE jump is blocked.
+            // EARNED-ROMANCE GATE: promotion INTO a romantic-leaning type requires Fond-tier
+            // affinity (56+, matches getAffinityTierName) and an explicit reason from the model.
+            // Below that, blocked - one flirty exchange must not flip a stranger to romantic.
             // Downgrades OUT of romantic and moves between non-romantic types are unaffected.
             $romanticTypes = ['romantic', 'crush', 'admirer', 'obsessed', 'infatuated', 'lover'];
             $oldIsRomantic = in_array(strtolower((string)$oldType), $romanticTypes, true);
@@ -1346,8 +1366,9 @@ PROMPT;
             if ($newType) {
                 // LLM explicitly set a type
                 $newTypeLower = strtolower($newType);
-                if (in_array($newTypeLower, $romanticTypes, true) && !$oldIsRomantic) {
-                    Logger::info("[REL-LLM] BLOCKED romantic auto-promotion: {$npc['npc_name']} -> {$target}: {$oldType} => {$newTypeLower} (kept '{$oldType}'; romantic types are player-set in the UI)");
+                $promotesToRomantic = in_array($newTypeLower, $romanticTypes, true) && !$oldIsRomantic;
+                if ($promotesToRomantic && ($newAff < 56 || trim((string)$reason) === '')) {
+                    Logger::info("[REL-LLM] BLOCKED romantic promotion: {$npc['npc_name']} -> {$target}: {$oldType} => {$newTypeLower} (aff {$newAff} below fond tier or no reason; kept '{$oldType}')");
                 } else {
                     if ($oldType !== $newTypeLower) {
                         Logger::info("[REL-LLM] TYPE CHANGE: {$npc['npc_name']} -> {$target}: {$oldType} => {$newTypeLower}");
@@ -1489,6 +1510,7 @@ PROMPT;
                         'extended_data' => $jsonData
                     ]);
                 });
+                if (function_exists('chimRelationshipTimelineStamp')) { chimRelationshipTimelineStamp($npcId); }
 
                 $this->releaseNpcLock($npcId);
                 Logger::debug("[REL-LLM] Database update for NPC {$npcId}: " . ($result === false ? "FAILED" : "OK") . " - relationships: " . json_encode($existingRels));

--- a/lib/core/npc_master.class.php
+++ b/lib/core/npc_master.class.php
@@ -150,6 +150,53 @@ if (!function_exists('herikaResolveNpcRolemasterState')) {
     }
 }
 
+if (!function_exists('chimRelationshipTimelineStamp')) {
+    // Timeline safety for relationship writes (re-applied 2026-07-06; this is the USEFUL half of the
+    // reverted 110e0b84 - the paradox-clear NULL bucket below stays exactly as designed). Relationship
+    // progress previously lived ONLY in the live row between infosave backups: rows were never
+    // gamets-stamped (so the restore paradox-clear treated them as unsaved data and a mere server
+    // reconnect wiped them) and never snapshotted (so a load restored pre-grind state).
+    // 1) stamp gamets_last_updated with the current game time so the row sits on the timeline;
+    // 2) drop a THROTTLED history snapshot (once per NPC per 30 real minutes, cross-process via
+    //    the history table itself) so the progress is restorable like any other profile state.
+    // A genuine Dragon Break (loading an older save) still clears these rows correctly: their stamp
+    // is provably in that save's future.
+    function chimRelationshipTimelineStamp($npcId)
+    {
+        try {
+            $npcId = (int) $npcId;
+            if ($npcId <= 0 || !isset($GLOBALS['db'])) {
+                return;
+            }
+            $g = 0;
+            if (isset($GLOBALS['gameRequest'][2]) && is_numeric($GLOBALS['gameRequest'][2])) {
+                $g = (float) $GLOBALS['gameRequest'][2];
+            } elseif (function_exists('DataLastKnownGameTS')) {
+                $g = (float) DataLastKnownGameTS();
+            }
+            if ($g > 0) {
+                $GLOBALS['db']->execQuery("UPDATE core_npc_master SET gamets_last_updated = {$g} WHERE id = {$npcId}");
+            }
+            static $lastSnap = [];
+            $now = time();
+            if (($lastSnap[$npcId] ?? 0) > $now - 1800) {
+                return;
+            }
+            $row = $GLOBALS['db']->fetchOne("SELECT extract(epoch from created) AS e FROM core_npc_master_history WHERE npc_id = {$npcId} ORDER BY created DESC LIMIT 1");
+            if ($row && (float) ($row['e'] ?? 0) > $now - 1800) {
+                $lastSnap[$npcId] = $now;
+                return;
+            }
+            $nm = new NpcMaster();
+            $nm->backupNpcById($npcId);
+            $lastSnap[$npcId] = $now;
+            error_log("[REL] Timeline snapshot for npc_id {$npcId} (relationship progress persisted to history)");
+        } catch (Exception $e) {
+            error_log("[REL] Timeline stamp failed for npc_id " . (int) $npcId . ": " . $e->getMessage());
+        }
+    }
+}
+
 if (!function_exists('chimRunWithRelationshipExtendedDataWrite')) {
     function chimRunWithRelationshipExtendedDataWrite($callback)
     {

--- a/lib/relationship_manager.php
+++ b/lib/relationship_manager.php
@@ -696,6 +696,7 @@ class RelationshipManager {
                     'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
                 ]);
             });
+            if (function_exists('chimRelationshipTimelineStamp')) { chimRelationshipTimelineStamp($npcData['id']); }
         }
 
         // Strip commands before TTS
@@ -739,6 +740,7 @@ class RelationshipManager {
                 'extended_data' => json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
             ]);
         });
+        if (function_exists('chimRelationshipTimelineStamp')) { chimRelationshipTimelineStamp($npcData['id']); }
 
         error_log("[REL] Set $npcName -> $targetName: " . $rels[$targetName]['aff'] .
                   " (" . $rels[$targetName]['type'] . ")");


### PR DESCRIPTION
Follow-up to #559/#560: three improvements to the relationship evaluation pipeline, all live-tested on my install.

## 1. Type-change proposals for defining moments

The eval prompt now teaches the model it may include a `type` alongside the affinity delta when an exchange genuinely changed the relationship's NATURE (romance, betrayal, marriage, becoming enemies), with conservative guardrails baked into the prompt: one passing compliment or flirty line never flips a type, the change must be backed by sustained energy or real history, and the evidence must come from the speaker's own expressed feelings (the other party pushing is never grounds). When in doubt the model omits `type` and only affinity moves.

Seeded default prompts from before the type syntax existed teach a delta-only output; those are upgraded in place. Custom prompts that already mention `"type"` are left alone.

## 2. Earned-romance gate

Promotion INTO a romantic-leaning type (`romantic`, `crush`, `admirer`, `obsessed`, `infatuated`, `lover`) previously hit a blanket block, so a genuinely earned romance could never be recorded by the model. It now requires fond-tier affinity (56+, matching `getAffinityTierName`) AND an explicit reason from the model; below that it stays blocked, so one flirty exchange still cannot flip a stranger to romantic. Downgrades out of romantic and moves between non-romantic types are unaffected.

## 3. Relationship timeline stamping

Relationship writes previously lived only in the live row between infosave backups: the rows were never gamets-stamped, so the restore paradox-clear treated them as unsaved data and a mere server reconnect could wipe fresh progress, and they were never snapshotted, so a load restored pre-grind state.

New `chimRelationshipTimelineStamp($npcId)` (guarded by `function_exists`) stamps `gamets_last_updated` with the current game time and drops a THROTTLED history snapshot (once per NPC per 30 real minutes, cross-process via the history table itself), called after each relationship write (3 sites in `relationship_llm.php`, 2 in `relationship_manager.php`).

**The paradox-clear itself is untouched** - the NULL bucket stays exactly as designed, and a genuine Dragon Break (loading an older save) still clears future-stamped rows correctly. Verified live: snapshot count increments on relationship writes, log line `[REL] Timeline snapshot`.

## Footprint

3 files, +81/-10. No schema changes, no new settings.
