### PR TITLE
Add TTS Studio voice removal controls

### DIFF
--- a/tts/tts-cartesia.php
+++ b/tts/tts-cartesia.php
@@ -234,6 +234,63 @@ function deleteCachedCartesiaVoiceId($voiceName, ?array $config = null, bool $in
     }
 }
 
+function getCartesiaVoiceMetadataKey($voiceName, ?array $config = null): string {
+    return 'cartesia_voice_meta_' . substr(md5(getCartesiaVoiceCachePrefix($config)), 0, 12) . '__' . $voiceName;
+}
+
+function getCartesiaVoiceMetadata($voiceName, ?array $config = null): array {
+    $db = ensureCartesiaDb();
+    if (!$db) {
+        return [];
+    }
+    $key = $db->escape(getCartesiaVoiceMetadataKey($voiceName, $config));
+    $row = $db->fetchOne("SELECT value FROM conf_opts WHERE id = '{$key}' LIMIT 1");
+    $decoded = json_decode(strval($row['value'] ?? ''), true);
+    return is_array($decoded) ? $decoded : [];
+}
+
+function storeCartesiaVoiceMetadata($voiceName, $voiceId, $samplePath, bool $managed, ?array $config = null): void {
+    $db = ensureCartesiaDb();
+    if (!$db) {
+        return;
+    }
+    $metadata = [
+        'voice_id' => trim(strval($voiceId)),
+        'managed' => $managed,
+        'sample_sha256' => is_file($samplePath) ? hash_file('sha256', $samplePath) : '',
+        'created_at' => gmdate('c'),
+    ];
+    $key = $db->escape(getCartesiaVoiceMetadataKey($voiceName, $config));
+    $value = $db->escape(json_encode($metadata, JSON_UNESCAPED_SLASHES));
+    $db->execQuery(
+        "INSERT INTO conf_opts (id, value) VALUES ('{$key}', '{$value}')
+         ON CONFLICT(id) DO UPDATE SET value = '{$value}'"
+    );
+}
+
+function deleteCartesiaVoiceMetadata($voiceName, ?array $config = null): void {
+    $db = ensureCartesiaDb();
+    if (!$db) {
+        return;
+    }
+    $key = $db->escape(getCartesiaVoiceMetadataKey($voiceName, $config));
+    $db->execQuery("DELETE FROM conf_opts WHERE id = '{$key}'");
+}
+
+function findCartesiaVoiceSamplePath($voiceName): string {
+    $possiblePaths = [
+        __DIR__ . "/../data/voices/{$voiceName}.wav",
+        "/var/www/html/HerikaServer/data/voices/{$voiceName}.wav",
+    ];
+    foreach ($possiblePaths as $testPath) {
+        $normalized = realpath($testPath);
+        if ($normalized !== false && is_file($normalized)) {
+            return $normalized;
+        }
+    }
+    return '';
+}
+
 function getCartesiaCachedVoicesMap(bool $includeLegacy = true, ?array $config = null): array {
     $db = ensureCartesiaDb();
     if (!$db) {
@@ -398,6 +455,7 @@ function getOrCreateCartesiaVoice($voiceName) {
     if ($existingVoiceId !== '') {
         Logger::info("Found existing Cartesia voice for {$voiceName}: {$existingVoiceId}");
         storeCachedCartesiaVoiceId($voiceName, $existingVoiceId, $config);
+        storeCartesiaVoiceMetadata($voiceName, $existingVoiceId, '', false, $config);
         return $existingVoiceId;
     }
     
@@ -446,6 +504,7 @@ function getOrCreateCartesiaVoice($voiceName) {
     }
     
     storeCachedCartesiaVoiceId($voiceName, $cartesiaVoiceId, $config);
+    storeCartesiaVoiceMetadata($voiceName, $cartesiaVoiceId, $voiceSamplePath, true, $config);
     clearCartesiaLastError();
     
     Logger::info("Successfully cloned voice {$voiceName} to Cartesia with ID: {$cartesiaVoiceId}");
@@ -594,6 +653,97 @@ function cloneVoiceToCartesia($voiceName, $voiceSamplePath, ?array $config = nul
     
     clearCartesiaLastError();
     return $result['id'];
+}
+
+function deleteCartesiaRemoteVoice($voiceId, ?array $config = null): bool {
+    $config = is_array($config) ? $config : getCartesiaActiveConfig();
+    $apiKey = trim(strval($config['api_key'] ?? ''));
+    $voiceId = trim(strval($voiceId));
+    if ($apiKey === '' || $voiceId === '') {
+        return false;
+    }
+    $options = [
+        'http' => [
+            'method' => 'DELETE',
+            'header' => "X-API-Key: {$apiKey}\r\nCartesia-Version: 2026-03-01\r\nAccept: application/json\r\n",
+            'ignore_errors' => true,
+            'timeout' => 30,
+        ],
+    ];
+    $response = @file_get_contents(
+        'https://api.cartesia.ai/voices/' . rawurlencode($voiceId),
+        false,
+        stream_context_create($options)
+    );
+    $statusLine = $http_response_header[0] ?? '';
+    $httpCode = preg_match('/\s(\d{3})\s/', $statusLine, $matches) ? intval($matches[1]) : 0;
+    if ($httpCode >= 200 && $httpCode < 300) {
+        unset($GLOBALS['CARTESIA_REMOTE_VOICES_CACHE']);
+        return true;
+    }
+    setCartesiaLastError("Cartesia delete API returned HTTP {$httpCode}.");
+    Logger::warn("Failed to delete Cartesia voice {$voiceId}: HTTP {$httpCode}; " . substr(strval($response), 0, 500));
+    return false;
+}
+
+function rebuildCartesiaVoice($voiceName) {
+    clearCartesiaLastError();
+    $config = getCartesiaActiveConfig();
+    $samplePath = findCartesiaVoiceSamplePath($voiceName);
+    if ($samplePath === '') {
+        setCartesiaLastError("Voice sample not found for {$voiceName}.");
+        return false;
+    }
+
+    $oldVoiceId = getCachedCartesiaVoiceId($voiceName, $config);
+    $oldMetadata = getCartesiaVoiceMetadata($voiceName, $config);
+    $newVoiceId = cloneVoiceToCartesia($voiceName, $samplePath, $config);
+    if ($newVoiceId === false || $newVoiceId === '') {
+        return false;
+    }
+
+    $validationAudio = generateCartesiaTTS('Voice synchronization test.', $newVoiceId);
+    if (!is_string($validationAudio) || $validationAudio === '') {
+        $validationError = getCartesiaLastError();
+        deleteCartesiaRemoteVoice($newVoiceId, $config);
+        setCartesiaLastError($validationError !== '' ? $validationError : 'The new Cartesia clone failed validation.');
+        return false;
+    }
+
+    storeCachedCartesiaVoiceId($voiceName, $newVoiceId, $config);
+    storeCartesiaVoiceMetadata($voiceName, $newVoiceId, $samplePath, true, $config);
+    if (
+        $oldVoiceId !== '' &&
+        $oldVoiceId !== $newVoiceId &&
+        !empty($oldMetadata['managed']) &&
+        trim(strval($oldMetadata['voice_id'] ?? '')) === $oldVoiceId
+    ) {
+        deleteCartesiaRemoteVoice($oldVoiceId, $config);
+    }
+    clearCartesiaLastError();
+    return $newVoiceId;
+}
+
+function deleteManagedCartesiaVoice($voiceName): bool {
+    clearCartesiaLastError();
+    $config = getCartesiaActiveConfig();
+    $voiceId = getCachedCartesiaVoiceId($voiceName, $config);
+    $metadata = getCartesiaVoiceMetadata($voiceName, $config);
+    if (
+        $voiceId === '' ||
+        empty($metadata['managed']) ||
+        trim(strval($metadata['voice_id'] ?? '')) !== $voiceId
+    ) {
+        setCartesiaLastError('This Cartesia voice is not marked as managed by this installation; only its cached ID can be forgotten.');
+        return false;
+    }
+    if (!deleteCartesiaRemoteVoice($voiceId, $config)) {
+        return false;
+    }
+    deleteCachedCartesiaVoiceId($voiceName, $config, true);
+    deleteCartesiaVoiceMetadata($voiceName, $config);
+    clearCartesiaLastError();
+    return true;
 }
 
 /**

--- a/tts/tts-inworld.php
+++ b/tts/tts-inworld.php
@@ -396,6 +396,63 @@ function deleteCachedInworldVoiceId($voiceName, ?array $config = null, bool $inc
     }
 }
 
+function getInworldVoiceMetadataKey($voiceName, ?array $config = null): string {
+    return 'inworld_voice_meta_' . substr(md5(getInworldVoiceCachePrefix($config)), 0, 12) . '__' . $voiceName;
+}
+
+function getInworldVoiceMetadata($voiceName, ?array $config = null): array {
+    $db = ensureInworldDb();
+    if (!$db) {
+        return [];
+    }
+    $key = $db->escape(getInworldVoiceMetadataKey($voiceName, $config));
+    $row = $db->fetchOne("SELECT value FROM conf_opts WHERE id = '{$key}' LIMIT 1");
+    $decoded = json_decode(strval($row['value'] ?? ''), true);
+    return is_array($decoded) ? $decoded : [];
+}
+
+function storeInworldVoiceMetadata($voiceName, $voiceId, $samplePath, bool $managed, ?array $config = null): void {
+    $db = ensureInworldDb();
+    if (!$db) {
+        return;
+    }
+    $metadata = [
+        'voice_id' => trim(strval($voiceId)),
+        'managed' => $managed,
+        'sample_sha256' => is_file($samplePath) ? hash_file('sha256', $samplePath) : '',
+        'created_at' => gmdate('c'),
+    ];
+    $key = $db->escape(getInworldVoiceMetadataKey($voiceName, $config));
+    $value = $db->escape(json_encode($metadata, JSON_UNESCAPED_SLASHES));
+    $db->execQuery(
+        "INSERT INTO conf_opts (id, value) VALUES ('{$key}', '{$value}')
+         ON CONFLICT(id) DO UPDATE SET value = '{$value}'"
+    );
+}
+
+function deleteInworldVoiceMetadata($voiceName, ?array $config = null): void {
+    $db = ensureInworldDb();
+    if (!$db) {
+        return;
+    }
+    $key = $db->escape(getInworldVoiceMetadataKey($voiceName, $config));
+    $db->execQuery("DELETE FROM conf_opts WHERE id = '{$key}'");
+}
+
+function findInworldVoiceSamplePath($voiceName): string {
+    $possiblePaths = [
+        __DIR__ . "/../data/voices/{$voiceName}.wav",
+        "/var/www/html/HerikaServer/data/voices/{$voiceName}.wav",
+    ];
+    foreach ($possiblePaths as $testPath) {
+        $normalized = realpath($testPath);
+        if ($normalized !== false && is_file($normalized)) {
+            return $normalized;
+        }
+    }
+    return '';
+}
+
 function getInworldCachedVoicesMap(bool $includeLegacy = true, ?array $config = null): array {
     $db = ensureInworldDb();
     if (!$db) {
@@ -597,6 +654,7 @@ function getOrCreateInworldVoice($voiceName) {
     if ($existingVoiceId !== '') {
         Logger::info("Found existing Inworld voice for {$voiceName}: {$existingVoiceId}");
         storeCachedInworldVoiceId($voiceName, $existingVoiceId, $config);
+        storeInworldVoiceMetadata($voiceName, $existingVoiceId, '', false, $config);
         return $existingVoiceId;
     }
     
@@ -653,6 +711,7 @@ function getOrCreateInworldVoice($voiceName) {
     }
     
     storeCachedInworldVoiceId($voiceName, $inworldVoiceId, $config);
+    storeInworldVoiceMetadata($voiceName, $inworldVoiceId, $voiceSamplePath, true, $config);
     clearInworldLastError();
     
     Logger::info("Successfully cloned voice {$voiceName} to Inworld with ID: {$inworldVoiceId}");
@@ -794,6 +853,97 @@ function cloneVoiceToInworld($voiceName, $voiceSamplePath, ?array $config = null
     clearInworldLastError();
     
     return $result['voice']['voiceId'];
+}
+
+function deleteInworldRemoteVoice($voiceId, ?array $config = null): bool {
+    $config = is_array($config) ? $config : getInworldActiveConfig();
+    $apiCredential = trim(strval($config['api_key'] ?? ''));
+    $voiceId = trim(strval($voiceId));
+    if ($apiCredential === '' || $voiceId === '') {
+        return false;
+    }
+    $options = [
+        'http' => [
+            'method' => 'DELETE',
+            'header' => "Authorization: Basic {$apiCredential}\r\nAccept: application/json\r\n",
+            'ignore_errors' => true,
+            'timeout' => 30,
+        ],
+    ];
+    $response = @file_get_contents(
+        'https://api.inworld.ai/voices/v1/voices/' . rawurlencode($voiceId),
+        false,
+        stream_context_create($options)
+    );
+    $statusLine = $http_response_header[0] ?? '';
+    $httpCode = preg_match('/\s(\d{3})\s/', $statusLine, $matches) ? intval($matches[1]) : 0;
+    if ($httpCode >= 200 && $httpCode < 300) {
+        unset($GLOBALS['INWORLD_REMOTE_VOICES_CACHE']);
+        return true;
+    }
+    setInworldLastError("Inworld delete API returned HTTP {$httpCode}.");
+    Logger::warn("Failed to delete Inworld voice {$voiceId}: HTTP {$httpCode}; " . substr(strval($response), 0, 500));
+    return false;
+}
+
+function rebuildInworldVoice($voiceName) {
+    clearInworldLastError();
+    $config = getInworldActiveConfig();
+    $samplePath = findInworldVoiceSamplePath($voiceName);
+    if ($samplePath === '') {
+        setInworldLastError("Voice sample not found for {$voiceName}.");
+        return false;
+    }
+
+    $oldVoiceId = getCachedInworldVoiceId($voiceName, $config);
+    $oldMetadata = getInworldVoiceMetadata($voiceName, $config);
+    $newVoiceId = cloneVoiceToInworld($voiceName, $samplePath, $config);
+    if ($newVoiceId === false || $newVoiceId === '') {
+        return false;
+    }
+
+    $validationAudio = generateInworldTTS('Voice synchronization test.', $newVoiceId);
+    if (!is_string($validationAudio) || $validationAudio === '') {
+        $validationError = getInworldLastError();
+        deleteInworldRemoteVoice($newVoiceId, $config);
+        setInworldLastError($validationError !== '' ? $validationError : 'The new Inworld clone failed validation.');
+        return false;
+    }
+
+    storeCachedInworldVoiceId($voiceName, $newVoiceId, $config);
+    storeInworldVoiceMetadata($voiceName, $newVoiceId, $samplePath, true, $config);
+    if (
+        $oldVoiceId !== '' &&
+        $oldVoiceId !== $newVoiceId &&
+        !empty($oldMetadata['managed']) &&
+        trim(strval($oldMetadata['voice_id'] ?? '')) === $oldVoiceId
+    ) {
+        deleteInworldRemoteVoice($oldVoiceId, $config);
+    }
+    clearInworldLastError();
+    return $newVoiceId;
+}
+
+function deleteManagedInworldVoice($voiceName): bool {
+    clearInworldLastError();
+    $config = getInworldActiveConfig();
+    $voiceId = getCachedInworldVoiceId($voiceName, $config);
+    $metadata = getInworldVoiceMetadata($voiceName, $config);
+    if (
+        $voiceId === '' ||
+        empty($metadata['managed']) ||
+        trim(strval($metadata['voice_id'] ?? '')) !== $voiceId
+    ) {
+        setInworldLastError('This Inworld voice is not marked as managed by this installation; only its cached ID can be forgotten.');
+        return false;
+    }
+    if (!deleteInworldRemoteVoice($voiceId, $config)) {
+        return false;
+    }
+    deleteCachedInworldVoiceId($voiceName, $config, true);
+    deleteInworldVoiceMetadata($voiceName, $config);
+    clearInworldLastError();
+    return true;
 }
 
 /**

--- a/ui/xtts_clone.php
+++ b/ui/xtts_clone.php
@@ -2073,6 +2073,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $voice = resolveLocalVoiceName($_POST['voice']);
         if ($voice !== '') {
             deleteCachedCartesiaVoiceId($voice, null, true);
+            deleteCartesiaVoiceMetadata($voice);
             $cartesiaMessage .= "<p style='color:rgb(247, 231, 16);'><strong>Unsynced Cartesia voice cache for " . htmlspecialchars($voice) . ".</strong></p>";
         } else {
             $cartesiaMessage .= "<p style='color:red;'><strong>Voice file not found.</strong></p>";
@@ -2089,8 +2090,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $voice = resolveLocalVoiceName($_POST['voice']);
             $voiceSamplePath = __DIR__ . '/../data/voices/' . $voice . '.wav';
             if ($voice !== '' && file_exists($voiceSamplePath)) {
-                deleteCachedCartesiaVoiceId($voice, null, true);
-                $result = getOrCreateCartesiaVoice($voice);
+                $result = rebuildCartesiaVoice($voice);
                 if ($result !== false && !empty($result)) {
                     header('Location: ' . $webRoot . '/ui/xtts_clone.php?tab=cartesia&synced=' . urlencode($voice));
                     exit;
@@ -2105,12 +2105,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 
+    if (isset($_POST['action']) && $_POST['action'] === 'delete_cartesia_single' && isset($_POST['voice'])) {
+        chimTtsStudioApplyConnectorGlobals('cartesia');
+        $voice = resolveLocalVoiceName($_POST['voice']);
+        if ($voice !== '' && deleteManagedCartesiaVoice($voice)) {
+            $cartesiaMessage .= "<p style='color:rgb(247, 231, 16);'><strong>Deleted managed Cartesia clone for " . htmlspecialchars($voice) . ".</strong></p>";
+        } else {
+            $error = getCartesiaLastError();
+            $cartesiaMessage .= "<p style='color:red;'><strong>" . htmlspecialchars($error !== '' ? $error : 'Could not delete Cartesia voice.') . "</strong></p>";
+        }
+    }
+
     // Cartesia clear cache handler
     if (isset($_POST['action']) && $_POST['action'] === 'clear_cartesia_cache') {
         $db = $GLOBALS["db"];
         $legacyPrefixEscaped = $db->escape('cartesia_voice_id_');
         $scopedPrefixEscaped = $db->escape('cartesia_voice_scope_');
-        $db->execQuery("DELETE FROM conf_opts WHERE id LIKE '{$legacyPrefixEscaped}%' OR id LIKE '{$scopedPrefixEscaped}%'");
+        $metadataPrefixEscaped = $db->escape('cartesia_voice_meta_');
+        $db->execQuery("DELETE FROM conf_opts WHERE id LIKE '{$legacyPrefixEscaped}%' OR id LIKE '{$scopedPrefixEscaped}%' OR id LIKE '{$metadataPrefixEscaped}%'");
         $cartesiaMessage .= "<p style='color:rgb(247, 231, 16);'><strong>Cartesia voice cache cleared.</strong></p>";
     }
 
@@ -2270,6 +2282,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $voice = resolveLocalVoiceName($_POST['voice']);
         if ($voice !== '') {
             deleteCachedInworldVoiceId($voice, null, true);
+            deleteInworldVoiceMetadata($voice);
             $inworldMessage .= "<p style='color:rgb(247, 231, 16);'><strong>Unsynced Inworld voice cache for " . htmlspecialchars($voice) . ".</strong></p>";
         } else {
             $inworldMessage .= "<p style='color:red;'><strong>Voice file not found.</strong></p>";
@@ -2286,8 +2299,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $voice = resolveLocalVoiceName($_POST['voice']);
             $voiceSamplePath = __DIR__ . '/../data/voices/' . $voice . '.wav';
             if ($voice !== '' && file_exists($voiceSamplePath)) {
-                deleteCachedInworldVoiceId($voice, null, true);
-                $result = getOrCreateInworldVoice($voice);
+                $result = rebuildInworldVoice($voice);
                 if ($result !== false && !empty($result)) {
                     header('Location: ' . $webRoot . '/ui/xtts_clone.php?tab=inworld&synced=' . urlencode($voice));
                     exit;
@@ -2302,12 +2314,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 
+    if (isset($_POST['action']) && $_POST['action'] === 'delete_inworld_single' && isset($_POST['voice'])) {
+        chimTtsStudioApplyConnectorGlobals('inworld');
+        $voice = resolveLocalVoiceName($_POST['voice']);
+        if ($voice !== '' && deleteManagedInworldVoice($voice)) {
+            $inworldMessage .= "<p style='color:rgb(247, 231, 16);'><strong>Deleted managed Inworld clone for " . htmlspecialchars($voice) . ".</strong></p>";
+        } else {
+            $error = getInworldLastError();
+            $inworldMessage .= "<p style='color:red;'><strong>" . htmlspecialchars($error !== '' ? $error : 'Could not delete Inworld voice.') . "</strong></p>";
+        }
+    }
+
     // Inworld clear cache handler
     if (isset($_POST['action']) && $_POST['action'] === 'clear_inworld_cache') {
         $db = $GLOBALS["db"];
         $legacyPrefixEscaped = $db->escape('inworld_voice_id_');
         $scopedPrefixEscaped = $db->escape('inworld_voice_scope_');
-        $db->execQuery("DELETE FROM conf_opts WHERE id LIKE '{$legacyPrefixEscaped}%' OR id LIKE '{$scopedPrefixEscaped}%'");
+        $metadataPrefixEscaped = $db->escape('inworld_voice_meta_');
+        $db->execQuery("DELETE FROM conf_opts WHERE id LIKE '{$legacyPrefixEscaped}%' OR id LIKE '{$scopedPrefixEscaped}%' OR id LIKE '{$metadataPrefixEscaped}%'");
         $inworldMessage .= "<p style='color:rgb(247, 231, 16);'><strong>Inworld voice cache cleared.</strong></p>";
     }
 
@@ -2957,8 +2981,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     function manageCloudVoice(provider, voiceName, mode) {
         const actionTextMap = {
             unsync: 'Forgetting cached voice ID for ' + provider,
-            resync: 'Regenerating voice for ' + provider
+            resync: 'Rebuilding voice from the local sample for ' + provider,
+            delete: 'Deleting managed cloud voice from ' + provider
         };
+        if (mode === 'delete' && !confirm('Delete the managed ' + provider + ' cloud clone for ' + voiceName + '? The local sample will be kept.')) {
+            return;
+        }
         showLoadingMessage((actionTextMap[mode] || 'Processing voice for ' + provider) + ', please wait...');
 
         const form = document.createElement('form');
@@ -4438,7 +4466,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             <div class="voice-status-grid">
                 <?php foreach ($localVoices as $voice): ?>
-                    <?php $isCloned = isset($clonedVoices[$voice]); ?>
+                    <?php
+                    $isCloned = isset($clonedVoices[$voice]);
+                    $cartesiaMetadata = $isCloned ? getCartesiaVoiceMetadata($voice) : [];
+                    $cartesiaManaged = !empty($cartesiaMetadata['managed'])
+                        && trim(strval($cartesiaMetadata['voice_id'] ?? '')) === strval($clonedVoices[$voice] ?? '');
+                    ?>
                     <div class="voice-status-item" onclick="copyToClipboard('<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')" title="Click to copy voice name">
                         <span class="voice-name"><?php echo htmlspecialchars($voice); ?></span>
                         <span class="status-icon <?php echo $isCloned ? 'cloned' : 'not-cloned'; ?>">
@@ -4456,7 +4489,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                 <button onclick="event.stopPropagation(); manageCloudVoice('cartesia', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>', 'unsync')"
                                         class="unsync-btn" title="Forget cached Cartesia voice ID">×</button>
                                 <button onclick="event.stopPropagation(); manageCloudVoice('cartesia', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>', 'resync')"
-                                        class="resync-btn" title="Forget cached ID and generate a new Cartesia voice" <?php echo !$cartesiaConfigured ? 'disabled' : ''; ?>>↻</button>
+                                        class="resync-btn" title="Clone again from the local sample, validate it, and switch IDs" <?php echo !$cartesiaConfigured ? 'disabled' : ''; ?>>↻</button>
+                                <?php if ($cartesiaManaged): ?>
+                                    <button onclick="event.stopPropagation(); manageCloudVoice('cartesia', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>', 'delete')"
+                                            class="delete-provider-btn" title="Delete this managed Cartesia cloud clone">🗑</button>
+                                <?php endif; ?>
                             <?php else: ?>
                                 <button onclick="event.stopPropagation(); syncSingleVoice('cartesia', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
                                         class="sync-btn" title="Sync this voice" <?php echo !$cartesiaConfigured ? 'disabled' : ''; ?>>↻</button>
@@ -4562,7 +4599,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             <div class="voice-status-grid">
                 <?php foreach ($localVoices as $voice): ?>
-                    <?php $isCloned = isset($clonedVoices[$voice]); ?>
+                    <?php
+                    $isCloned = isset($clonedVoices[$voice]);
+                    $inworldMetadata = $isCloned ? getInworldVoiceMetadata($voice) : [];
+                    $inworldManaged = !empty($inworldMetadata['managed'])
+                        && trim(strval($inworldMetadata['voice_id'] ?? '')) === strval($clonedVoices[$voice] ?? '');
+                    ?>
                     <div class="voice-status-item" onclick="copyToClipboard('<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')" title="Click to copy voice name">
                         <span class="voice-name"><?php echo htmlspecialchars($voice); ?></span>
                         <span class="status-icon <?php echo $isCloned ? 'cloned' : 'not-cloned'; ?>">
@@ -4580,7 +4622,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                 <button onclick="event.stopPropagation(); manageCloudVoice('inworld', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>', 'unsync')"
                                         class="unsync-btn" title="Forget cached Inworld voice ID">×</button>
                                 <button onclick="event.stopPropagation(); manageCloudVoice('inworld', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>', 'resync')"
-                                        class="resync-btn" title="Forget cached ID and generate a new Inworld voice" <?php echo !$inworldConfigured ? 'disabled' : ''; ?>>↻</button>
+                                        class="resync-btn" title="Clone again from the local sample, validate it, and switch IDs" <?php echo !$inworldConfigured ? 'disabled' : ''; ?>>↻</button>
+                                <?php if ($inworldManaged): ?>
+                                    <button onclick="event.stopPropagation(); manageCloudVoice('inworld', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>', 'delete')"
+                                            class="delete-provider-btn" title="Delete this managed Inworld cloud clone">🗑</button>
+                                <?php endif; ?>
                             <?php else: ?>
                                 <button onclick="event.stopPropagation(); syncSingleVoice('inworld', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
                                         class="sync-btn" title="Sync this voice" <?php echo !$inworldConfigured ? 'disabled' : ''; ?>>↻</button>

--- a/ui/xtts_clone.php
+++ b/ui/xtts_clone.php
@@ -378,15 +378,85 @@ if (!function_exists('chimTtsStudioFetchOmniVoiceVoiceItems')) {
 if (!function_exists('chimTtsStudioVoiceUploadPostFields')) {
     function chimTtsStudioVoiceUploadPostFields(string $driver, string $voicePath, string $fileType, string $fileName, string $language = ''): array
     {
-        $postFields = ['wavFile' => new CURLFile($voicePath, $fileType, $fileName)];
+        $postFields = [
+            'wavFile' => new CURLFile($voicePath, $fileType, $fileName),
+            'force' => 'true',
+        ];
         if ($driver === 'omnivoice') {
             $voiceName = pathinfo($fileName, PATHINFO_FILENAME);
             $postFields['language'] = chimTtsStudioResolveOmniVoiceLanguage($language);
             $postFields['speaker_name'] = $voiceName;
             $postFields['display_name'] = $voiceName;
-            $postFields['force'] = 'true';
         }
         return $postFields;
+    }
+}
+
+if (!function_exists('chimTtsStudioDeleteVoice')) {
+    function chimTtsStudioDeleteVoice(string $driver, string $voice, string $language = ''): array
+    {
+        $endpoint = chimTtsStudioResolveEndpointForDriver($driver);
+        if ($endpoint === '') {
+            return ['success' => false, 'message' => 'No endpoint is configured for this provider.'];
+        }
+        if (chimTtsStudioIsAudioCppPocketTts($driver, $endpoint)) {
+            return [
+                'success' => false,
+                'message' => 'audio.cpp uses the local data/voices sample directly; upload a replacement local WAV instead.',
+            ];
+        }
+
+        $voice = preg_replace('/\.wav$/i', '', trim($voice));
+        if ($voice === '' || !preg_match('/^[A-Za-z0-9][A-Za-z0-9_.-]*$/', $voice)) {
+            return ['success' => false, 'message' => 'Invalid voice ID.'];
+        }
+
+        $url = rtrim($endpoint, '/') . '/voices/' . rawurlencode($voice);
+        if ($driver === 'omnivoice') {
+            $url .= '?language=' . rawurlencode(chimTtsStudioResolveOmniVoiceLanguage($language));
+        }
+
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['accept: application/json']);
+        $response = curl_exec($ch);
+        $httpCode = intval(curl_getinfo($ch, CURLINFO_HTTP_CODE));
+        $curlError = curl_error($ch);
+        curl_close($ch);
+
+        if ($response === false) {
+            return ['success' => false, 'message' => 'Delete request failed: ' . $curlError];
+        }
+
+        $decoded = json_decode($response, true);
+        $detailValue = is_array($decoded)
+            ? ($decoded['detail'] ?? $decoded['message'] ?? $decoded['error'] ?? '')
+            : '';
+        if (is_array($detailValue)) {
+            $detailParts = array_filter([
+                trim(strval($detailValue['error'] ?? '')),
+                trim(strval($detailValue['reason'] ?? '')),
+                trim(strval($detailValue['hint'] ?? '')),
+            ]);
+            $detail = implode(': ', $detailParts);
+        } else {
+            $detail = trim(strval($detailValue));
+        }
+        if ($detail === '' && !is_array($decoded)) {
+            $detail = trim($response);
+        }
+        if ($httpCode >= 200 && $httpCode < 300) {
+            return ['success' => true, 'message' => $detail !== '' ? $detail : 'Voice removed from provider.'];
+        }
+
+        if ($httpCode === 404 && $detail === '') {
+            $detail = 'Voice was not found, or this connector version does not support deletion.';
+        }
+        return [
+            'success' => false,
+            'message' => $detail !== '' ? $detail : 'Provider returned HTTP ' . $httpCode . '.',
+        ];
     }
 }
 
@@ -2305,6 +2375,41 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
 
+    // Remove only the provider-side copy. The local data/voices WAV remains available for re-upload.
+    if (isset($_POST['action'], $_POST['voice']) &&
+        in_array($_POST['action'], ['delete_xtts_single', 'delete_chatterbox_single', 'delete_pockettts_single', 'delete_omnivoice_single'], true)) {
+        $deleteActionTabs = [
+            'delete_xtts_single' => 'xtts',
+            'delete_chatterbox_single' => 'chatterbox',
+            'delete_pockettts_single' => 'pockettts',
+            'delete_omnivoice_single' => 'omnivoice',
+        ];
+        $redirectTab = $deleteActionTabs[$_POST['action']];
+        $driver = chimTtsStudioTabToDriver($redirectTab);
+        $voice = trim(strval($_POST['voice']));
+        $language = $driver === 'omnivoice'
+            ? chimTtsStudioResolveOmniVoiceLanguage($_POST['language'] ?? ($_GET['language'] ?? ''))
+            : '';
+        $deleteResult = chimTtsStudioDeleteVoice($driver, $voice, $language);
+
+        if ($deleteResult['success']) {
+            chimTtsStudioStoreSpeakersList(
+                $driver,
+                chimTtsStudioFetchSpeakersList($driver, $language),
+                $language
+            );
+            $redirect = $webRoot . '/ui/xtts_clone.php?tab=' . rawurlencode($redirectTab) . '&deleted=' . rawurlencode($voice);
+            if ($language !== '') {
+                $redirect .= '&language=' . rawurlencode($language);
+            }
+            header('Location: ' . $redirect);
+            exit;
+        }
+
+        $message .= '<p style="color:red;">Could not remove voice from provider: '
+            . htmlspecialchars($deleteResult['message']) . '</p>';
+    }
+
     // XTTS/Chatterbox/PocketTTS/OmniVoice single voice sync handler
     if (isset($_POST['action']) && isset($_POST['voice']) &&
         in_array($_POST['action'], ['sync_xtts_single', 'sync_chatterbox_single', 'sync_pockettts_single', 'sync_omnivoice_single'])) {
@@ -2573,9 +2678,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Clean up URL after showing success message
     window.addEventListener('DOMContentLoaded', function() {
         const url = new URL(window.location);
-        if (url.searchParams.has('synced')) {
-            // Remove the 'synced' parameter from URL without refreshing
+        if (url.searchParams.has('synced') || url.searchParams.has('deleted')) {
+            // Remove one-time result parameters from the URL without refreshing.
             url.searchParams.delete('synced');
+            url.searchParams.delete('deleted');
             window.history.replaceState({}, '', url);
         }
     });
@@ -2801,6 +2907,40 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         actionInput.type = 'hidden';
         actionInput.name = 'action';
         actionInput.value = 'sync_' + provider + '_single';
+
+        const voiceInput = document.createElement('input');
+        voiceInput.type = 'hidden';
+        voiceInput.name = 'voice';
+        voiceInput.value = voiceName;
+
+        form.appendChild(actionInput);
+        form.appendChild(voiceInput);
+        appendProviderLanguageInput(form, provider);
+        document.body.appendChild(form);
+        form.submit();
+    }
+
+    function deleteProviderVoice(provider, voiceName) {
+        const providerNames = {
+            xtts: 'XTTS',
+            chatterbox: 'Chatterbox',
+            pockettts: 'PocketTTS',
+            omnivoice: 'OmniVoice'
+        };
+        const providerName = providerNames[provider] || provider;
+        if (!window.confirm('Remove "' + voiceName + '" from ' + providerName + '? The local WAV will be kept for re-upload.')) {
+            return;
+        }
+
+        showLoadingMessage('Removing voice from ' + providerName + ', please wait...');
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = WEB_ROOT + '/ui/xtts_clone.php?tab=' + provider;
+
+        const actionInput = document.createElement('input');
+        actionInput.type = 'hidden';
+        actionInput.name = 'action';
+        actionInput.value = 'delete_' + provider + '_single';
 
         const voiceInput = document.createElement('input');
         voiceInput.type = 'hidden';
@@ -3252,7 +3392,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     .sync-btn,
     .unsync-btn,
-    .resync-btn {
+    .resync-btn,
+    .delete-provider-btn {
         opacity: 0.4;
         background: none;
         border: none;
@@ -3265,7 +3406,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     .voice-status-item:hover .sync-btn,
     .voice-status-item:hover .unsync-btn,
-    .voice-status-item:hover .resync-btn {
+    .voice-status-item:hover .resync-btn,
+    .voice-status-item:hover .delete-provider-btn {
         opacity: 0.8;
     }
 
@@ -3276,7 +3418,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         color: rgb(242, 124, 17);
     }
 
-    .unsync-btn:hover:not(:disabled) {
+    .unsync-btn:hover:not(:disabled),
+    .delete-provider-btn:hover:not(:disabled) {
         opacity: 1 !important;
         transform: scale(1.1);
         color: #f44336;
@@ -3595,6 +3738,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <p style='color:rgb(247, 231, 16);'><strong>Successfully synced voice '<?php echo htmlspecialchars($_GET['synced']); ?>' to server.</strong></p>
         </div>
     <?php endif; ?>
+    <?php if (isset($_GET['deleted']) && in_array($activeTab, ['xtts', 'chatterbox', 'pockettts', 'omnivoice'], true)): ?>
+        <div class="message">
+            <p style='color:rgb(247, 231, 16);'><strong>Removed provider copy of '<?php echo htmlspecialchars($_GET['deleted']); ?>'. The local WAV is still available to re-upload.</strong></p>
+        </div>
+    <?php endif; ?>
     <?php if (isset($_GET['synced']) && $activeTab === 'cartesia'): ?>
         <div class="message">
             <p style='color:rgb(247, 231, 16);'><strong>Successfully generated voice '<?php echo htmlspecialchars($_GET['synced']); ?>' for Cartesia.</strong></p>
@@ -3667,6 +3815,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             <?php if ($isOnServer): ?>
                                 <button onclick="event.stopPropagation(); testVoice('<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
                                         class="play-btn" title="Test voice">▶</button>
+                                <button onclick="event.stopPropagation(); deleteProviderVoice('xtts', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
+                                        class="delete-provider-btn" title="Remove from XTTS server">×</button>
                             <?php else: ?>
                                 <button onclick="event.stopPropagation(); syncSingleVoice('xtts', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
                                         class="sync-btn" title="Sync this voice to XTTS server">↻</button>
@@ -3817,6 +3967,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             <?php if ($isOnServer): ?>
                                 <button onclick="event.stopPropagation(); testVoice('<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
                                         class="play-btn" title="Test voice">▶</button>
+                                <button onclick="event.stopPropagation(); deleteProviderVoice('chatterbox', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
+                                        class="delete-provider-btn" title="Remove from Chatterbox server">×</button>
                             <?php elseif ($hasLocalSample): ?>
                                 <button onclick="event.stopPropagation(); syncSingleVoice('chatterbox', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
                                         class="sync-btn" title="Sync this voice to Chatterbox server">↻</button>
@@ -3931,6 +4083,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $displayName = basename($speaker, '.wav');
                     $xttsVoices[$displayName] = true;
             }
+            $pocketTtsEndpoint = chimTtsStudioResolveEndpointForDriver('pockettts');
+            $pocketTtsCanDeleteRemote = !chimTtsStudioIsAudioCppPocketTts('pockettts', $pocketTtsEndpoint);
             ?>
 
             <div class="button-group" style="margin-top: 20px;">
@@ -3952,6 +4106,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             <?php if ($isOnServer): ?>
                                 <button onclick="event.stopPropagation(); testVoice('<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
                                         class="play-btn" title="Test voice">▶</button>
+                                <?php if ($pocketTtsCanDeleteRemote): ?>
+                                    <button onclick="event.stopPropagation(); deleteProviderVoice('pockettts', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
+                                            class="delete-provider-btn" title="Remove from PocketTTS server">×</button>
+                                <?php endif; ?>
                             <?php else: ?>
                                 <button onclick="event.stopPropagation(); syncSingleVoice('pockettts', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
                                         class="sync-btn" title="Sync this voice to PocketTTS server">↻</button>
@@ -4151,6 +4309,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $item = $omnivoiceItemMap[$voice] ?? [];
                     $isReady = isset($omnivoiceReadyVoices[$voice]);
                     $hasLocalSample = isset($localVoiceMap[$voice]);
+                    $canDeleteProviderVoice = !empty($item['can_delete']) || !empty($item['custom_voice']);
                     $serverStatus = strtolower(trim(strval($item['status'] ?? ($isReady ? 'ready' : 'local'))));
                     $statusTitle = $serverStatus;
                     if (!$isReady && !empty($item['transcription_error'])) {
@@ -4176,6 +4335,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             <?php elseif ($hasLocalSample): ?>
                                 <button onclick="event.stopPropagation(); syncSingleVoice('omnivoice', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
                                         class="sync-btn" title="Import this voice into OmniVoice">↻</button>
+                            <?php endif; ?>
+                            <?php if ($canDeleteProviderVoice): ?>
+                                <button onclick="event.stopPropagation(); deleteProviderVoice('omnivoice', '<?php echo htmlspecialchars($voice, ENT_QUOTES); ?>')"
+                                        class="delete-provider-btn" title="Remove custom voice from OmniVoice">×</button>
                             <?php endif; ?>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- add provider-copy removal controls to XTTS, Chatterbox, PocketTTS, and OmniVoice tabs
- keep local `data/voices` samples available for re-upload
- send `force=true` for safe same-name replacement and refresh provider voice caches after deletion
- hide remote deletion for audio.cpp PocketTTS, which reads local samples directly

## Validation
- `php -l ui/xtts_clone.php`
- unstable guard: **PR REQUIRED** due to large-file growth; feature branch targets `unstable`
