### PR TITLE
Keep narrator voice after inline narration

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -1069,6 +1069,23 @@ function restoreVoiceSettings($savedSettings) {
     }
 }
 
+/**
+ * Restore the original speaker after inline narration uses the narrator voice.
+ *
+ * Narrator-originated events can enter this path before their voice override is
+ * loaded. Restoring that stale snapshot would replace the configured narrator
+ * voice with the connector fallback for the dialogue that follows.
+ */
+function restoreInlineNarrationSpeakerVoiceSettings($savedSettings, $speakerName): void {
+    $GLOBALS["HERIKA_NAME"] = $speakerName;
+
+    if (strcasecmp(trim((string)$speakerName), "The Narrator") === 0) {
+        return;
+    }
+
+    restoreVoiceSettings($savedSettings);
+}
+
 
 function unmoodSentence($sentence) {
     global $forceMood;
@@ -1427,9 +1444,9 @@ function returnLines($lines,$writeOutput=true)
                     }
                 }
 
-                // Restore NPC voice settings
-                restoreVoiceSettings($savedVoiceSettings);
-                $GLOBALS["HERIKA_NAME"] = $savedHerikaName;
+                // Restore NPC settings, but keep the narrator settings that were
+                // just loaded when the original speaker is already The Narrator.
+                restoreInlineNarrationSpeakerVoiceSettings($savedVoiceSettings, $savedHerikaName);
 
                 // Now generate TTS for the NPC's dialogue (if any)
                 if (!empty($narrationParts['dialogue'])) {

--- a/unittests/tests/AsteriskParsingTest.php
+++ b/unittests/tests/AsteriskParsingTest.php
@@ -27,6 +27,11 @@ final class AsteriskParsingTest extends TestCase
             $GLOBALS['strip_emotes_from_output'],
             $GLOBALS['PATCH_OVERRIDE_VOICE'],
             $GLOBALS['PATCH_OVERRIDE_VOICE_ID'],
+            $GLOBALS['TTSFUNCTION'],
+            $GLOBALS['TTS_FUNCTION'],
+            $GLOBALS['CHIM_CORE_CURRENT_TTS_CONNECTOR_ID'],
+            $GLOBALS['PATCH_OVERRIDE_TTS_LANGUAGE'],
+            $GLOBALS['PATCH_OVERRIDE_TTS_OPTIONS'],
             $GLOBALS['CHIM_EXECUTION_MODE'],
             $GLOBALS['TTS']
         );
@@ -105,6 +110,39 @@ final class AsteriskParsingTest extends TestCase
         $this->assertSame('text_only', getInlineNarrationMode());
         $this->assertFalse(shouldSplitInlineNarration());
         $this->assertTrue(isInlineNarrationEnabled());
+    }
+
+    public function testNarratorInlineNarrationKeepsLoadedNarratorVoice(): void
+    {
+        $savedSettings = [
+            'tts' => ['POCKETTTS' => ['voiceid' => 'alba']],
+            'has_patch_override_voice' => false,
+        ];
+        $GLOBALS['TTS'] = ['POCKETTTS' => ['voiceid' => 'alisenvoice']];
+        $GLOBALS['PATCH_OVERRIDE_VOICE'] = 'alisenvoice';
+
+        restoreInlineNarrationSpeakerVoiceSettings($savedSettings, 'The Narrator');
+
+        $this->assertSame('The Narrator', $GLOBALS['HERIKA_NAME']);
+        $this->assertSame('alisenvoice', $GLOBALS['PATCH_OVERRIDE_VOICE']);
+        $this->assertSame('alisenvoice', $GLOBALS['TTS']['POCKETTTS']['voiceid']);
+    }
+
+    public function testNpcInlineNarrationRestoresOriginalNpcVoice(): void
+    {
+        $savedSettings = [
+            'tts' => ['POCKETTTS' => ['voiceid' => 'lydiavoice']],
+            'has_patch_override_voice' => true,
+            'patch_override_voice' => 'lydiavoice',
+        ];
+        $GLOBALS['TTS'] = ['POCKETTTS' => ['voiceid' => 'alisenvoice']];
+        $GLOBALS['PATCH_OVERRIDE_VOICE'] = 'alisenvoice';
+
+        restoreInlineNarrationSpeakerVoiceSettings($savedSettings, 'Lydia');
+
+        $this->assertSame('Lydia', $GLOBALS['HERIKA_NAME']);
+        $this->assertSame('lydiavoice', $GLOBALS['PATCH_OVERRIDE_VOICE']);
+        $this->assertSame('lydiavoice', $GLOBALS['TTS']['POCKETTTS']['voiceid']);
     }
 
     public function testPlayerSpeechStripsAsteriskActionBlocksWhenPlayerFilterEnabled(): void


### PR DESCRIPTION
﻿## What changed
- Preserve the configured narrator TTS settings when a narrator response is split into inline narration and dialogue.
- Continue restoring the original voice settings for ordinary NPC responses.
- Add regression coverage for narrator and NPC voice-state behavior.

## Root cause
Narrator-originated events can enter inline narration before their narrator voice override is loaded into the current request state. The inline narration block loads the correct narrator voice, but the old handoff restored the stale snapshot, causing PocketTTS to use its `alba` fallback for the remaining dialogue.

## Validation
- PHP syntax checks passed.
- Focused inline narration suite: 40 tests, 68 assertions.
- `git diff --check` passed.

Dev-targeted counterpart of #579. This branch was created directly from `dev` and contains only the narrator voice fix.
