### PR TITLE
Fix TTS Studio API format warning

### DIFF
--- a/ui/xtts_clone.php
+++ b/ui/xtts_clone.php
@@ -180,7 +180,10 @@ if (!function_exists('chimTtsStudioIsAudioCppPocketTts')) {
         }
 
         $metadata = chimTtsStudioResolveConnectorMetadata($driver);
-        $apiFormat = strtolower(trim(strval($metadata['api_format'] ?? '')));
+        $apiFormatValue = $metadata['api_format'] ?? '';
+        $apiFormat = is_scalar($apiFormatValue)
+            ? strtolower(trim(strval($apiFormatValue)))
+            : '';
         if ($apiFormat === 'audio_cpp' || $apiFormat === 'audiocpp') {
             return true;
         }


### PR DESCRIPTION
﻿## Summary
- safely ignore legacy array-shaped api_format connector metadata in TTS Studio
- preserve the existing endpoint-based PocketTTS API detection fallback
- prevent the PHP "Array to string conversion" warning

## Validation
- php -l ui/xtts_clone.php
- exercised scalar, null, and legacy array metadata with warnings promoted to exceptions

## Coordination
The unstable push guard requires review because this file overlaps open PR #578.