### PR TITLE
Fix: middleterm scheduler ignores profile-inherited MTM enablement

### DIFF
--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -73,7 +73,26 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
     $results = $GLOBALS["db"]->fetchAll("select max(gamets) as gamets from eventlog"); // faster
     $maxRow = intval($results[0]["gamets"]);
 
-    $allEnabledMtNpc = $GLOBALS["db"]->fetchAll("SELECT * FROM core_npc_master WHERE extended_data->'middle_term_enabled' = '1' ");
+    // Middle-term-memory eligibility is a 3-state setting, not a single per-NPC flag:
+    //   - extended_data.middle_term_enabled = 1/0  -> explicit per-NPC override
+    //   - key absent                               -> inherit the assigned profile's
+    //                                                 core_profiles.metadata.MIDDLE_TERM_MEMORY_ENABLED
+    // The UI writes it this way on purpose (npc_master.php: "delete ... // Remove to inherit
+    // from profile") and the aiview API resolves it this way (chim_aiview.php: explicit npc
+    // value else profile default). The dynamic-profile runtime gate honors the same
+    // inheritance (dynamic_update_util.php). This scheduler query, however, matched ONLY the
+    // explicit `= '1'` key, so every NPC that inherits "on" from an MTM-enabled profile (no
+    // explicit key) was silently skipped and never got middle-term memory generated.
+    // COALESCE(explicit, profile-default) restores inheritance: the per-NPC override wins
+    // (including an explicit '0' force-off), otherwise fall back to the profile default.
+    // (DRY: this explicit-then-profile resolution is currently inlined in several places —
+    //  chim_aiview.php, dynamic_update_util.php, comm.php, and here. A shared helper such as
+    //  NpcMaster::isFeatureEnabled($npc, 'MIDDLE_TERM_MEMORY_ENABLED') would consolidate them.)
+    $allEnabledMtNpc = $GLOBALS["db"]->fetchAll(
+        "SELECT m.* FROM core_npc_master m
+         LEFT JOIN core_profiles p ON p.id = m.profile_id
+         WHERE COALESCE(NULLIF(m.extended_data->>'middle_term_enabled',''),
+                        p.metadata->>'MIDDLE_TERM_MEMORY_ENABLED') = '1' ");
 
     foreach ($allEnabledMtNpc as $npc) {
         $mwdata = json_decode($npc["extended_data"]);


### PR DESCRIPTION
## Problem

The middle-term-memory (MTM) generation loop in `service/processors/middleterm/entrypoint.php` selects eligible NPCs with:

```sql
SELECT * FROM core_npc_master WHERE extended_data->'middle_term_enabled' = '1'
```

But `extended_data.middle_term_enabled` is a **3-state** setting, not a boolean flag:

- `1` / `0` — explicit per-NPC override
- **absent — inherit** the assigned profile's `core_profiles.metadata.MIDDLE_TERM_MEMORY_ENABLED`

The rest of the codebase already treats it that way:

- The NPC editor **deletes** the key when it matches the profile default — `ui/core/npc_master.php`: `delete obj.middle_term_enabled; // Remove to inherit from profile`.
- The aiview API resolves effective state as explicit-else-profile — `ui/api/chim_aiview.php` (reports `source: npc` vs `source: profile`).
- The dynamic-profile runtime gate honors the same inheritance — `lib/dynamic_update_util.php`.

Because the scheduler matched only the explicit `= '1'` key, **every NPC that inherits "on" from an MTM-enabled profile (no explicit override) is silently skipped and never gets middle-term memory generated** — even though the UI shows it as enabled (inherited). Any NPC assigned an MTM-enabled profile through the normal flow (which sets `profile_id` but writes no per-NPC key) is affected.

## Fix

Resolve eligibility in the query the same way the aiview resolver does:

```sql
SELECT m.* FROM core_npc_master m
LEFT JOIN core_profiles p ON p.id = m.profile_id
WHERE COALESCE(NULLIF(m.extended_data->>'middle_term_enabled',''),
               p.metadata->>'MIDDLE_TERM_MEMORY_ENABLED') = '1'
```

- Explicit per-NPC value wins (including an explicit `0` force-off).
- Absent → falls back to the profile default.
- NPCs on a profile without `MIDDLE_TERM_MEMORY_ENABLED` (e.g. the Default profile) and NPCs with no profile stay disabled.

## Testing

- `php -l` clean.
- Verified against a live DB: the eligible set moved from *NPCs-with-an-explicit-flag* to *all-effectively-enabled NPCs*. A cast of main NPCs that had been silently receiving no MTM (assigned MTM-on profiles but with no explicit key) began generating their catch-up digests on the next scheduler tick.
- No schema change.

## Note

This explicit-then-profile resolution is currently inlined in several places (`chim_aiview.php`, `dynamic_update_util.php`, `comm.php`, and here). A future cleanup could extract a shared helper such as `NpcMaster::isFeatureEnabled($npc, 'MIDDLE_TERM_MEMORY_ENABLED')` to prevent this gate/UI divergence recurring (noted in a code comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
