### PR TITLE
Plugin catalog: drop 'official' from SHARMAT description

### DIFF
--- a/ui/data/plugin_repository.json
+++ b/ui/data/plugin_repository.json
@@ -44,7 +44,7 @@
             "display_name": "SHARMAT",
             "featured": true,
             "icon": "https://raw.githubusercontent.com/Wondernuttz/Sharmat-Alpha/main/images/ChimNSFWLogoTransparent.png",
-            "description": "The official NSFW framework for CHIM. Consent-driven intimacy and scenes (OStim + SexLab), arousal and relationship-aware behavior, VR touch reactions.",
+            "description": "An NSFW framework for CHIM. Consent-driven intimacy and scenes (OStim + SexLab), arousal and relationship-aware behavior, VR touch reactions.",
             "git_repo": "Wondernuttz/Sharmat-Alpha",
             "github_url": "https://github.com/Wondernuttz/Sharmat-Alpha",
             "mod_download_url": "https://github.com/Wondernuttz/Sharmat-Alpha/tree/main/mod",


### PR DESCRIPTION
## What

One-line wording fix to the SHARMAT entry in the plugin catalog.

The description read "**The official** NSFW framework for CHIM" - dropping "official" so it makes no claim of being an endorsed/sanctioned CHIM component. It's a third-party plugin and shouldn't imply otherwise.

```
- "description": "The official NSFW framework for CHIM. ..."
+ "description": "An NSFW framework for CHIM. ..."
```

No other change. The SHARMAT entry (repo, channels, install behavior) is untouched and already installs through the plugin browser like the others.
