### PR TITLE
Fix AI Quest V1 FormID persistence

### DIFF
--- a/gamedata.php
+++ b/gamedata.php
@@ -25,6 +25,7 @@ require_once(__DIR__ . "/lib/core/transformation_state.php");
 require_once(__DIR__ . "/lib/core/game_plugins.php");
 require_once(__DIR__ . "/lib/logger.php");
 require_once(__DIR__ . "/lib/chim_quest_engine.php");
+require_once(__DIR__ . "/lib/quest_reference_data.php");
 
 // Only accept POST requests
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -354,6 +355,20 @@ function handleLoadedPluginsUpdate(array $data): void
 
     $pluginCount = chimReplaceLoadedGamePlugins($data['plugins']);
     Logger::debug("[gamedata.php] Updated loaded plugin manifest ({$pluginCount} plugins)");
+
+    $repair = quest_reference_repair_runtime_formids_to_stable($data['plugins']);
+    if ($repair['error'] !== null) {
+        Logger::warn("[gamedata.php] AI Quest V1 FormID repair skipped: {$repair['error']}");
+        return;
+    }
+
+    Logger::debug(
+        "[gamedata.php] AI Quest V1 FormID repair: "
+        . "{$repair['rows_updated']}/{$repair['rows_scanned']} rows updated, "
+        . "{$repair['converted']} references converted, "
+        . "{$repair['unresolved']} unresolved, "
+        . "{$repair['dynamic']} dynamic"
+    );
 }
 
 function buildEquipmentMetadataValue(array $equipment): array

--- a/lib/core/game_plugins.php
+++ b/lib/core/game_plugins.php
@@ -62,6 +62,59 @@ if (!function_exists('chimNormalizeFormIdPrefix')) {
     }
 }
 
+if (!function_exists('chimNormalizeLoadedGamePluginManifest')) {
+    function chimNormalizeLoadedGamePluginManifest(array $plugins): array
+    {
+        $normalizedPlugins = [];
+        foreach ($plugins as $pluginRow) {
+            if (!is_array($pluginRow)) {
+                continue;
+            }
+
+            $pluginName = chimNormalizePluginName($pluginRow['plugin_name'] ?? '');
+            $formIdPrefix = chimNormalizeFormIdPrefix($pluginRow['formid_prefix'] ?? '');
+            if ($pluginName === '' || $formIdPrefix === '') {
+                continue;
+            }
+
+            $normalizedPlugins[strtolower($pluginName)] = [
+                'plugin_name' => $pluginName,
+                'is_light' => !empty($pluginRow['is_light']),
+                'compile_index' => isset($pluginRow['compile_index']) ? intval($pluginRow['compile_index']) : 0,
+                'small_file_compile_index' => isset($pluginRow['small_file_compile_index']) ? intval($pluginRow['small_file_compile_index']) : 0,
+                'partial_index' => isset($pluginRow['partial_index']) ? intval($pluginRow['partial_index']) : 0,
+                'formid_prefix' => $formIdPrefix,
+            ];
+        }
+
+        return array_values($normalizedPlugins);
+    }
+}
+
+if (!function_exists('chimIndexLoadedGamePluginsByPrefix')) {
+    function chimIndexLoadedGamePluginsByPrefix(array $plugins): array
+    {
+        $pluginsByPrefix = [];
+        foreach (chimNormalizeLoadedGamePluginManifest($plugins) as $pluginRow) {
+            $pluginsByPrefix[strtoupper($pluginRow['formid_prefix'])] = $pluginRow;
+        }
+
+        return $pluginsByPrefix;
+    }
+}
+
+if (!function_exists('chimIndexLoadedGamePluginsByName')) {
+    function chimIndexLoadedGamePluginsByName(array $plugins): array
+    {
+        $pluginsByName = [];
+        foreach (chimNormalizeLoadedGamePluginManifest($plugins) as $pluginRow) {
+            $pluginsByName[strtolower($pluginRow['plugin_name'])] = $pluginRow;
+        }
+
+        return $pluginsByName;
+    }
+}
+
 if (!function_exists('chimBuildStableFormReference')) {
     function chimBuildStableFormReference($pluginName, $localFormId): string
     {
@@ -260,6 +313,34 @@ if (!function_exists('chimExtractLocalFormIdFromRuntimeFormId')) {
     }
 }
 
+if (!function_exists('chimConvertRuntimeFormIdToStableReference')) {
+    function chimConvertRuntimeFormIdToStableReference($runtimeFormId, ?array $pluginsByPrefix = null): ?string
+    {
+        $runtimeFormId = chimNormalizeRuntimeFormId($runtimeFormId);
+        if (strlen($runtimeFormId) !== 8 || strpos($runtimeFormId, 'FF') === 0) {
+            return null;
+        }
+
+        $formIdPrefix = (strpos($runtimeFormId, 'FE') === 0)
+            ? substr($runtimeFormId, 0, 5)
+            : substr($runtimeFormId, 0, 2);
+
+        if ($pluginsByPrefix === null) {
+            $pluginRow = chimGetLoadedGamePluginByFormIdPrefix($formIdPrefix);
+        } else {
+            $pluginRow = $pluginsByPrefix[strtoupper($formIdPrefix)] ?? null;
+        }
+
+        $localFormId = chimExtractLocalFormIdFromRuntimeFormId($runtimeFormId);
+        if (!is_array($pluginRow) || empty($pluginRow['plugin_name']) || $localFormId === '') {
+            return null;
+        }
+
+        $stableReference = chimBuildStableFormReference($pluginRow['plugin_name'], $localFormId);
+        return $stableReference !== '' ? $stableReference : null;
+    }
+}
+
 if (!function_exists('chimBuildLegacyDescriptionBaseId')) {
     function chimBuildLegacyDescriptionBaseId($runtimeFormId, ?array $pluginRow = null): string
     {
@@ -388,27 +469,7 @@ if (!function_exists('chimReplaceLoadedGamePlugins')) {
             return 0;
         }
 
-        $normalizedPlugins = [];
-        foreach ($plugins as $pluginRow) {
-            if (!is_array($pluginRow)) {
-                continue;
-            }
-
-            $pluginName = chimNormalizePluginName($pluginRow['plugin_name'] ?? '');
-            $formIdPrefix = chimNormalizeFormIdPrefix($pluginRow['formid_prefix'] ?? '');
-            if ($pluginName === '' || $formIdPrefix === '') {
-                continue;
-            }
-
-            $normalizedPlugins[strtolower($pluginName)] = [
-                'plugin_name' => $pluginName,
-                'is_light' => !empty($pluginRow['is_light']),
-                'compile_index' => isset($pluginRow['compile_index']) ? intval($pluginRow['compile_index']) : 0,
-                'small_file_compile_index' => isset($pluginRow['small_file_compile_index']) ? intval($pluginRow['small_file_compile_index']) : 0,
-                'partial_index' => isset($pluginRow['partial_index']) ? intval($pluginRow['partial_index']) : 0,
-                'formid_prefix' => $formIdPrefix,
-            ];
-        }
+        $normalizedPlugins = chimNormalizeLoadedGamePluginManifest($plugins);
 
         if (count($normalizedPlugins) === 0) {
             return 0;

--- a/lib/quest_reference_data.php
+++ b/lib/quest_reference_data.php
@@ -201,19 +201,163 @@ if (!function_exists('quest_reference_normalize_formid')) {
         return null;
     }
 
-    function quest_reference_canonicalize_formid_for_text_storage($value)
+    function quest_reference_classify_formid_for_text_storage($value, ?array $pluginsByPrefix = null)
     {
         $stableReference = chimParseStableFormReference($value);
         if ($stableReference) {
-            return $stableReference['stable_key'];
+            return [
+                'value' => $stableReference['stable_key'],
+                'status' => 'stable',
+                'runtime_formid' => null,
+            ];
         }
 
         $runtimeFormId = quest_reference_resolve_runtime_formid_string($value);
         if ($runtimeFormId === null) {
-            return null;
+            return [
+                'value' => null,
+                'status' => 'invalid',
+                'runtime_formid' => null,
+            ];
         }
 
-        return strtolower('0x' . $runtimeFormId);
+        if (strpos($runtimeFormId, 'FF') === 0) {
+            return [
+                'value' => null,
+                'status' => 'dynamic',
+                'runtime_formid' => $runtimeFormId,
+            ];
+        }
+
+        $stableReference = chimConvertRuntimeFormIdToStableReference($runtimeFormId, $pluginsByPrefix);
+        if ($stableReference !== null) {
+            return [
+                'value' => $stableReference,
+                'status' => 'converted',
+                'runtime_formid' => $runtimeFormId,
+            ];
+        }
+
+        return [
+            'value' => strtolower('0x' . $runtimeFormId),
+            'status' => 'unresolved',
+            'runtime_formid' => $runtimeFormId,
+        ];
+    }
+
+    function quest_reference_canonicalize_formid_for_text_storage($value, ?array $pluginsByPrefix = null)
+    {
+        $classified = quest_reference_classify_formid_for_text_storage($value, $pluginsByPrefix);
+        return $classified['value'];
+    }
+
+    function quest_reference_legacy_local_plugin_name($datasetName, $keyName, $runtimeFormId)
+    {
+        $datasetName = strtolower(trim((string) $datasetName));
+        $keyName = strtolower(trim((string) $keyName));
+        $runtimeFormId = chimNormalizeRuntimeFormId($runtimeFormId);
+        $runtimeValue = $runtimeFormId !== '' ? hexdec($runtimeFormId) : -1;
+
+        $isLegacyNpcTemplateKey = preg_match(
+            '/^(female|male)_(breton|nord|imperial|redguard|orc|argonian)_(noble|merchant|warrior|assassin|mage|beggar|farmer|bard|soldier)$/',
+            $keyName
+        ) === 1 || in_array($keyName, ['female_breton_forsworn', 'male_breton_forsworn'], true);
+        if (
+            $datasetName === 'npc_own_templates'
+            && $isLegacyNpcTemplateKey
+            && (
+                ($runtimeValue >= 0x00025844 && $runtimeValue <= 0x0002584D)
+                || ($runtimeValue >= 0x00025DAF && $runtimeValue <= 0x00025DED)
+            )
+        ) {
+            return 'AIAgent.esp';
+        }
+
+        $legacyItemFormIds = [
+            'potion' => 0x0002481F,
+            'necklace' => 0x0002481D,
+            'amulet' => 0x0002481E,
+            'ring' => 0x000242B9,
+        ];
+        if ($datasetName === 'item_types' && ($legacyItemFormIds[$keyName] ?? -1) === $runtimeValue) {
+            return 'AIAgent.esp';
+        }
+
+        return null;
+    }
+
+    function quest_reference_classify_dataset_formid_for_text_storage(
+        $datasetName,
+        $keyName,
+        $value,
+        ?array $pluginsByPrefix = null,
+        ?array $pluginsByName = null
+    ) {
+        $stableReference = chimParseStableFormReference($value);
+        if ($stableReference) {
+            return [
+                'value' => $stableReference['stable_key'],
+                'status' => 'stable',
+                'runtime_formid' => null,
+            ];
+        }
+
+        $runtimeFormId = quest_reference_resolve_runtime_formid_string($value);
+        $legacyPluginName = quest_reference_legacy_local_plugin_name($datasetName, $keyName, $runtimeFormId);
+        if (
+            $runtimeFormId !== null
+            && $runtimeFormId !== '00000000'
+            && substr($runtimeFormId, 0, 2) === '00'
+            && $legacyPluginName !== null
+        ) {
+            $pluginRow = $pluginsByName === null
+                ? chimGetLoadedGamePluginByName($legacyPluginName)
+                : ($pluginsByName[strtolower($legacyPluginName)] ?? null);
+
+            if (is_array($pluginRow) && !empty($pluginRow['plugin_name'])) {
+                return [
+                    'value' => chimBuildStableFormReference(
+                        $pluginRow['plugin_name'],
+                        chimExtractLocalFormIdFromRuntimeFormId($runtimeFormId)
+                    ),
+                    'status' => 'converted',
+                    'runtime_formid' => $runtimeFormId,
+                ];
+            }
+
+            return [
+                'value' => strtolower('0x' . $runtimeFormId),
+                'status' => 'unresolved',
+                'runtime_formid' => $runtimeFormId,
+            ];
+        }
+
+        if ($runtimeFormId === '00000000') {
+            return [
+                'value' => '0x00000000',
+                'status' => 'unresolved',
+                'runtime_formid' => $runtimeFormId,
+            ];
+        }
+
+        return quest_reference_classify_formid_for_text_storage($value, $pluginsByPrefix);
+    }
+
+    function quest_reference_canonicalize_dataset_formid_for_text_storage(
+        $datasetName,
+        $keyName,
+        $value,
+        ?array $pluginsByPrefix = null,
+        ?array $pluginsByName = null
+    ) {
+        $classified = quest_reference_classify_dataset_formid_for_text_storage(
+            $datasetName,
+            $keyName,
+            $value,
+            $pluginsByPrefix,
+            $pluginsByName
+        );
+        return $classified['value'];
     }
 
     function quest_reference_normalize_formid($value)
@@ -263,6 +407,185 @@ if (!function_exists('quest_reference_normalize_formid')) {
         }
 
         return null;
+    }
+}
+
+if (!function_exists('quest_reference_repair_formid_values')) {
+    function quest_reference_repair_formid_values(
+        $datasetName,
+        $keyName,
+        $values,
+        array $pluginsByPrefix,
+        array $pluginsByName
+    )
+    {
+        if (!is_array($values)) {
+            return [
+                'values' => [],
+                'changed' => false,
+                'converted' => 0,
+                'unresolved' => 0,
+                'dynamic' => 0,
+                'invalid' => 1,
+            ];
+        }
+
+        $repaired = [];
+        $seen = [];
+        $summary = [
+            'values' => [],
+            'changed' => false,
+            'converted' => 0,
+            'unresolved' => 0,
+            'dynamic' => 0,
+            'invalid' => 0,
+        ];
+
+        foreach ($values as $value) {
+            $original = trim((string) $value);
+            if ($original === '') {
+                $summary['invalid']++;
+                continue;
+            }
+
+            $classified = quest_reference_classify_dataset_formid_for_text_storage(
+                $datasetName,
+                $keyName,
+                $original,
+                $pluginsByPrefix,
+                $pluginsByName
+            );
+            $status = $classified['status'];
+            $canonical = $classified['value'];
+
+            if ($status === 'dynamic' || $status === 'invalid') {
+                $canonical = $original;
+                $summary[$status]++;
+            } elseif ($status === 'converted') {
+                $summary['converted']++;
+            } elseif ($status === 'unresolved') {
+                $summary['unresolved']++;
+            }
+
+            $dedupeKey = strtolower($canonical);
+            if (isset($seen[$dedupeKey])) {
+                continue;
+            }
+
+            $seen[$dedupeKey] = true;
+            $repaired[] = $canonical;
+        }
+
+        $summary['values'] = $repaired;
+        $summary['changed'] = array_values($values) !== $repaired;
+        return $summary;
+    }
+}
+
+if (!function_exists('quest_reference_repair_runtime_formids_to_stable')) {
+    function quest_reference_repair_runtime_formids_to_stable(array $plugins)
+    {
+        $summary = [
+            'rows_scanned' => 0,
+            'rows_updated' => 0,
+            'converted' => 0,
+            'unresolved' => 0,
+            'dynamic' => 0,
+            'invalid' => 0,
+            'error' => null,
+        ];
+
+        if (!quest_reference_has_db()) {
+            $summary['error'] = 'database_unavailable';
+            return $summary;
+        }
+
+        $pluginsByPrefix = chimIndexLoadedGamePluginsByPrefix($plugins);
+        $pluginsByName = chimIndexLoadedGamePluginsByName($plugins);
+        if (empty($pluginsByPrefix)) {
+            $summary['error'] = 'plugin_manifest_empty';
+            return $summary;
+        }
+
+        $transactionStarted = false;
+        try {
+            $beginResult = $GLOBALS["db"]->execQuery("BEGIN");
+            if ($beginResult === false) {
+                throw new RuntimeException("Could not start quest reference repair transaction.");
+            }
+            $transactionStarted = true;
+
+            foreach (quest_reference_dataset_config() as $datasetName => $cfg) {
+                $table = $cfg['table'];
+                $keyColumn = $cfg['key_column'];
+                if (!quest_reference_table_exists($table) || !quest_reference_column_exists($table, 'formids_json')) {
+                    continue;
+                }
+
+                $rows = $GLOBALS["db"]->fetchAll("
+                    SELECT {$keyColumn} AS key_name, formids_json
+                    FROM public.{$table}
+                ");
+
+                foreach ((array) $rows as $row) {
+                    $summary['rows_scanned']++;
+                    $encodedValues = $row['formids_json'] ?? '[]';
+                    $values = is_array($encodedValues) ? $encodedValues : json_decode((string) $encodedValues, true);
+                    if (!is_array($values)) {
+                        $summary['invalid']++;
+                        continue;
+                    }
+
+                    $keyName = trim((string) ($row['key_name'] ?? ''));
+                    if ($keyName === '') {
+                        $summary['invalid']++;
+                        continue;
+                    }
+
+                    $repair = quest_reference_repair_formid_values(
+                        $datasetName,
+                        $keyName,
+                        $values,
+                        $pluginsByPrefix,
+                        $pluginsByName
+                    );
+                    foreach (['converted', 'unresolved', 'dynamic', 'invalid'] as $counter) {
+                        $summary[$counter] += $repair[$counter];
+                    }
+
+                    if (!$repair['changed']) {
+                        continue;
+                    }
+
+                    $keyCn = $GLOBALS["db"]->escape($keyName);
+                    $jsonCn = $GLOBALS["db"]->escape(json_encode($repair['values']));
+                    $updateResult = $GLOBALS["db"]->execQuery("
+                        UPDATE public.{$table}
+                        SET formids_json = '{$jsonCn}'::jsonb,
+                            updated_at = now()
+                        WHERE {$keyColumn} = '{$keyCn}'
+                    ");
+                    if ($updateResult === false) {
+                        throw new RuntimeException("Could not update quest reference row '{$keyName}'.");
+                    }
+
+                    $summary['rows_updated']++;
+                }
+            }
+
+            $commitResult = $GLOBALS["db"]->execQuery("COMMIT");
+            if ($commitResult === false) {
+                throw new RuntimeException("Could not commit quest reference repair transaction.");
+            }
+            $transactionStarted = false;
+        } catch (Throwable $e) {
+            if ($transactionStarted) {
+                $GLOBALS["db"]->execQuery("ROLLBACK");
+            }
+            $summary['error'] = $e->getMessage();
+        }
+
+        return $summary;
     }
 }
 
@@ -347,27 +670,39 @@ if (!function_exists('quest_reference_normalize_dataset_values')) {
                 continue;
             }
 
-            $list = quest_reference_extract_formids($formIds);
+            $list = is_array($formIds) ? $formIds : [$formIds];
             if (empty($list)) {
                 continue;
             }
 
+            $final = [];
             $dedupe = [];
             foreach ($list as $formId) {
+                $stableReference = chimParseStableFormReference($formId);
+                if ($stableReference) {
+                    $dedupeKey = strtolower($stableReference['stable_key']);
+                    if (!isset($dedupe[$dedupeKey])) {
+                        $dedupe[$dedupeKey] = true;
+                        $final[] = $stableReference['stable_key'];
+                    }
+                    continue;
+                }
+
                 $value = quest_reference_normalize_formid($formId);
                 if ($value === null || $value < 0) {
                     continue;
                 }
-                $dedupe[$value] = true;
+
+                $dedupeKey = 'runtime:' . $value;
+                if (!isset($dedupe[$dedupeKey])) {
+                    $dedupe[$dedupeKey] = true;
+                    $final[] = intval($value);
+                }
             }
 
-            if (empty($dedupe)) {
-                continue;
+            if (!empty($final)) {
+                $normalized[$keyCn] = $final;
             }
-
-            $final = array_map('intval', array_keys($dedupe));
-            sort($final, SORT_NUMERIC);
-            $normalized[$keyCn] = $final;
         }
 
         return $normalized;
@@ -375,12 +710,16 @@ if (!function_exists('quest_reference_normalize_dataset_values')) {
 }
 
 if (!function_exists('quest_reference_prepare_formids_for_storage')) {
-    function quest_reference_prepare_formids_for_storage($formIds, $storeAsText)
+    function quest_reference_prepare_formids_for_storage($datasetName, $keyName, $formIds, $storeAsText)
     {
         $prepared = [];
         foreach ($formIds as $formId) {
             if ($storeAsText) {
-                $canonical = quest_reference_canonicalize_formid_for_text_storage($formId);
+                $canonical = quest_reference_canonicalize_dataset_formid_for_text_storage(
+                    $datasetName,
+                    $keyName,
+                    $formId
+                );
                 if ($canonical === null || $canonical === '') {
                     continue;
                 }
@@ -401,10 +740,14 @@ if (!function_exists('quest_reference_prepare_formids_for_storage')) {
 }
 
 if (!function_exists('quest_reference_sql_formid_literal')) {
-    function quest_reference_sql_formid_literal($formId, $storeAsText)
+    function quest_reference_sql_formid_literal($datasetName, $keyName, $formId, $storeAsText)
     {
         if ($storeAsText) {
-            $canonical = quest_reference_canonicalize_formid_for_text_storage($formId);
+            $canonical = quest_reference_canonicalize_dataset_formid_for_text_storage(
+                $datasetName,
+                $keyName,
+                $formId
+            );
             if ($canonical === null || $canonical === '') {
                 return null;
             }
@@ -500,7 +843,12 @@ if (!function_exists('quest_reference_seed_dataset_if_empty')) {
             $keyCn = $GLOBALS["db"]->escape($key);
 
             if ($hasArrayColumn) {
-                $preparedFormIds = quest_reference_prepare_formids_for_storage($formIds, $storeAsText);
+                $preparedFormIds = quest_reference_prepare_formids_for_storage(
+                    $datasetName,
+                    $key,
+                    $formIds,
+                    $storeAsText
+                );
                 $jsonPayload = $GLOBALS["db"]->escape(json_encode($preparedFormIds));
                 if ($hasFormIdColumn) {
                     $arraySentinelSql = quest_reference_sql_array_sentinel_literal($storeAsText);
@@ -532,7 +880,12 @@ if (!function_exists('quest_reference_seed_dataset_if_empty')) {
             }
 
             foreach ($formIds as $formId) {
-                $formIdSql = quest_reference_sql_formid_literal($formId, $storeAsText);
+                $formIdSql = quest_reference_sql_formid_literal(
+                    $datasetName,
+                    $key,
+                    $formId,
+                    $storeAsText
+                );
                 if ($formIdSql === null) {
                     continue;
                 }
@@ -583,7 +936,12 @@ if (!function_exists('quest_reference_replace_dataset_with_arrays')) {
 
             foreach ($normalized as $key => $formIds) {
                 $keyCn = $GLOBALS["db"]->escape($key);
-                $preparedFormIds = quest_reference_prepare_formids_for_storage($formIds, $storeAsText);
+                $preparedFormIds = quest_reference_prepare_formids_for_storage(
+                    $datasetName,
+                    $key,
+                    $formIds,
+                    $storeAsText
+                );
                 $jsonPayload = $GLOBALS["db"]->escape(json_encode($preparedFormIds));
                 if ($hasFormIdColumn) {
                     $arraySentinelSql = quest_reference_sql_array_sentinel_literal($storeAsText);

--- a/ui/addons/snqe/quest_reference_table.php
+++ b/ui/addons/snqe/quest_reference_table.php
@@ -35,11 +35,11 @@ function quest_ref_normalize_key($value)
     return strtolower(trim((string) $value));
 }
 
-function quest_ref_parse_formids_input($rawInput)
+function quest_ref_parse_formids_input($rawInput, $datasetName = '', $keyName = '')
 {
     $raw = trim((string) $rawInput);
     if ($raw === "") {
-        return [[], []];
+        return [[], [], []];
     }
 
     $tokens = [];
@@ -57,6 +57,7 @@ function quest_ref_parse_formids_input($rawInput)
 
     $valid = [];
     $invalid = [];
+    $unresolved = [];
     $seen = [];
     foreach ($tokens as $token) {
         $tokenCn = trim((string) $token, " \t\n\r\0\x0B\"'");
@@ -64,10 +65,18 @@ function quest_ref_parse_formids_input($rawInput)
             continue;
         }
 
-        $canonical = quest_reference_canonicalize_formid_for_text_storage($tokenCn);
+        $classified = quest_reference_classify_dataset_formid_for_text_storage(
+            $datasetName,
+            $keyName,
+            $tokenCn
+        );
+        $canonical = $classified['value'];
         if ($canonical === null || $canonical === '') {
             $invalid[] = $tokenCn;
             continue;
+        }
+        if ($classified['status'] === 'unresolved') {
+            $unresolved[] = $tokenCn;
         }
 
         $dedupeKey = strtolower($canonical);
@@ -78,10 +87,10 @@ function quest_ref_parse_formids_input($rawInput)
         }
     }
 
-    return [$valid, $invalid];
+    return [$valid, $invalid, $unresolved];
 }
 
-function quest_ref_decode_formids_json($value)
+function quest_ref_decode_formids_json($value, $datasetName = '', $keyName = '')
 {
     if (is_array($value)) {
         $arr = $value;
@@ -104,9 +113,13 @@ function quest_ref_decode_formids_json($value)
             continue;
         }
 
-        $canonical = quest_reference_canonicalize_formid_for_text_storage($itemCn);
+        $canonical = quest_reference_canonicalize_dataset_formid_for_text_storage(
+            $datasetName,
+            $keyName,
+            $itemCn
+        );
         if ($canonical === null || $canonical === '') {
-            continue;
+            $canonical = $itemCn;
         }
 
         $dedupeKey = strtolower($canonical);
@@ -146,20 +159,20 @@ function quest_ref_example_rows($datasetName)
 {
     $examples = [
         "item_types" => [
-            ["key_name" => "weapon", "formids" => ["0x0001397e", "0x00013989"], "active" => "true", "note" => "weapons"],
-            ["key_name" => "armor", "formids" => ["0x00012e49", "0x00013952"], "active" => "true", "note" => "armor pieces"],
+            ["key_name" => "weapon", "formids" => ["Skyrim.esm|0001397E", "Skyrim.esm|00013989"], "active" => "true", "note" => "weapons"],
+            ["key_name" => "armor", "formids" => ["Skyrim.esm|00012E49", "Skyrim.esm|00013952"], "active" => "true", "note" => "armor pieces"],
         ],
         "npc_templates" => [
-            ["key_name" => "male_redguard", "formids" => ["0x0006762e", "0x00058b3f", "0x0010f5a1"], "active" => "true", "note" => "grouped template sample"],
-            ["key_name" => "female_nord", "formids" => ["0x00013bbf", "0x00013bbe"], "active" => "true", "note" => "grouped template sample"],
+            ["key_name" => "male_redguard", "formids" => ["Skyrim.esm|0006762E", "Skyrim.esm|00058B3F", "Skyrim.esm|0010F5A1"], "active" => "true", "note" => "grouped template sample"],
+            ["key_name" => "female_nord", "formids" => ["Skyrim.esm|00013BBF", "Skyrim.esm|00013BBE"], "active" => "true", "note" => "grouped template sample"],
         ],
         "npc_own_templates" => [
-            ["key_name" => "balgruuf_the_greater", "formids" => ["0x00013baa"], "active" => "true", "note" => "single NPC override"],
-            ["key_name" => "farengar_secret_fire", "formids" => ["0x00013bbb"], "active" => "false", "note" => "inactive example"],
+            ["key_name" => "balgruuf_the_greater", "formids" => ["Skyrim.esm|00013BAA"], "active" => "true", "note" => "single NPC override"],
+            ["key_name" => "farengar_secret_fire", "formids" => ["Skyrim.esm|00013BBB"], "active" => "false", "note" => "inactive example"],
         ],
         "outfit" => [
-            ["key_name" => "warrior", "formids" => ["0x000d191f", "0x000d1920"], "active" => "true", "note" => "heavy outfit sample"],
-            ["key_name" => "mage", "formids" => ["0x000d1922", "0x000d1923"], "active" => "true", "note" => "robe outfit sample"],
+            ["key_name" => "warrior", "formids" => ["Skyrim.esm|000D191F", "Skyrim.esm|000D1920"], "active" => "true", "note" => "heavy outfit sample"],
+            ["key_name" => "mage", "formids" => ["Skyrim.esm|000D1922", "Skyrim.esm|000D1923"], "active" => "true", "note" => "robe outfit sample"],
         ],
     ];
 
@@ -295,6 +308,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["submit_csv"])) {
                 $imported = 0;
                 $skipped = 0;
                 $warnInvalid = 0;
+                $warnUnresolved = 0;
                 $warnPreview = [];
                 $map = ["key" => 0, "formids" => 1, "active" => 2, "note" => 3];
                 $headerChecked = false;
@@ -325,13 +339,18 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["submit_csv"])) {
                         continue;
                     }
 
-                    [$formids, $invalidFormids] = quest_ref_parse_formids_input($formidsInput);
+                    [$formids, $invalidFormids, $unresolvedFormids] = quest_ref_parse_formids_input(
+                        $formidsInput,
+                        $datasetName,
+                        $keyName
+                    );
                     if (!empty($invalidFormids)) {
                         $warnInvalid += count($invalidFormids);
                         if (count($warnPreview) < 5) {
                             $warnPreview[] = $keyName . ": " . implode(", ", array_slice($invalidFormids, 0, 3));
                         }
                     }
+                    $warnUnresolved += count($unresolvedFormids);
 
                     $active = ($activeRaw === "") ? true : quest_ref_bool($activeRaw);
 
@@ -352,6 +371,9 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["submit_csv"])) {
                         $message .= " (" . implode(" | ", $warnPreview) . ")";
                     }
                     $message .= ".";
+                }
+                if ($warnUnresolved > 0) {
+                    $message .= " {$warnUnresolved} raw FormID value(s) could not be matched to the loaded plugin manifest and remain load-order dependent.";
                 }
                 $messageType = "success";
             }
@@ -376,7 +398,11 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["submit_csv"])) {
                     throw new Exception("Key is required.");
                 }
 
-                [$formids, $invalidFormids] = quest_ref_parse_formids_input($formidsInput);
+                [$formids, $invalidFormids, $unresolvedFormids] = quest_ref_parse_formids_input(
+                    $formidsInput,
+                    $datasetName,
+                    $keyName
+                );
                 if (!empty($invalidFormids)) {
                     $preview = implode(", ", array_slice($invalidFormids, 0, 8));
                     if (count($invalidFormids) > 8) {
@@ -387,6 +413,9 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["submit_csv"])) {
                 quest_ref_upsert_entry($db, $tableName, $keyColumn, $keyName, $formids, $active, $note);
 
                 $message = "Entry saved for key '{$keyName}' with " . count($formids) . " form IDs.";
+                if (!empty($unresolvedFormids)) {
+                    $message .= " " . count($unresolvedFormids) . " raw FormID value(s) could not be matched to the loaded plugin manifest and remain load-order dependent.";
+                }
                 $messageType = "success";
             } elseif ($action === "delete_entry") {
                 if ($keyName === "") {
@@ -451,7 +480,11 @@ foreach ($rows as $row) {
     }
 
     $active = quest_ref_bool($row["active"] ?? true);
-    $formids = quest_ref_decode_formids_json($row["formids_json"] ?? "[]");
+    $formids = quest_ref_decode_formids_json(
+        $row["formids_json"] ?? "[]",
+        $datasetName,
+        $key
+    );
     $note = trim((string) ($row["note"] ?? ""));
     $updated = trim((string) ($row["updated_at"] ?? ""));
 
@@ -725,7 +758,7 @@ tr:hover {
 <main>
     <div class="page-header">
         <h1><?php echo htmlspecialchars($datasetLabel); ?></h1>
-        <p class="page-subtitle">Manage quest reference entries stored in <code><?php echo htmlspecialchars($tableName); ?></code>. One row per key with all form IDs in <code>formids_json</code>. Supports both raw FormIDs and stable <code>Plugin.esp|LocalFormId</code> references.</p>
+        <p class="page-subtitle">Manage quest reference entries stored in <code><?php echo htmlspecialchars($tableName); ?></code>. Stable <code>Plugin.esp|LocalFormId</code> references survive load-order changes. Raw FormIDs are converted automatically when their loaded plugin can be identified.</p>
     </div>
 
     <?php if ($message !== ""): ?>
@@ -744,8 +777,8 @@ tr:hover {
                 <input type="text" id="entry-key" name="key_name" placeholder="male_redguard" required>
 
                 <label for="entry-formids">Form IDs</label>
-                <textarea id="entry-formids" name="formids_input" placeholder='["0x0006762e", "MyMod.esp|000058B3"]'></textarea>
-                <p class="muted">Accepts JSON array or comma/newline-separated values. Decimal values are converted to canonical hex, and stable <code>Plugin.esp|LocalFormId</code> values are preserved.</p>
+                <textarea id="entry-formids" name="formids_input" placeholder='["Skyrim.esm|0006762E", "MyMod.esp|000058B3"]'></textarea>
+                <p class="muted">Accepts JSON arrays or comma/newline-separated values. Use <code>Plugin.esp|LocalFormId</code> when possible. Raw runtime IDs are matched against the loaded plugin manifest; unresolved values are retained with a warning. Dynamic <code>FFxxxxxx</code> references are not supported.</p>
 
                 <label for="entry-note">Note (optional)</label>
                 <input type="text" id="entry-note" name="note" placeholder="synced from rolemaster hardcode">
@@ -779,7 +812,7 @@ tr:hover {
                 CSV columns: <code><?php echo htmlspecialchars($keyColumn); ?></code>, <code>formids_json</code>, <code>active</code>, <code>note</code>.
             </p>
             <p class="muted">
-                Quote JSON arrays in CSV, for example <code>"[""0x0006762e"",""MyMod.esp|000058B3""]"</code>. Empty <code>active</code> defaults to <code>true</code>.
+                Quote JSON arrays in CSV, for example <code>"[""Skyrim.esm|0006762E"",""MyMod.esp|000058B3""]"</code>. Empty <code>active</code> defaults to <code>true</code>.
             </p>
             <p class="muted">
                 Current rows: <?php echo intval($entryCount); ?> (active: <?php echo intval($activeCount); ?>, form IDs: <?php echo intval($formidCount); ?>).

--- a/unittests/tests/FormReferenceSupportTest.php
+++ b/unittests/tests/FormReferenceSupportTest.php
@@ -18,7 +18,10 @@ final class FormReferenceSupportTest extends TestCase
 
             public function fetchOne(string $query): ?array
             {
-                if (stripos($query, "where lower(plugin_name) = lower('mymod.esp')") !== false) {
+                if (
+                    stripos($query, "where lower(plugin_name) = lower('mymod.esp')") !== false
+                    || stripos($query, "where formid_prefix = '02'") !== false
+                ) {
                     return [
                         'plugin_name' => 'MyMod.esp',
                         'is_light' => false,
@@ -30,7 +33,10 @@ final class FormReferenceSupportTest extends TestCase
                     ];
                 }
 
-                if (stripos($query, "where lower(plugin_name) = lower('somelight.esl')") !== false) {
+                if (
+                    stripos($query, "where lower(plugin_name) = lower('somelight.esl')") !== false
+                    || stripos($query, "where formid_prefix = 'FE123'") !== false
+                ) {
                     return [
                         'plugin_name' => 'SomeLight.esl',
                         'is_light' => true,
@@ -38,6 +44,36 @@ final class FormReferenceSupportTest extends TestCase
                         'small_file_compile_index' => 0x123,
                         'partial_index' => 0x123,
                         'formid_prefix' => 'FE123',
+                        'updated_at' => '2026-04-27 00:00:00',
+                    ];
+                }
+
+                if (
+                    stripos($query, "where lower(plugin_name) = lower('skyrim.esm')") !== false
+                    || stripos($query, "where formid_prefix = '00'") !== false
+                ) {
+                    return [
+                        'plugin_name' => 'Skyrim.esm',
+                        'is_light' => false,
+                        'compile_index' => 0,
+                        'small_file_compile_index' => 0,
+                        'partial_index' => 0,
+                        'formid_prefix' => '00',
+                        'updated_at' => '2026-04-27 00:00:00',
+                    ];
+                }
+
+                if (
+                    stripos($query, "where lower(plugin_name) = lower('aiagent.esp')") !== false
+                    || stripos($query, "where formid_prefix = '05'") !== false
+                ) {
+                    return [
+                        'plugin_name' => 'AIAgent.esp',
+                        'is_light' => false,
+                        'compile_index' => 5,
+                        'small_file_compile_index' => 0,
+                        'partial_index' => 0,
+                        'formid_prefix' => '05',
                         'updated_at' => '2026-04-27 00:00:00',
                     ];
                 }
@@ -66,6 +102,223 @@ final class FormReferenceSupportTest extends TestCase
             hexdec('FE123822'),
             quest_reference_normalize_formid('SomeLight.esl|00000822')
         );
+    }
+
+    public function testRuntimeFormIdsAreCanonicalizedToStableStorageReferences(): void
+    {
+        $this->assertSame(
+            'MyMod.esp|000086EE',
+            quest_reference_canonicalize_formid_for_text_storage('0x020086ee')
+        );
+        $this->assertSame(
+            'SomeLight.esl|00000822',
+            quest_reference_canonicalize_formid_for_text_storage('FE123822')
+        );
+        $this->assertSame(
+            'Skyrim.esm|0001397E',
+            quest_reference_canonicalize_formid_for_text_storage('0x0001397e')
+        );
+    }
+
+    public function testUnresolvedRuntimeIdsArePreservedAndDynamicIdsAreRejected(): void
+    {
+        $this->assertSame(
+            '0x03001234',
+            quest_reference_canonicalize_formid_for_text_storage('0x03001234')
+        );
+        $this->assertNull(
+            quest_reference_canonicalize_formid_for_text_storage('0xFF001234')
+        );
+
+        $unresolved = quest_reference_classify_formid_for_text_storage('0x03001234');
+        $this->assertSame('unresolved', $unresolved['status']);
+
+        $dynamic = quest_reference_classify_formid_for_text_storage('0xFF001234');
+        $this->assertSame('dynamic', $dynamic['status']);
+    }
+
+    public function testLegacyQuestReferenceRepairUsesManifestPrefixesWithoutDroppingUnknownValues(): void
+    {
+        $plugins = [
+            [
+                'plugin_name' => 'MyMod.esp',
+                'is_light' => false,
+                'compile_index' => 2,
+                'formid_prefix' => '02',
+            ],
+            [
+                'plugin_name' => 'SomeLight.esl',
+                'is_light' => true,
+                'compile_index' => 254,
+                'small_file_compile_index' => 0x123,
+                'formid_prefix' => 'FE123',
+            ],
+        ];
+        $pluginsByPrefix = chimIndexLoadedGamePluginsByPrefix($plugins);
+        $pluginsByName = chimIndexLoadedGamePluginsByName($plugins);
+
+        $repair = quest_reference_repair_formid_values(
+            'item_types',
+            'weapon',
+            [
+                '0x020086ee',
+                'MyMod.esp|86EE',
+                '0xFE123822',
+                '0x03001234',
+                '0xFF001234',
+                'not-a-formid',
+            ],
+            $pluginsByPrefix,
+            $pluginsByName
+        );
+
+        $this->assertSame([
+            'MyMod.esp|000086EE',
+            'SomeLight.esl|00000822',
+            '0x03001234',
+            '0xFF001234',
+            'not-a-formid',
+        ], $repair['values']);
+        $this->assertTrue($repair['changed']);
+        $this->assertSame(2, $repair['converted']);
+        $this->assertSame(1, $repair['unresolved']);
+        $this->assertSame(1, $repair['dynamic']);
+        $this->assertSame(1, $repair['invalid']);
+    }
+
+    public function testLegacyAIAgentLocalIdsDoNotGetMisidentifiedAsSkyrimForms(): void
+    {
+        $plugins = [
+            [
+                'plugin_name' => 'Skyrim.esm',
+                'is_light' => false,
+                'compile_index' => 0,
+                'formid_prefix' => '00',
+            ],
+            [
+                'plugin_name' => 'AIAgent.esp',
+                'is_light' => false,
+                'compile_index' => 5,
+                'formid_prefix' => '05',
+            ],
+        ];
+        $pluginsByPrefix = chimIndexLoadedGamePluginsByPrefix($plugins);
+        $pluginsByName = chimIndexLoadedGamePluginsByName($plugins);
+
+        $npcTemplate = quest_reference_classify_dataset_formid_for_text_storage(
+            'npc_own_templates',
+            'female_breton_noble',
+            '0x00025844',
+            $pluginsByPrefix,
+            $pluginsByName
+        );
+        $this->assertSame('AIAgent.esp|00025844', $npcTemplate['value']);
+        $this->assertSame(
+            hexdec('05025844'),
+            quest_reference_normalize_formid($npcTemplate['value'])
+        );
+
+        $questItem = quest_reference_classify_dataset_formid_for_text_storage(
+            'item_types',
+            'potion',
+            '0x0002481F',
+            $pluginsByPrefix,
+            $pluginsByName
+        );
+        $this->assertSame('AIAgent.esp|0002481F', $questItem['value']);
+
+        $legacyBook = quest_reference_classify_dataset_formid_for_text_storage(
+            'item_types',
+            'book',
+            '0x000CE70B',
+            $pluginsByPrefix,
+            $pluginsByName
+        );
+        $this->assertSame('Skyrim.esm|000CE70B', $legacyBook['value']);
+
+        $customVanillaTemplate = quest_reference_classify_dataset_formid_for_text_storage(
+            'npc_own_templates',
+            'custom_template',
+            '0x00025844',
+            $pluginsByPrefix,
+            $pluginsByName
+        );
+        $this->assertSame('Skyrim.esm|00025844', $customVanillaTemplate['value']);
+
+        $vanillaTemplate = quest_reference_classify_dataset_formid_for_text_storage(
+            'npc_templates',
+            'male_redguard',
+            '0x00013BAA',
+            $pluginsByPrefix,
+            $pluginsByName
+        );
+        $this->assertSame('Skyrim.esm|00013BAA', $vanillaTemplate['value']);
+    }
+
+    public function testPluginManifestRepairUpdatesLegacyQuestReferenceRows(): void
+    {
+        $db = new class {
+            public array $queries = [];
+
+            public function escape($value): string
+            {
+                return str_replace("'", "''", (string) $value);
+            }
+
+            public function fetchOne(string $query): ?array
+            {
+                if (stripos($query, 'information_schema.tables') !== false) {
+                    return ['n' => 1];
+                }
+                if (stripos($query, 'information_schema.columns') !== false) {
+                    return ['n' => 1];
+                }
+
+                return null;
+            }
+
+            public function fetchAll(string $query): array
+            {
+                if (stripos($query, 'from public.quest_item_types') !== false) {
+                    return [[
+                        'key_name' => 'weapon',
+                        'formids_json' => '["0x020086ee","0x03001234"]',
+                    ]];
+                }
+
+                return [];
+            }
+
+            public function execQuery(string $query): bool
+            {
+                $this->queries[] = $query;
+                return true;
+            }
+        };
+        $GLOBALS['db'] = $db;
+
+        $repair = quest_reference_repair_runtime_formids_to_stable([
+            [
+                'plugin_name' => 'MyMod.esp',
+                'is_light' => false,
+                'compile_index' => 2,
+                'formid_prefix' => '02',
+            ],
+        ]);
+
+        $this->assertNull($repair['error']);
+        $this->assertSame(1, $repair['rows_scanned']);
+        $this->assertSame(1, $repair['rows_updated']);
+        $this->assertSame(1, $repair['converted']);
+        $this->assertSame(1, $repair['unresolved']);
+
+        $updateQueries = array_values(array_filter(
+            $db->queries,
+            static fn (string $query): bool => stripos($query, 'UPDATE public.quest_item_types') !== false
+        ));
+        $this->assertCount(1, $updateQueries);
+        $this->assertStringContainsString('MyMod.esp|000086EE', $updateQueries[0]);
+        $this->assertStringContainsString('0x03001234', $updateQueries[0]);
     }
 
     public function testNpcMasterSupportsStableFactionDetection(): void


### PR DESCRIPTION
﻿## Summary
- store AI Quest V1 references as stable `Plugin.esp|LocalFormId` values instead of load-order-dependent runtime IDs
- support regular plugins and ESL `FE###` prefixes using the loaded plugin manifest
- repair legacy V1 rows after plugin sync while preserving unresolved, dynamic, and malformed values instead of dropping them
- preserve the known AIAgent-local V1 templates/items without misclassifying vanilla or custom references
- update the quest reference editor and CSV examples with stable FormID guidance and warnings

## Testing
- `php -l` passed for all five changed PHP files
- focused PHPUnit: 7 tests, 34 assertions passed
- `git diff --check` passed
- full PHPUnit attempted: 99 tests, 301 assertions, 9 existing environment/harness errors caused by Windows PostgreSQL setup, the Linux-only `/var/www/html/HerikaServer/log/chim.log` path, and the existing `sql::escapeLiteral()` PHPUnit adapter gap

## Review notes
- migration is transactional and only updates rows whose canonical values change
- unresolved raw IDs remain usable but are reported as load-order dependent
- dynamic `FFxxxxxx` IDs are rejected for new UI entries and preserved during legacy repair
