### PR TITLE
fix: wrong table name in power_awareness.php

### DIFF
--- a/lib/power_awareness.php
+++ b/lib/power_awareness.php
@@ -50,7 +50,7 @@ function getNpcLevel(string $npcName): ?int {
         $db = $GLOBALS["db"];
         $escapedName = $db->escape($npcName);
         
-        $npcData = $db->fetchOne("SELECT metadata FROM core_npc WHERE npc_name = '{$escapedName}' LIMIT 1");
+        $npcData = $db->fetchOne("SELECT metadata FROM core_npc_master WHERE npc_name = '{$escapedName}' LIMIT 1");
         
         if (!$npcData || empty($npcData['metadata'])) {
             return null;


### PR DESCRIPTION
# ⚠️ ALL PR'S MUST BE SUBMITTED TO THE `UNSTABLE` BRANCH ⚠️

---

## What

fix wrong table name in power_awareness.php

## Why

ERROR:  relation "core_npc" does not exist

