### PR TITLE
Add physics_raw to fast_commands (client telemetry: log-only by default)

### DIFF
--- a/main.php
+++ b/main.php
@@ -193,7 +193,8 @@ if (in_array($gameRequest[0],["inputtext","inputtext_s","ginputtext","ginputtext
 $fast_commands = ["addnpc","addbgnpc","updateprofile","updateprofile_narrator","diary","diary_narrator","diary_player","_quest","setconf","request","_speech","infoloc","infonpc","infonpc_close",
     "infoaction","status_msg","delete_event","itemfound","_questdata","_uquest","location","_questreset","chat","bleedout","waitstart","waitstop",
     "util_location_name","util_faction_name","spellcast","npcspellcast","updateprofiles_batch_async","core_profile_assign","switchrace","combatbark",
-    "util_location_npc","enable_bg","region","named_cell","snqe","named_cell_static","player_menu_tts_prefetch","player_menu_tts_play"];
+    "util_location_npc","enable_bg","region","named_cell","snqe","named_cell_static","player_menu_tts_prefetch","player_menu_tts_play",
+    "physics_raw"]; // raw VR contact/gaze telemetry from client plugins: log-only unless an extension opts in by renaming it in preprocessing
 
 if (isset($GLOBALS["external_fast_commands"])) {
     $fast_commands = array_merge($fast_commands, $GLOBALS["external_fast_commands"]);


### PR DESCRIPTION
Per tyler.maister's review of the SHARMAT gaze/VR-contact events (Discord, 2026-07-09): DLL-emitted events should not use the ext_* namespace, and unrecognized client telemetry must never reach the LLM path - it should just be logged so it is trackable.

This adds `physics_raw` (raw VR contact/gaze telemetry emitted by SHARMAT's AIAgent plugin build) to the core `$fast_commands` list, so the default behavior on any server is log-only: no LLM turn, no unexplained NPC dialogue, and the event is visible in the log when debugging.

Extensions that consume it opt in by renaming the event in their preprocessing include (which runs before this list is checked). The SHARMAT extension already ships that rename (`physics_raw` -> its internal `ext_nsfw_physics_raw`), and its plugin is being updated to emit the new neutral name. Servers without the extension simply log the event.

One line plus a comment; no behavior change for any existing event.
