### PR TITLE
Load configured settings in relationship worker

### DIFF
--- a/ext/relationship_system/worker.php
+++ b/ext/relationship_system/worker.php
@@ -112,6 +112,8 @@ try {
     // Load required classes
     require_once $enginePath . 'lib/core/api_badge.class.php';
     require_once $enginePath . 'lib/logger.php';
+    require_once $enginePath . 'lib/settings.php';
+    chimLoadGeneralSettingsIntoGlobals();
 
     // Set up minimal globals that LLM connector needs
     $GLOBALS['HERIKA_NAME'] = 'Worker';


### PR DESCRIPTION
﻿## What changed

- Load database-backed general settings when the standalone Relationship Manager worker starts.
- Keep the existing connector fallback behavior unchanged for genuinely unconfigured installations.

## Root cause

`worker.php` creates its own PHP process and manually bootstraps only `conf.php`, PostgreSQL, the API badge class, and the logger. It never loads `lib/settings.php` or calls `chimLoadGeneralSettingsIntoGlobals()`.

As a result, settings saved through the Global Settings UI, including `RELLLM_CONNECTOR`, are absent in the worker. `RelationshipLLM` then takes its existing fallback path and selects the first connector returned by `readAll()`. This is why renaming a desired connector to start with `AAA` appears to fix routing. Missing globals such as `HTTP_TIMEOUT` in user logs are another symptom of the same incomplete worker bootstrap.

## User impact

Relationship Manager requests now use the connector selected in Global Settings instead of unexpectedly falling back to the first connector, commonly OpenRouter. This prevents misleading OpenRouter 401 errors for users who configured KoboldCPP or another connector.

## Scope

This PR intentionally does not include malformed-JSON recovery or log-directory ACL changes. Those are independent issues and should be reviewed separately.

## Validation

- `php -l ext/relationship_system/worker.php`
- Verified bootstrap order: database connection, general settings load, worker startup
- `git diff --check`
- Confirmed one-file, two-line diff against `unstable`
