### PR TITLE
Plugins page: SHARMAT as the maintained NSFW entry + featured-plugin branding

### DIFF
--- a/ui/data/plugin_repository.json
+++ b/ui/data/plugin_repository.json
@@ -39,12 +39,24 @@
                 }
             }
         },
-        "aiagent_nsfw": {
+        "sharmat": {
             "name": "aiagent_nsfw",
-            "description": "Integration with OSTIM.",
-            "git_repo": "maister-sk/aiagent_nsfw",
-            "github_url": "https://github.com/maister-sk/aiagent_nsfw",
-            "mod_download_url": "https://github.com/maister-sk/aiagent_nsfw/releases/download/<version>/AIAgentNSFW.zip"
+            "display_name": "SHARMAT",
+            "featured": true,
+            "icon": "https://raw.githubusercontent.com/Wondernuttz/Sharmat-Alpha/main/images/ChimNSFWLogoTransparent.png",
+            "description": "The official NSFW framework for CHIM. Consent-driven intimacy and scenes (OStim + SexLab), arousal and relationship-aware behavior, VR touch reactions.",
+            "git_repo": "Wondernuttz/Sharmat-Alpha",
+            "github_url": "https://github.com/Wondernuttz/Sharmat-Alpha",
+            "mod_download_url": "https://github.com/Wondernuttz/Sharmat-Alpha/tree/main/mod",
+            "default_channel": "main",
+            "channels": {
+                "main": {
+                    "label": "Live",
+                    "branch": "main",
+                    "package_source": "branch",
+                    "allow_force": true
+                }
+            }
         }
     }
 } 

--- a/ui/server_plugins.php
+++ b/ui/server_plugins.php
@@ -112,6 +112,116 @@ tr:hover td {
 /* Extra styling parity with index.php */
 .title-with-button { display:flex; align-items:center; }
 .title-with-button h2 { margin-right:10px; margin-bottom:0; }
+/* Featured-plugin branding (SHARMAT) - matches the SHARMAT UI language exactly:
+   gold-glow name = .gold-glow-text (#FDF5D0 + neonPulse purple halo),
+   buttons = .create-style-btn (dark indigo #252233, cream border, creamPulse breathing),
+   row = batchCardBreathing purple over the dark indigo wash. */
+@keyframes sharmatNeonPulse {
+    from { text-shadow: none; }
+    to {
+        text-shadow:
+            0 0 8px #C9A0DC,
+            0 0 25px rgba(180, 130, 200, 0.8),
+            0 0 50px rgba(150, 100, 180, 0.6),
+            0 0 70px rgba(107, 91, 122, 0.4);
+    }
+}
+@keyframes sharmatCreamPulse {
+    from {
+        text-shadow: 0 0 3px rgba(253, 245, 208, 0.2);
+        box-shadow: 0 0 5px rgba(253, 245, 208, 0.2);
+        border-color: rgba(253, 245, 208, 0.7);
+    }
+    to {
+        text-shadow: 0 0 8px rgba(253, 245, 208, 0.6), 0 0 15px rgba(253, 245, 208, 0.4);
+        box-shadow: 0 0 12px rgba(253, 245, 208, 0.5), 0 0 20px rgba(253, 245, 208, 0.3);
+        border-color: #FDF5D0;
+    }
+}
+/* All SHARMAT breathing runs on the SAME clock: 3s ease-in-out alternate, from = rest, to = peak,
+   so the lady, the SHARMAT wording, the row, and the buttons inhale and exhale together. */
+@keyframes sharmatRowBreathing {
+    from {
+        border-color: rgba(139, 92, 246, 0.4);
+        box-shadow: inset 0 0 20px rgba(139, 92, 246, 0.05);
+    }
+    to {
+        border-color: rgba(168, 85, 247, 0.7);
+        box-shadow: inset 0 0 30px rgba(168, 85, 247, 0.1);
+    }
+}
+@keyframes sharmatIconPulse {
+    from { filter: drop-shadow(0 0 5px rgba(168, 85, 247, 0.7)); }
+    to { filter: drop-shadow(0 0 12px rgba(168, 85, 247, 1)) drop-shadow(0 0 18px rgba(253, 245, 208, 0.45)); }
+}
+.featured-plugin-cell { display: inline-flex; align-items: center; gap: 12px; }
+.featured-plugin-icon { width: 52px; height: 52px; object-fit: contain; animation: sharmatIconPulse 3s ease-in-out infinite alternate; }
+.featured-plugin-name {
+    font-family: 'MagicCards', 'Segoe UI', sans-serif;
+    font-weight: 600;
+    font-size: 1.6em;
+    letter-spacing: 1px;
+    word-spacing: 6px;
+    color: #FDF5D0;
+    animation: sharmatNeonPulse 3s ease-in-out infinite alternate;
+}
+.btn-sharmat {
+    font-family: 'MagicCards', 'Segoe UI', sans-serif;
+    font-size: 14px;
+    letter-spacing: 1px;
+    word-spacing: 6px;
+    color: #FDF5D0 !important;
+    background: #252233 !important;
+    border: 2px solid #FDF5D0 !important;
+    border-radius: 10px;
+    padding: 6px 14px;
+    cursor: pointer;
+    animation: sharmatCreamPulse 3s ease-in-out infinite alternate;
+}
+.btn-sharmat:hover { background: #2A2740 !important; }
+.btn-sharmat:disabled { opacity: 0.75; }
+/* SHARMAT delete button: maroon-red body, GOLD text + gold trim, breathing the SAME
+   sharmatCreamPulse gold glow as the strip buttons so it's locked to their cadence. */
+.btn-sharmat-danger {
+    font-family: 'MagicCards', 'Segoe UI', sans-serif;
+    font-size: 14px;
+    letter-spacing: 1px;
+    word-spacing: 6px;
+    font-weight: 600;
+    color: #FDF5D0 !important;
+    background: linear-gradient(135deg, #3E0E22 0%, #2A0816 100%) !important;
+    border: 2px solid #FDF5D0 !important;
+    border-radius: 10px;
+    padding: 6px 14px;
+    cursor: pointer;
+    animation: sharmatCreamPulse 3s ease-in-out infinite alternate;
+}
+.btn-sharmat-danger:hover {
+    background: linear-gradient(135deg, #4E1230 0%, #360A1E 100%) !important;
+}
+/* The SHARMAT row itself: dark indigo wash + breathing purple separators instead of the gray line.
+   Row text = the SHARMAT UI's regular note font in the lavender wording color, no glow.
+   The channel label ("Live") keeps MagicCards + the gold glow via .featured-live. */
+tr.featured-plugin-row td {
+    background: linear-gradient(135deg, rgba(28, 26, 36, 0.9), rgba(37, 34, 51, 0.95)) !important;
+    border-top: 1px solid rgba(139, 92, 246, 0.5);
+    border-bottom: 1px solid rgba(139, 92, 246, 0.5) !important;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-weight: normal;
+    font-size: 1em;
+    line-height: 1.6;
+    color: #C9A8FF;
+    animation: sharmatRowBreathing 3s ease-in-out infinite alternate;
+}
+.featured-live {
+    font-family: 'MagicCards', 'Segoe UI', sans-serif;
+    font-weight: 600;
+    font-size: 1.15em;
+    letter-spacing: 1px;
+    word-spacing: 6px;
+    color: #FDF5D0;
+    animation: sharmatNeonPulse 3s ease-in-out infinite alternate;
+}
 </style>
 
 <main>
@@ -386,11 +496,27 @@ tr:hover td {
                     $latestVersion = getPluginManagerChannelVersion($gitRepo, $currentChannel);
                 }
 
-                echo '<tr>';
-                echo '<td>' . htmlspecialchars($name) . '</td>';
+                // Featured-plugin branding (display_name / icon / featured from manifest or repository entry)
+                $displayName = (string)($manifest['display_name'] ?? (is_array($repositoryEntry) ? ($repositoryEntry['display_name'] ?? $name) : $name));
+                $isFeatured = !empty($manifest['featured']) || (is_array($repositoryEntry) && !empty($repositoryEntry['featured']));
+                $iconRef = (string)($manifest['icon'] ?? (is_array($repositoryEntry) ? ($repositoryEntry['icon'] ?? '') : ''));
+                $iconUrl = '';
+                if ($iconRef !== '') {
+                    $iconUrl = preg_match('#^https?://#i', $iconRef) ? $iconRef : ($webRoot . '/ext/' . rawurlencode($folder) . '/' . ltrim($iconRef, '/'));
+                }
+                $rowBtnPrimary = $isFeatured ? 'btn-base btn-sharmat' : 'btn-base btn-primary';
+                $rowBtnSave = $isFeatured ? 'btn-base btn-sharmat' : 'btn-base btn-save';
+
+                echo $isFeatured ? '<tr class="featured-plugin-row">' : '<tr>';
+                if ($isFeatured) {
+                    echo '<td><span class="featured-plugin-cell">' . ($iconUrl !== '' ? '<img src="' . htmlspecialchars($iconUrl) . '" class="featured-plugin-icon" alt="">' : '') . '<span class="featured-plugin-name">' . htmlspecialchars($displayName) . '</span></span></td>';
+                } else {
+                    echo '<td>' . htmlspecialchars($displayName) . '</td>';
+                }
                 echo '<td>' . htmlspecialchars($description) . '</td>';
                 echo '<td>' . htmlspecialchars($version) . '</td>';
-                echo '<td>' . htmlspecialchars($currentChannel['label'] ?? $currentChannelId) . '</td>';
+                $channelLabelHtml = htmlspecialchars($currentChannel['label'] ?? $currentChannelId);
+                echo '<td>' . ($isFeatured ? '<span class="featured-live">' . $channelLabelHtml . '</span>' : $channelLabelHtml) . '</td>';
                 if (!empty($latestVersion) && !empty($version) && version_compare($latestVersion, $version, '>')) {
                     echo '<td style="color: #ff4444; font-weight: bold;">' . htmlspecialchars($latestVersion) . ' <span title="Update Available">⬆️</span></td>';
                 } else {
@@ -398,21 +524,21 @@ tr:hover td {
                 }
                 echo '<td>';
                 if (!empty($configUrl)) {
-                    echo '<button onclick="window.open(\'' . htmlspecialchars($configUrl) . '\', \'_blank\')" class="btn-base btn-primary">Plugin Page</button>';
+                    echo '<button onclick="window.open(\'' . htmlspecialchars($configUrl) . '\', \'_blank\')" class="' . $rowBtnPrimary . '">Plugin Page</button>';
                     if (isset($manifest['schema_version']) && $manifest['schema_version']==2 && !empty($gitRepo)) {
                         $forceCurrentChannel = !empty($currentChannel['allow_force']);
                         $updateUrl = buildPluginInstallerUrl($pluginId, $name, $gitRepo, $currentChannelId, $forceCurrentChannel);
-                        echo ' <button onclick="window.open(\'' . htmlspecialchars($updateUrl) . '\', \'_blank\')" class="btn-base btn-save">Update ' . htmlspecialchars($currentChannel['label'] ?? 'Plugin') . '</button>';
+                        echo ' <button onclick="window.open(\'' . htmlspecialchars($updateUrl) . '\', \'_blank\')" class="' . $rowBtnSave . '">Update ' . htmlspecialchars($currentChannel['label'] ?? 'Plugin') . '</button>';
                         foreach ($channels as $channelId => $channel) {
                             if ($channelId === $currentChannelId) {
                                 continue;
                             }
                             $switchUrl = buildPluginInstallerUrl($pluginId, $name, $gitRepo, $channelId, true);
-                            echo ' <button onclick="window.open(\'' . htmlspecialchars($switchUrl) . '\', \'_blank\')" class="btn-base btn-primary">Switch to ' . htmlspecialchars($channel['label']) . '</button>';
+                            echo ' <button onclick="window.open(\'' . htmlspecialchars($switchUrl) . '\', \'_blank\')" class="' . $rowBtnPrimary . '">Switch to ' . htmlspecialchars($channel['label']) . '</button>';
                         }
                     }
                     if (!empty($modDownloadUrl)) {
-                        echo ' <button onclick="window.open(\'' . htmlspecialchars($modDownloadUrl) . '\', \'_blank\')" class="btn-base btn-save">Download Skyrim Modfile</button>';
+                        echo ' <button onclick="window.open(\'' . htmlspecialchars($modDownloadUrl) . '\', \'_blank\')" class="' . $rowBtnSave . '">Download Skyrim Modfile</button>';
                     }
 
                 } else {
@@ -423,7 +549,7 @@ tr:hover td {
                 if ($folder !== 'herika_heal' && $folder !== 'time_awareness') {
                     echo '<form method="post" style="margin:0;" onsubmit="return confirm(\'Are you sure you want to delete the ' . htmlspecialchars($name) . ' plugin?\');">';
                     echo '<input type="hidden" name="delete_plugin" value="' . htmlspecialchars($folder) . '">';
-                    echo '<button type="submit" class="btn-base btn-danger">Delete Plugin</button>';
+                    echo '<button type="submit" class="btn-base ' . ($isFeatured ? 'btn-sharmat-danger' : 'btn-danger') . '">Delete Plugin</button>';
                     echo '</form>';
                 } else {
                     echo 'Cannot be deleted';
@@ -463,25 +589,37 @@ tr:hover td {
                 }
             }
 
-            echo '<tr>';
-            echo '<td>' . htmlspecialchars($name) . '</td>';
+            // Featured-plugin branding (SHARMAT)
+            $displayName = (string)($plugin['display_name'] ?? $name);
+            $isFeatured = !empty($plugin['featured']);
+            $repoIconUrl = (string)($plugin['icon'] ?? '');
+            $rowBtnPrimary = $isFeatured ? 'btn-base btn-sharmat' : 'btn-base btn-primary';
+            $rowBtnSave = $isFeatured ? 'btn-base btn-sharmat' : 'btn-base btn-save';
+
+            echo $isFeatured ? '<tr class="featured-plugin-row">' : '<tr>';
+            if ($isFeatured) {
+                echo '<td><span class="featured-plugin-cell">' . ($repoIconUrl !== '' ? '<img src="' . htmlspecialchars($repoIconUrl) . '" class="featured-plugin-icon" alt="">' : '') . '<span class="featured-plugin-name">' . htmlspecialchars($displayName) . '</span></span></td>';
+            } else {
+                echo '<td>' . htmlspecialchars($displayName) . '</td>';
+            }
             echo '<td>' . htmlspecialchars($description) . '</td>';
             echo '<td>';
             if ($isInstalled) {
-                echo '<button class="btn-base" disabled style="opacity: 0.6;">Already Installed</button>';
+                echo '<button class="btn-base' . ($isFeatured ? ' btn-sharmat' : '') . '" disabled style="opacity: 0.6;">Already Installed</button>';
             } else {
                 $defaultChannelId = (string)($plugin['default_channel'] ?? 'main');
                 foreach ($channels as $channelId => $channel) {
                     $installUrl = buildPluginInstallerUrl($pluginId, $name, $plugin['git_repo'], $channelId, false);
-                    $installLabel = ($channelId === $defaultChannelId) ? 'Install Plugin' : 'Install ' . ($channel['label'] ?? ucfirst((string)$channelId));
-                    echo ' <button onclick="window.open(\'' . htmlspecialchars($installUrl) . '\', \'_blank\')" class="btn-base btn-save">' . htmlspecialchars($installLabel) . '</button>';
+                    $installBase = $isFeatured ? 'Install ' . $displayName : 'Install Plugin';
+                    $installLabel = ($channelId === $defaultChannelId) ? $installBase : 'Install ' . ($channel['label'] ?? ucfirst((string)$channelId));
+                    echo ' <button onclick="window.open(\'' . htmlspecialchars($installUrl) . '\', \'_blank\')" class="' . $rowBtnSave . '">' . htmlspecialchars($installLabel) . '</button>';
                 }
             }
             if (!empty($githubUrl)) {
-                echo ' <button onclick="window.open(\'' . htmlspecialchars($githubUrl) . '\', \'_blank\')" class="btn-base btn-primary">GitHub</button>';
+                echo ' <button onclick="window.open(\'' . htmlspecialchars($githubUrl) . '\', \'_blank\')" class="' . $rowBtnPrimary . '">GitHub</button>';
             }
             if (!empty($modDownloadUrl)) {
-                echo ' <button onclick="window.open(\'' . htmlspecialchars($modDownloadUrl) . '\', \'_blank\')" class="btn-base btn-primary">Mod Download</button>';
+                echo ' <button onclick="window.open(\'' . htmlspecialchars($modDownloadUrl) . '\', \'_blank\')" class="' . $rowBtnPrimary . '">Mod Download</button>';
             }
             echo '</td>';
             echo '</tr>';


### PR DESCRIPTION
## What

Two things, one page:

**1. The NSFW plugin entry now points at its maintained successor.** The `aiagent_nsfw` registry entry pointed at `maister-sk/aiagent_nsfw`, which is no longer maintained. SHARMAT ([Wondernuttz/Sharmat-Alpha](https://github.com/Wondernuttz/Sharmat-Alpha)) is the actively maintained successor built against current CHIM: consent-driven intimacy and scenes (OStim + SexLab), arousal and relationship-aware behavior, VR touch reactions, all configured from its own plugin page.

- Installs into the **same `ext/aiagent_nsfw` folder**, so existing installs update in place from the new source and nothing else changes for them.
- Uses a **main-branch install channel** (`package_source: branch`), so installs work with no release assets; the repo root already carries `manifest.json` and the standard layout the installer expects.
- Mod download button points at the in-repo `mod/` folder.

**2. Optional featured-plugin branding.** Repository entries and installed-plugin manifests may now carry three optional keys: `display_name`, `icon`, and `featured`. A featured row renders its icon and display name with themed styling and themed buttons; everything else renders exactly as before (all three keys absent = zero visual change). SHARMAT is the first entry to use it.

## Notes

- No installer changes needed; `server_plugin_installer.php` already handles the branch channel.
- `php -l` clean; JSON validated.

