### PR TITLE
Fix core request pipeline stability

### DIFF
--- a/connector/openrouterjson.php
+++ b/connector/openrouterjson.php
@@ -1372,7 +1372,7 @@ class openrouterjson
                 'method' => 'POST',
                 'header' => implode("\r\n", $headers),
                 'content' => json_encode($data),
-                'timeout' => ($GLOBALS["HTTP_TIMEOUT"]) ?: 30
+                'timeout' => ($GLOBALS["HTTP_TIMEOUT"] ?? null) ?: 30
             )
         );
 

--- a/functions/json_response.php
+++ b/functions/json_response.php
@@ -695,7 +695,7 @@
     }
 
     Function zonosIsActive() {
-        return $GLOBALS["TTSFUNCTION"] == "zonos_gradio" && isset($GLOBALS["TTS"]["ZONOS_GRADIO"]["dynamic_tones"]) && $GLOBALS["TTS"]["ZONOS_GRADIO"]["dynamic_tones"];
+        return ($GLOBALS["TTSFUNCTION"] ?? "") === "zonos_gradio" && isset($GLOBALS["TTS"]["ZONOS_GRADIO"]["dynamic_tones"]) && $GLOBALS["TTS"]["ZONOS_GRADIO"]["dynamic_tones"];
     }
 
 ?>

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -2430,6 +2430,17 @@ function getGametsLimitFor($actor) {
 
 
 
+function chimMemorySearchInputFromRequest(array $gameRequest): string
+{
+    $rawInput = trim((string)($gameRequest[3] ?? ''));
+    if (($gameRequest[0] ?? '') !== 'rechat') {
+        return $rawInput;
+    }
+
+    $payload = chimParseServerSideRechatPayload($rawInput);
+    return trim((string)($payload['origin_line'] ?? ''));
+}
+
 function offerMemory($gameRequest)
 {
     global $db;
@@ -2451,6 +2462,7 @@ function offerMemory($gameRequest)
     }
 
     $timeThreshold=round($gameRequest[2]-(getGametsLimitFor($npc)/0.0000024),0)-1;
+    $memorySearchInput = chimMemorySearchInputFromRequest($gameRequest);
 
     error_log("[DataSearchMemoryByVector] Using timeThreshold $timeThreshold");
     $contextKeywords  = implode(" ", lastKeyWordsContext(5,$npc));
@@ -2458,9 +2470,9 @@ function offerMemory($gameRequest)
     if ($GLOBALS["FEATURES"]["MEMORY_EMBEDDING"]["USE_TEXT2VEC"]) {
         $localStartTime = microtime(true);
         error_log("[DataSearchMemoryByVector calling]  : " . (microtime(true) - $localStartTime) . " seconds");
-        $res = DataSearchMemoryByVector($gameRequest[3], $npc, true,$timeThreshold);
+        $res = DataSearchMemoryByVector($memorySearchInput, $npc, true,$timeThreshold);
         error_log("[DataSearchMemoryByVector called 1]  : " . (microtime(true) - $localStartTime) . " seconds");
-        $res2 = DataSearchMemoryByVector($gameRequest[3], $npc,false,$timeThreshold);
+        $res2 = DataSearchMemoryByVector($memorySearchInput, $npc,false,$timeThreshold);
         error_log("[DataSearchMemoryByVector called 2]  : " . (microtime(true) - $localStartTime) . " seconds");
 
         if (isset($res[0]) && isset($res2[0])) {
@@ -2471,7 +2483,7 @@ function offerMemory($gameRequest)
         $memories = $resFinal;
         
     } else {
-        $memories=DataSearchMemory($gameRequest[3],$npc);
+        $memories=DataSearchMemory($memorySearchInput,$npc);
     }
    
     

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -598,12 +598,16 @@ function chimFormatProfileEquipmentParts(array $equipmentData, array $slots, boo
             continue;
         }
 
+        if (!is_scalar($equipmentData[$slot])) {
+            continue;
+        }
+
         $itemName = trim((string) $equipmentData[$slot]);
         if ($itemName === '' || isItemBlacklisted($itemName) || stripos($itemName, 'Missing Name') !== false) {
             continue;
         }
 
-        $baseid = isset($equipmentData[$slot . '_baseid'])
+        $baseid = isset($equipmentData[$slot . '_baseid']) && is_scalar($equipmentData[$slot . '_baseid'])
             ? trim((string) $equipmentData[$slot . '_baseid'])
             : '';
         $description = null;
@@ -628,7 +632,7 @@ function chimProfileEquipmentSlotsFromData(array $equipmentData, array $preferre
     $slots = $preferredSlots;
     foreach ($equipmentData as $key => $value) {
         $slot = trim((string) $key);
-        if ($slot === '' || substr($slot, -7) === '_baseid') {
+        if ($slot === '' || substr($slot, -7) === '_baseid' || substr($slot, -9) === '_keywords' || !is_scalar($value)) {
             continue;
         }
         if (!in_array($slot, $slots, true)) {
@@ -4961,6 +4965,22 @@ function DataSearchMemory($rawstring,$npcfilter) {
 }
 
 
+function chimNormalizeTsQueryTerms(string $text): array {
+    if (!preg_match_all('/[\p{L}\p{N}_]+/u', $text, $matches)) {
+        return [];
+    }
+
+    $terms = [];
+    foreach ($matches[0] as $term) {
+        if (mb_strlen($term, 'UTF-8') < 3) {
+            continue;
+        }
+        $terms[] = $term;
+    }
+
+    return array_values(array_unique($terms));
+}
+
 function DataSearchMemoryByVector($rawstring,$npcfilter,$useContextKw=false,$timeThreshold=0) {
     
         $localStartTime=microtime(true);
@@ -5154,17 +5174,7 @@ function DataSearchMemoryByVector($rawstring,$npcfilter,$useContextKw=false,$tim
 
         }
 
-        $result = explode(" ",$contextKeywords);
-
-        $resultNormalized=[];
-        foreach ($result as $word) {
-            if (strlen($word)<3)
-                continue;
-            if (!empty($word))
-                $resultNormalized[]=$word;
-        }
-
-        
+        $resultNormalized = chimNormalizeTsQueryTerms($contextKeywords);
         $kwStringAny=implode(" | ",$resultNormalized);
         $kwStringAll=implode(" & ",$resultNormalized);
         error_log("[DataSearchMemoryByVector] Generated Tags: $kwStringAny" );
@@ -5172,30 +5182,22 @@ function DataSearchMemoryByVector($rawstring,$npcfilter,$useContextKw=false,$tim
 
         if (is_array($vector) && isset($vector["embedding"])) {
             $vectorString="'[".implode(",",$vector["embedding"])."]'";
-   
-            $finalQuery="
-                SELECT summary, gamets_truncated,
-                        embedding <-> $vectorString as distance,
-                         ts_rank(native_vec, to_tsquery('$kwStringAny'))+ts_rank(native_vec, to_tsquery('$kwStringAll')) AS rank_any_fts,
-                         ts_rank(native_vec, to_tsquery('$kwStringAll')) AS rank_all_fts,
-                         (embedding <-> $vectorString) - ts_rank(native_vec, to_tsquery('$kwStringAny'))+ts_rank(native_vec, to_tsquery('$kwStringAll'))
-                          AS mixed_distance
-                    FROM public.memory_summary 
-                    WHERE embedding IS NOT NULL
-                    and $scopeConditionSql
-                    and companions like '|%{$GLOBALS["db"]->escape($npcfilter)}|%'
-                    ORDER BY (embedding <-> $vectorString)
-                    LIMIT 5 OFFSET 0
-                ";
+            $rankAnySql = $kwStringAny !== ''
+                ? "ts_rank(native_vec, to_tsquery('" . $GLOBALS["db"]->escape($kwStringAny) . "'))"
+                : "0::real";
+            $rankAllSql = $kwStringAll !== ''
+                ? "ts_rank(native_vec, to_tsquery('" . $GLOBALS["db"]->escape($kwStringAll) . "'))"
+                : "0::real";
+            $rankCombinedSql = "($rankAnySql + $rankAllSql)";
 
-             $finalQuery="
+            $finalQuery="
                 SELECT rowid,gamets_truncated,
                         embedding <-> $vectorString as distance,
-                         ts_rank(native_vec, to_tsquery('$kwStringAny')) AS rank_any_fts_raw,
-                         ts_rank(native_vec, to_tsquery('$kwStringAll')) AS rank_all_fts_raw,
-                         ts_rank(native_vec, to_tsquery('$kwStringAny'))+ts_rank(native_vec, to_tsquery('$kwStringAll')) AS rank_any_fts,
-                         ts_rank(native_vec, to_tsquery('$kwStringAny'))+ts_rank(native_vec, to_tsquery('$kwStringAll')) AS rank_all_fts,
-                         (embedding <-> $vectorString) - (ts_rank(native_vec, to_tsquery('$kwStringAny'))+ts_rank(native_vec, to_tsquery('$kwStringAll')) ) AS mixed_distance,
+                         $rankAnySql AS rank_any_fts_raw,
+                         $rankAllSql AS rank_all_fts_raw,
+                         $rankCombinedSql AS rank_any_fts,
+                         $rankCombinedSql AS rank_all_fts,
+                         (embedding <-> $vectorString) - $rankCombinedSql AS mixed_distance,
                          summary
                     FROM public.memory_summary 
                     WHERE embedding IS NOT NULL
@@ -5205,7 +5207,7 @@ function DataSearchMemoryByVector($rawstring,$npcfilter,$useContextKw=false,$tim
                     
                     ORDER BY 
                         round((embedding <-> $vectorString)::numeric, 2) ASC,
-                        (ts_rank(native_vec, to_tsquery('$kwStringAny'))+ts_rank(native_vec, to_tsquery('$kwStringAll'))) DESC
+                        $rankCombinedSql DESC
                     LIMIT 50 OFFSET 0
                 ";    
             $memory=$GLOBALS["db"]->fetchAll($finalQuery);

--- a/lib/dynamic_update_util.php
+++ b/lib/dynamic_update_util.php
@@ -1580,94 +1580,105 @@ function saveDynamicProfileUpdates($npcName, $updatedFields, $db, $updateTimeSta
     }
 }
 
-function triggerImmediateProfileProcessing() {
+function queueDynamicProfileBatch(array $npcNames, array $gameRequest): string {
     global $db;
-    
-    // Ensure required dependencies are loaded
-    if (!function_exists('DataSpeechJournal') || !function_exists('buildDynamicProfileDisplay')) {
-        require_once(__DIR__ . "/../lib/data_functions.php");
+
+    $npcNames = array_values(array_unique(array_filter(array_map('trim', $npcNames), static fn($name) => $name !== '')));
+    if (empty($npcNames)) {
+        throw new InvalidArgumentException('Cannot queue an empty dynamic profile batch');
     }
-    
-    // Check if there are any queue entries to process
-    $queueResults = $db->fetchAll("SELECT id, value FROM conf_opts WHERE id LIKE 'dynamic_profiles_queue_%' ORDER BY id LIMIT 5");
-    
-    if (empty($queueResults)) {
-        Logger::debug("triggerImmediateProfileProcessing: No queue entries found");
-        return;
+
+    $queueData = [
+        'timestamp' => time(),
+        'npcs' => $npcNames,
+        'gameRequest' => $gameRequest,
+    ];
+    $encoded = json_encode($queueData, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+    $queueId = 'dynamic_profiles_queue_' . time() . '_' . uniqid();
+
+    $db->upsertRowOnConflict('conf_opts', [
+        'id' => $queueId,
+        'value' => $encoded,
+    ], 'id');
+
+    return $queueId;
+}
+
+function chimPostgresBoolean($value): bool {
+    return $value === true || $value === 1 || $value === '1' || $value === 't' || $value === 'true';
+}
+
+function triggerImmediateProfileProcessing(?callable $profileProcessor = null): array {
+    global $db;
+
+    $result = [
+        'locked' => false,
+        'jobs' => 0,
+        'npcs' => 0,
+        'updated' => 0,
+    ];
+
+    $lockRows = $db->fetchAll("SELECT pg_try_advisory_lock(hashtext('herika_dynamic_profile_worker')) AS acquired");
+    if (empty($lockRows) || !chimPostgresBoolean($lockRows[0]['acquired'] ?? false)) {
+        Logger::debug("triggerImmediateProfileProcessing: Another worker owns the queue lock");
+        return $result;
     }
-    
-    Logger::info("triggerImmediateProfileProcessing: Processing " . count($queueResults) . " queue entries immediately");
-    
-    // Check if already processing (lock exists)
-    $lockId = 'dynamic_profiles_lock';
-    $lockResult = $db->fetchAll("SELECT value FROM conf_opts WHERE id = '$lockId'");
-    
-    if (!empty($lockResult)) {
-        $lockTime = intval($lockResult[0]['value']);
-        // If lock is recent (less than 30 seconds), skip immediate processing
-        if (time() - $lockTime < 30) {
-            Logger::debug("triggerImmediateProfileProcessing: Processing already in progress, skipping");
-            return;
-        } else {
-            // Remove stale lock
-            $db->delete("conf_opts", "id = '$lockId'");
-        }
-    }
-    
-    // Create processing lock
-    $db->upsertRowOnConflict('conf_opts', array('id' => $lockId, 'value' => time()), 'id');
-    
+
+    $result['locked'] = true;
+    $profileProcessor = $profileProcessor ?? 'processSingleDynamicProfile';
+
     try {
-        $processedJobs = 0;
-        $totalNPCs = 0;
-        
+        $queueResults = $db->fetchAll("SELECT id, value FROM conf_opts WHERE id LIKE 'dynamic_profiles_queue_%' ORDER BY id LIMIT 5");
+        if (empty($queueResults)) {
+            Logger::debug("triggerImmediateProfileProcessing: No queue entries found");
+            return $result;
+        }
+
+        Logger::info("triggerImmediateProfileProcessing: Processing " . count($queueResults) . " queue entries");
+
         foreach ($queueResults as $queueRow) {
             $queueId = $queueRow['id'];
             $queueJson = $queueRow['value'];
-            
-            // Delete this queue entry immediately
-            $db->delete("conf_opts", "id = '" . $db->escape($queueId) . "'");
-            
             $queueData = json_decode($queueJson, true);
             if (!$queueData || !isset($queueData['npcs']) || !isset($queueData['gameRequest'])) {
                 Logger::error("triggerImmediateProfileProcessing: Invalid queue data for $queueId");
+                $db->delete("conf_opts", "id = '" . $db->escape($queueId) . "'");
                 continue;
             }
 
-            $npcs = $queueData['npcs'];
+            $npcs = is_array($queueData['npcs']) ? $queueData['npcs'] : [];
             $gameRequest = $queueData['gameRequest'];
-            
             Logger::info("triggerImmediateProfileProcessing: Processing " . count($npcs) . " NPCs");
 
             $successCount = 0;
             foreach ($npcs as $npcName) {
                 try {
-                    if (processSingleDynamicProfile($npcName, $gameRequest)) {
+                    if ($profileProcessor($npcName, $gameRequest)) {
                         $successCount++;
                         Logger::debug("triggerImmediateProfileProcessing: Updated profile for $npcName");
                     }
-                } catch (Exception $e) {
+                } catch (Throwable $e) {
                     Logger::error("triggerImmediateProfileProcessing: Error processing $npcName: " . $e->getMessage());
                 }
             }
 
+            // A claimed job is removed only after every NPC has been attempted. If the
+            // worker process dies mid-job, the row remains and the next cycle retries it.
+            $db->delete("conf_opts", "id = '" . $db->escape($queueId) . "'");
             Logger::info("triggerImmediateProfileProcessing: Completed job - updated $successCount of " . count($npcs) . " profiles");
-            $processedJobs++;
-            $totalNPCs += count($npcs);
+            $result['jobs']++;
+            $result['npcs'] += count($npcs);
+            $result['updated'] += $successCount;
         }
 
-        if ($processedJobs > 0) {
-            Logger::info("triggerImmediateProfileProcessing: Total processed: $processedJobs jobs, $totalNPCs NPCs");
-        }
-
-    } catch (Exception $e) {
+        Logger::info("triggerImmediateProfileProcessing: Total processed: {$result['jobs']} jobs, {$result['npcs']} NPCs");
+    } catch (Throwable $e) {
         Logger::error("triggerImmediateProfileProcessing: Fatal error: " . $e->getMessage());
     } finally {
-        // Always remove lock
-        $db->delete("conf_opts", "id = '$lockId'");
+        $db->fetchAll("SELECT pg_advisory_unlock(hashtext('herika_dynamic_profile_worker')) AS released");
     }
 
-
+    return $result;
 }
 ?>
 

--- a/main.php
+++ b/main.php
@@ -171,6 +171,12 @@ if (isset($gameRequest[3]) && is_string($gameRequest[3]) &&
 // Call extension's preprocessing files
 requireFilesRecursively(__DIR__.DIRECTORY_SEPARATOR."ext".DIRECTORY_SEPARATOR,"preprocessing.php");
 
+// Raw physics telemetry is opt-in. Extensions may rename it during preprocessing;
+// if none did, acknowledge it here without entering the dialogue/LLM pipeline.
+if ($gameRequest[0] === "physics_raw") {
+    terminate();
+}
+
 if (in_array($gameRequest[0],["inputtext","inputtext_s","ginputtext","ginputtext_s","narrator_inputtext","instruction","init"])) {
     // This is just a mark that user has made an input request. We will check later when waiting for LLm response 
     // if user has made input after initial request, so we can abort it.

--- a/processor/comm.php
+++ b/processor/comm.php
@@ -2043,90 +2043,21 @@ if ($gameRequest[0] == "wipe") { // Reset reponses if init sent (Think about thi
     
     $enabledCount = count($enabledNPCs);
     
-    // Send immediate ACK message back to plugin with count - ONLY notification we send
+    // Persist the work before acknowledging it. The core service processes this queue;
+    // Apache must never retain the client connection while profile LLM calls run.
     if ($enabledCount > 0) {
-        echo "The Narrator|rolecommand|DebugNotification@Updating $enabledCount dynamic profile" . ($enabledCount == 1 ? "" : "s") . "..." . PHP_EOL;
-        Logger::info("updateprofiles_batch_async: Will update $enabledCount profiles in background: " . implode(', ', $enabledNPCs));
+        try {
+            $queueId = queueDynamicProfileBatch($enabledNPCs, $gameRequest);
+            echo "The Narrator|rolecommand|DebugNotification@Updating $enabledCount dynamic profile" . ($enabledCount == 1 ? "" : "s") . "..." . PHP_EOL;
+            Logger::info("updateprofiles_batch_async: Queued $enabledCount profiles as $queueId: " . implode(', ', $enabledNPCs));
+        } catch (Throwable $e) {
+            Logger::error("updateprofiles_batch_async: Failed to queue profiles: " . $e->getMessage());
+            echo "The Narrator|rolecommand|DebugNotification@Unable to queue dynamic profile updates." . PHP_EOL;
+        }
     } else {
         Logger::info("updateprofiles_batch_async: No profiles to update - none had DYNAMIC_PROFILE enabled");
     }
-    
-    if (ob_get_level() > 0) {
-        @ob_flush();
-    }
-    @flush();
-    
-    // Process in background if we have enabled NPCs
-    if ($enabledCount > 0) {
-        // Try to fork process for background processing
-        if (function_exists('pcntl_fork')) {
-            $pid = pcntl_fork();
-            if ($pid == 0) {
-                // Child process - do the background work
-                Logger::info("updateprofiles_batch_async: Child process started for background processing");
-                
-                $successCount = 0;
-                foreach ($enabledNPCs as $npcName) {
-                    try {
-                        if (processSingleDynamicProfile($npcName, $gameRequest)) {
-                            $successCount++;
-                        }
-                    } catch (Exception $e) {
-                        Logger::error("updateprofiles_batch_async: Error processing profile for $npcName: " . $e->getMessage());
-                    }
-                }
-                
-                Logger::info("updateprofiles_batch_async: Background processing completed. Updated $successCount of $enabledCount profiles");
-                exit(0);
-            } elseif ($pid > 0) {
-                // Parent process - continue normally
-                Logger::info("updateprofiles_batch_async: Forked background process with PID $pid");
-            } else {
-                // Fork failed - fall back to database queue method
-                Logger::warn("updateprofiles_batch_async: Fork failed, using database queue fallback");
-                $queueData = [
-                    'timestamp' => time(),
-                    'npcs' => $enabledNPCs,
-                    'gameRequest' => $gameRequest
-                ];
-                $queueId = 'dynamic_profiles_queue_' . time() . '_' . uniqid();
-                
-                try {
-                    $db->upsertRowOnConflict('conf_opts', array(
-                        'id' => $queueId,
-                        'value' => json_encode($queueData)
-                    ), 'id');
-                    Logger::info("updateprofiles_batch_async: Queued $enabledCount profiles for background processing in database");
-                } catch (Exception $e) {
-                    Logger::error("updateprofiles_batch_async: Failed to write to database queue: " . $e->getMessage());
-                }
-            }
-        } else {
-            // No fork available - use database queue method
-            Logger::info("updateprofiles_batch_async: pcntl_fork not available, using database queue method");
-            $queueData = [
-                'timestamp' => time(),
-                'npcs' => $enabledNPCs,
-                'gameRequest' => $gameRequest
-            ];
-            $queueId = 'dynamic_profiles_queue_' . time() . '_' . uniqid();
-            
-            try {
-                $db->upsertRowOnConflict('conf_opts', array(
-                    'id' => $queueId,
-                    'value' => json_encode($queueData)
-                ), 'id');
-                Logger::info("updateprofiles_batch_async: Queued $enabledCount profiles for background processing in database");
-            } catch (Exception $e) {
-                Logger::error("updateprofiles_batch_async: Failed to write to database queue: " . $e->getMessage());
-            }
-        }
-        
-        // Trigger immediate background processing
-        close();
-        triggerImmediateProfileProcessing();
-    }
-    
+
     terminate();
     //die("X-CUSTOM-CLOSE");
     

--- a/service/processors/dynamicprofile/entrypoint.php
+++ b/service/processors/dynamicprofile/entrypoint.php
@@ -1,0 +1,22 @@
+<?php
+
+$GLOBALS['TASKS']['dynamicprofile'] = [];
+$GLOBALS['TASKS']['dynamicprofile']['fn'] = function () {
+    $enginePath = $GLOBALS['ENGINE_ROOT'];
+    $GLOBALS['ENGINE_PATH'] = $enginePath;
+
+    if (!isset($GLOBALS['db'])) {
+        $GLOBALS['db'] = new sql();
+    }
+
+    require_once $enginePath . 'prompts/command_prompt.php';
+    require_once $enginePath . 'lib/chat_helper_functions.php';
+    require_once $enginePath . 'lib/data_functions.php';
+    require_once $enginePath . 'lib/dynamic_update_util.php';
+    require_once $enginePath . 'lib/core/npc_master.class.php';
+    require_once $enginePath . 'lib/core/core_profiles.class.php';
+    require_once $enginePath . 'lib/core/llm_connector.class.php';
+
+    triggerImmediateProfileProcessing();
+};
+

--- a/unittests/tests/CoreRequestStabilityTest.php
+++ b/unittests/tests/CoreRequestStabilityTest.php
@@ -1,0 +1,171 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/logger.php';
+Logger::setCustomLog(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'chim-core-request-stability-test.log');
+$GLOBALS['HERIKA_NAME'] = 'Test NPC';
+$GLOBALS['PLAYER_NAME'] = 'Test Player';
+require_once __DIR__ . '/../../lib/chat_helper_functions.php';
+require_once __DIR__ . '/../../lib/data_functions.php';
+require_once __DIR__ . '/../../lib/dynamic_update_util.php';
+require_once __DIR__ . '/../../functions/json_response.php';
+
+final class DynamicProfileQueueTestDb
+{
+    public array $rows = [];
+    public bool $lockAvailable = true;
+
+    public function upsertRowOnConflict(string $table, array $data, string $conflictColumn): void
+    {
+        $this->rows[(string)$data['id']] = (string)$data['value'];
+    }
+
+    public function fetchAll(string $query): array
+    {
+        if (str_contains($query, 'pg_try_advisory_lock')) {
+            return [['acquired' => $this->lockAvailable ? 't' : 'f']];
+        }
+        if (str_contains($query, 'pg_advisory_unlock')) {
+            return [['released' => 't']];
+        }
+        if (str_contains($query, "id LIKE 'dynamic_profiles_queue_%'")) {
+            $result = [];
+            foreach ($this->rows as $id => $value) {
+                if (str_starts_with($id, 'dynamic_profiles_queue_')) {
+                    $result[] = ['id' => $id, 'value' => $value];
+                }
+            }
+            return array_slice($result, 0, 5);
+        }
+        return [];
+    }
+
+    public function delete(string $table, string $where): void
+    {
+        if (preg_match("/id = '([^']+)'/", $where, $match)) {
+            unset($this->rows[$match[1]]);
+        }
+    }
+
+    public function escape($value): string
+    {
+        return str_replace("'", "''", (string)$value);
+    }
+}
+
+final class CoreRequestStabilityTest extends TestCase
+{
+    private bool $warningHandlerInstalled = false;
+
+    protected function tearDown(): void
+    {
+        if ($this->warningHandlerInstalled) {
+            restore_error_handler();
+            $this->warningHandlerInstalled = false;
+        }
+        unset($GLOBALS['db'], $GLOBALS['TTSFUNCTION'], $GLOBALS['TTS']);
+    }
+
+    private function failOnWarning(): void
+    {
+        set_error_handler(static function (int $severity, string $message): never {
+            throw new ErrorException($message, 0, $severity);
+        });
+        $this->warningHandlerInstalled = true;
+    }
+
+    public function testEquipmentKeywordMetadataIsNotTreatedAsAnItem(): void
+    {
+        $equipment = [
+            'armor' => 'Dawnguard Heavy Armor',
+            'armor_baseid' => '0200F3FA',
+            'armor_keywords' => ['ArmorHeavy', 'ArmorCuirass'],
+            'boots' => 'Dawnguard Boots',
+            'boots_baseid' => '0200F400',
+            'boots_keywords' => ['ArmorLight', 'ArmorBoots'],
+        ];
+
+        $this->failOnWarning();
+
+        $slots = chimProfileEquipmentSlotsFromData($equipment, ['armor', 'boots']);
+        $parts = chimFormatProfileEquipmentParts($equipment, $slots, false);
+
+        $this->assertSame(['armor', 'boots'], $slots);
+        $this->assertSame(['Dawnguard Heavy Armor', 'Dawnguard Boots'], $parts);
+    }
+
+    public function testEquipmentFormatterDefensivelySkipsStructuredValues(): void
+    {
+        $this->failOnWarning();
+
+        $parts = chimFormatProfileEquipmentParts(
+            ['armor' => ['name' => 'Invalid structured item'], 'boots' => 'Leather Boots'],
+            ['armor', 'boots'],
+            false
+        );
+
+        $this->assertSame(['Leather Boots'], $parts);
+    }
+
+    public function testRechatMemorySearchUsesOriginLineInsteadOfControlJson(): void
+    {
+        $payload = json_encode([
+            'speaker' => 'Lydia',
+            'listener_hint' => 'Prisoner',
+            'origin_line' => 'Lydia: The old barrow may contain the missing claw.',
+            'chain_id' => 'chain:with|operators',
+        ], JSON_THROW_ON_ERROR);
+
+        $input = chimMemorySearchInputFromRequest(['rechat', '0', '0', $payload]);
+
+        $this->assertSame('Lydia: The old barrow may contain the missing claw.', $input);
+        $this->assertStringNotContainsString('chain_id', $input);
+    }
+
+    public function testTsQueryTermsStripJsonAndPostgresOperators(): void
+    {
+        $terms = chimNormalizeTsQueryTerms('{"chain_id":"abc|def", "line":"claw & barrow: old"}');
+
+        $this->assertSame(['chain_id', 'abc', 'def', 'line', 'claw', 'barrow', 'old'], $terms);
+        $this->assertSame([], chimNormalizeTsQueryTerms('{} | & :'));
+    }
+
+    public function testZonosCheckDoesNotWarnWhenTtsIsNotInitialized(): void
+    {
+        unset($GLOBALS['TTSFUNCTION'], $GLOBALS['TTS']);
+        $this->failOnWarning();
+
+        $this->assertFalse(zonosIsActive());
+    }
+
+    public function testDynamicProfileBatchIsQueuedAndConsumedOnce(): void
+    {
+        $db = new DynamicProfileQueueTestDb();
+        $GLOBALS['db'] = $db;
+
+        $queueId = queueDynamicProfileBatch([' Lydia ', 'Lydia', 'Aela'], ['updateprofiles_batch_async', '1', '2']);
+        $processed = [];
+        $result = triggerImmediateProfileProcessing(static function (string $npcName, array $gameRequest) use (&$processed): bool {
+            $processed[] = [$npcName, $gameRequest[0]];
+            return true;
+        });
+
+        $this->assertArrayNotHasKey($queueId, $db->rows);
+        $this->assertSame([['Lydia', 'updateprofiles_batch_async'], ['Aela', 'updateprofiles_batch_async']], $processed);
+        $this->assertSame(['locked' => true, 'jobs' => 1, 'npcs' => 2, 'updated' => 2], $result);
+    }
+
+    public function testDynamicProfileQueueDoesNothingWhenAnotherWorkerOwnsLock(): void
+    {
+        $db = new DynamicProfileQueueTestDb();
+        $GLOBALS['db'] = $db;
+        $queueId = queueDynamicProfileBatch(['Lydia'], ['updateprofiles_batch_async', '1', '2']);
+        $db->lockAvailable = false;
+
+        $result = triggerImmediateProfileProcessing(static fn(): bool => true);
+
+        $this->assertArrayHasKey($queueId, $db->rows);
+        $this->assertSame(['locked' => false, 'jobs' => 0, 'npcs' => 0, 'updated' => 0], $result);
+    }
+}


### PR DESCRIPTION
﻿## Summary
- stop unhandled `physics_raw` telemetry before it enters the dialogue/LLM pipeline
- move dynamic-profile batch processing out of Apache requests and into the core service queue
- sanitize memory full-text search terms and use the rechat origin line instead of control JSON
- safely handle structured equipment metadata and optional timeout/TTS globals
- add focused regression coverage for the corrected request paths

## Root cause
Several core request paths assumed optional globals and scalar payload values were always initialized. Raw physics telemetry could also fall through without an extension handler, and dynamic-profile updates performed LLM work from the web request lifecycle. Rechat control JSON was passed directly into PostgreSQL `to_tsquery`, allowing syntax operators in metadata to produce malformed searches.

## Impact
These changes prevent avoidable PHP warnings and connector errors, keep raw telemetry from producing LLM requests, prevent malformed memory searches, and allow dynamic-profile updates to continue asynchronously without holding the game request open.

## Validation
- `php vendor/bin/phpunit tests/CoreRequestStabilityTest.php` (`7` tests, `13` assertions)
- PHP syntax checks passed for all changed files
- `git diff --check`
- live `physics_raw` request returned `X-CUSTOM-CLOSE` in approximately 118 ms without connector errors
- deployed dynamic-profile worker consumed an invalid test queue job without invoking an LLM
- local HerikaServer UI returned HTTP 200 after deployment

## Review notes
The unstable push guard requires a PR because this touches `main.php`, `processor/comm.php`, and `service/processors/`. It also reported overlap with open PRs #581 (`main.php`) and #568 (`lib/data_functions.php`), so this remains a draft pending conflict and semantic review.
