### PR TITLE
Dialogue scope v2: fix multi-NPC conversations broken by the cross-NPC bleed filter (#558 follow-up)

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -2390,6 +2390,37 @@ function buildHistoricContext($actor, $lastNelements = -10,$sqlfilter="") {
 
     $visibleChatStateSql = chimBuildChatDeliveryStateSql('delivery_state');
 
+    // Cross-NPC bleed fix, v2 (Lorkhan review 2026-07-10): v1 kept only own/addressed-to lines,
+    // which starved GROUP conversations - in player-led 3-ways and rechat rounds each NPC lost every
+    // co-participant line, and multi-listener stamps "(talking to B, C)" matched NOBODY because the
+    // ilike required a closing paren right after the name. v2 repairs all three while keeping the
+    // original fix (bystanders echoing NPC-to-NPC verbatim lines):
+    //  (a) group rounds (rechat/narration/continue) skip the dialogue filter entirely - every
+    //      participant needs the whole round in history, not just their own lines;
+    //  (b) the addressee match is a word-boundary regex INSIDE the listener list, so comma lists
+    //      and multi-listener lines reach every addressee;
+    //  (c) lines addressed to the PLAYER are public to NPCs present - a bystander plausibly hears
+    //      what you are told; the original bleed case (NPC-to-NPC scene lines ingested verbatim by
+    //      bystanders) stays filtered on normal turns.
+    $isGroupRound = in_array((string)($GLOBALS["gameRequest"][0] ?? ''), ["rechat", "narration", "continue", "continue_group"], true);
+    $dialogScopeSql = "";
+    if ($b_actor && !$isGroupRound) {
+        $actorRegex = $db->escape(preg_quote($actor));
+        $playerArm = "";
+        $playerNameForScope = trim((string)($GLOBALS["PLAYER_NAME"] ?? ''));
+        if ($playerNameForScope !== "" && strcasecmp($playerNameForScope, $actor) !== 0) {
+            $playerRegex = $db->escape(preg_quote($playerNameForScope));
+            $playerArm = "
+     or data ~* '\\(talking to [^)]*\\m{$playerRegex}\\M'";
+        }
+        $dialogScopeSql = "
+    AND (
+     type not in ('chat','prechat')
+     or data ilike '$actorEscaped:%'
+     or data ~* '\\(talking to [^)]*\\m{$actorRegex}\\M'{$playerArm}
+    )";
+    }
+
     $query="select  
     case 
       when type='infoaction' and a.data like '#%MEMORY%' then 'MEMORY'
@@ -2436,17 +2467,7 @@ function buildHistoricContext($actor, $lastNelements = -10,$sqlfilter="") {
      or people like '%|$actorEscaped (in combat)|%'
      or people like '%|$actorEscaped (restrained)|%'
      or type='info_timeforward'
-    )
-    AND (
-     -- Cross-NPC bleed fix: 'people' is proximity-stamped (every nearby NPC), so without this an NPC's
-     -- context pulled in every bystander's verbatim dialogue and they echoed each other. For actual NPC
-     -- dialogue (chat/prechat) keep ONLY this NPC's own lines or lines addressed TO it; non-dialogue rows
-     -- (infoaction/itemfound/etc.) stay broad so situational awareness is preserved. Player input is its
-     -- own type and is unaffected.
-     type not in ('chat','prechat')
-     or data ilike '$actorEscaped:%'
-     or data ilike '%(talking to $actorEscaped)%'
-    )" : " ").
+    ){$dialogScopeSql}" : " ").
     //((false)?" and gamets>".($currentGameTs-(60*60*60*60)):"").
     " {$ext_sqlfilter2} 
     ORDER BY gamets desc, ts desc, rowid desc LIMIT {$nRecordsLimit} OFFSET 0 ";


### PR DESCRIPTION
## What

Follow-up to #558. Lorkhan flagged that the cross-NPC dialogue filter breaks multi-NPC conversations - he's right, and this repairs it while keeping the original bleed protection.

## The defects in v1 (#558)

1. **Group conversations starved.** The filter kept a chat row in an NPC's history only when it was their own line or stamped `(talking to <them>)`. In player-led 3-ways and rechat rounds, every co-participant line was dropped - each NPC remembered only its own dialogue. It *looked* fine in play because rechat hands the previous line as direct input (`origin_line`), so turn-to-turn worked; what silently died was shared memory beyond one hop (repetition/incoherence in longer rounds).
2. **Multi-listener stamps matched nobody.** `(talking to Fironet, Ahtar)` failed the `ilike '%(talking to Fironet)%'` test for BOTH addressees - the pattern demanded a closing paren right after the name.
3. **Player-addressed lines vanished** from every present NPC's history.

## The fix

- **Group rounds** (`rechat` / `narration` / `continue` / `continue_group`) skip the dialogue filter entirely - every participant needs the whole round in history.
- **Addressee match is a word-boundary regex** over the listener list (`data ~* '\(talking to [^)]*\mNAME\M'`), so comma lists and suffixes like `(busy)` reach every listed listener. Names go through `preg_quote` + SQL escaping (apostrophes/hyphens safe).
- **Player-addressed lines are public** to NPCs present - a bystander plausibly hears what the player is told.
- The original bleed case - bystanders ingesting **NPC-to-NPC** verbatim lines on normal turns and echoing each other - **stays filtered**.

## Testing

- 6 listener-match cases run against live Postgres (single listener, comma list both positions, bystander exclusion, `(busy)` suffix): all pass.
- `buildHistoricContext` executes on both normal and group-round turns, including an apostrophe+hyphen actor name through the escaping.
- `php -l` clean.
