### PR TITLE
Install bundled server plugins automatically from CHIM

### DIFF
--- a/lib/plugin_package_manager.php
+++ b/lib/plugin_package_manager.php
@@ -1,0 +1,856 @@
+<?php
+
+declare(strict_types=1);
+
+final class DwemerPluginPackageException extends RuntimeException
+{
+}
+
+final class DwemerPluginPackageManager
+{
+    public const SCHEMA_VERSION = 3;
+    public const MAX_ENTRIES = 5000;
+    public const MAX_UNCOMPRESSED_BYTES = 1073741824;
+    public const MAX_ARCHIVE_BYTES = 536870912;
+    public const MAX_UPLOAD_CHUNK_BYTES = 1572864;
+
+    private string $serverRoot;
+    private string $stateRoot;
+    private $migrationRunner;
+
+    public function __construct(?string $serverRoot = null, ?string $stateRoot = null, ?callable $migrationRunner = null)
+    {
+        $this->serverRoot = rtrim($serverRoot ?? dirname(__DIR__), DIRECTORY_SEPARATOR);
+        $this->stateRoot = rtrim($stateRoot ?? ($this->serverRoot . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'plugin_packages'), DIRECTORY_SEPARATOR);
+        $this->migrationRunner = $migrationRunner;
+        $this->ensureStateDirectories();
+    }
+
+    public function getBrokerToken(): string
+    {
+        $path = $this->stateRoot . DIRECTORY_SEPARATOR . 'broker_token';
+        if (is_file($path)) {
+            $token = trim((string)file_get_contents($path));
+            if (preg_match('/^[a-f0-9]{64}$/', $token)) {
+                return $token;
+            }
+        }
+
+        $token = bin2hex(random_bytes(32));
+        $this->atomicWrite($path, $token . PHP_EOL, 0600);
+        return $token;
+    }
+
+    public function authenticateBrokerToken(?string $token): bool
+    {
+        return is_string($token) && $token !== '' && hash_equals($this->getBrokerToken(), trim($token));
+    }
+
+    public function queueArchive(string $sourceArchive, ?string $originalName = null): array
+    {
+        if (!is_file($sourceArchive) || !is_readable($sourceArchive)) {
+            throw new DwemerPluginPackageException('Package archive is missing or unreadable.');
+        }
+        if (!class_exists(ZipArchive::class)) {
+            throw new DwemerPluginPackageException('PHP ZipArchive support is required for unified plugin packages.');
+        }
+
+        $jobId = bin2hex(random_bytes(16));
+        $archivePath = $this->stateRoot . DIRECTORY_SEPARATOR . 'archives' . DIRECTORY_SEPARATOR . $jobId . '.dwpkg';
+        $stageRoot = $this->stateRoot . DIRECTORY_SEPARATOR . 'staging' . DIRECTORY_SEPARATOR . $jobId;
+
+        try {
+            if (!copy($sourceArchive, $archivePath)) {
+                throw new DwemerPluginPackageException('Could not copy the package into server staging.');
+            }
+
+            $manifest = $this->validateAndExtractArchive($archivePath, $stageRoot);
+            $hasGame = isset($manifest['components']['game']);
+            $hasServer = isset($manifest['components']['server']);
+            $now = gmdate(DATE_ATOM);
+            $job = [
+                'id' => $jobId,
+                'status' => $hasGame ? 'awaiting_launcher' : 'activating_server',
+                'package_id' => $manifest['package_id'],
+                'package_name' => $manifest['name'],
+                'version' => $manifest['version'],
+                'original_name' => $originalName ?? basename($sourceArchive),
+                'archive_path' => $archivePath,
+                'stage_root' => $stageRoot,
+                'manifest' => $manifest,
+                'has_game' => $hasGame,
+                'has_server' => $hasServer,
+                'created_at' => $now,
+                'updated_at' => $now,
+                'error' => null,
+            ];
+            $this->writeJob($job);
+
+            if (!$hasGame) {
+                $job = $this->activateAndFinalize($job);
+            }
+
+            return $this->publicJob($job);
+        } catch (Throwable $error) {
+            $this->removeDirectory($stageRoot);
+            @unlink($archivePath);
+            throw $error;
+        }
+    }
+
+    public function startChunkedUpload(string $originalName, int $size, int $totalChunks): array
+    {
+        if (strtolower(pathinfo($originalName, PATHINFO_EXTENSION)) !== 'dwpkg') {
+            throw new DwemerPluginPackageException('Unified plugin packages must use the .dwpkg extension.');
+        }
+        if ($size < 1 || $size > self::MAX_ARCHIVE_BYTES) {
+            throw new DwemerPluginPackageException('Package archive size is invalid or exceeds 512 MB.');
+        }
+        if ($totalChunks < 1 || $totalChunks > 1024) {
+            throw new DwemerPluginPackageException('Package upload chunk count is invalid.');
+        }
+        $uploadId = bin2hex(random_bytes(16));
+        $metadata = [
+            'id' => $uploadId,
+            'original_name' => basename($originalName),
+            'size' => $size,
+            'total_chunks' => $totalChunks,
+            'next_index' => 0,
+            'received_bytes' => 0,
+            'created_at' => gmdate(DATE_ATOM),
+        ];
+        $this->atomicWrite($this->uploadMetadataPath($uploadId), json_encode($metadata, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR) . PHP_EOL);
+        return ['upload_id' => $uploadId, 'next_index' => 0];
+    }
+
+    public function appendUploadChunk(string $uploadId, int $index, string $data): array
+    {
+        if (strlen($data) < 1 || strlen($data) > self::MAX_UPLOAD_CHUNK_BYTES) {
+            throw new DwemerPluginPackageException('Upload chunk is empty or exceeds the chunk size limit.');
+        }
+        $metadataPath = $this->uploadMetadataPath($uploadId);
+        if (!is_file($metadataPath)) {
+            throw new DwemerPluginPackageException('Chunked upload was not found.');
+        }
+        $handle = fopen($metadataPath, 'c+');
+        if (!is_resource($handle) || !flock($handle, LOCK_EX)) {
+            throw new DwemerPluginPackageException('Could not lock chunked upload.');
+        }
+        $complete = false;
+        try {
+            rewind($handle);
+            $metadata = json_decode((string)stream_get_contents($handle), true, 32, JSON_THROW_ON_ERROR);
+            if ($index !== (int)$metadata['next_index']) {
+                throw new DwemerPluginPackageException('Upload chunks must arrive once and in order.');
+            }
+            $receivedBytes = (int)$metadata['received_bytes'] + strlen($data);
+            if ($receivedBytes > (int)$metadata['size']) {
+                throw new DwemerPluginPackageException('Upload exceeds its declared archive size.');
+            }
+            $partPath = $this->uploadPartPath($uploadId);
+            if (file_put_contents($partPath, $data, FILE_APPEND | LOCK_EX) === false) {
+                throw new DwemerPluginPackageException('Could not write upload chunk.');
+            }
+            $metadata['received_bytes'] = $receivedBytes;
+            $metadata['next_index'] = $index + 1;
+            $complete = $metadata['next_index'] === (int)$metadata['total_chunks'];
+            if ($complete && $receivedBytes !== (int)$metadata['size']) {
+                throw new DwemerPluginPackageException('Completed upload size does not match the declared archive size.');
+            }
+            rewind($handle);
+            ftruncate($handle, 0);
+            fwrite($handle, json_encode($metadata, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR) . PHP_EOL);
+            fflush($handle);
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+
+        if (!$complete) {
+            return ['complete' => false, 'next_index' => $index + 1];
+        }
+
+        try {
+            $metadata = $this->readJsonFile($metadataPath);
+            $job = $this->queueArchive($this->uploadPartPath($uploadId), (string)$metadata['original_name']);
+            return ['complete' => true, 'job' => $job];
+        } finally {
+            @unlink($metadataPath);
+            @unlink($this->uploadPartPath($uploadId));
+        }
+    }
+
+    public function getJob(string $jobId): array
+    {
+        return $this->publicJob($this->readJob($jobId));
+    }
+
+    public function pendingJobs(): array
+    {
+        $jobs = [];
+        foreach (glob($this->stateRoot . DIRECTORY_SEPARATOR . 'jobs' . DIRECTORY_SEPARATOR . '*.json') ?: [] as $jobPath) {
+            $job = $this->readJsonFile($jobPath);
+            if (($job['status'] ?? '') === 'installing_game' && isset($job['claimed_at'])) {
+                $claimedAt = strtotime((string)$job['claimed_at']);
+                if ($claimedAt !== false && $claimedAt < time() - 600) {
+                    $job = $this->withLockedJob((string)$job['id'], static function (array $lockedJob): array {
+                        if (($lockedJob['status'] ?? '') === 'installing_game') {
+                            $lockedJob['status'] = 'awaiting_launcher';
+                            $lockedJob['updated_at'] = gmdate(DATE_ATOM);
+                            unset($lockedJob['claim_token'], $lockedJob['claimed_at']);
+                        }
+                        return $lockedJob;
+                    });
+                }
+            }
+            if (($job['status'] ?? '') !== 'awaiting_launcher') {
+                continue;
+            }
+            $jobs[] = $this->publicJob($job);
+        }
+        usort($jobs, static fn(array $left, array $right): int => strcmp((string)$left['created_at'], (string)$right['created_at']));
+        return $jobs;
+    }
+
+    public function claimJob(string $jobId): array
+    {
+        return $this->withLockedJob($jobId, function (array $job): array {
+            if (($job['status'] ?? '') !== 'awaiting_launcher') {
+                throw new DwemerPluginPackageException('Package job is not available for launcher installation.');
+            }
+            $job['status'] = 'installing_game';
+            $job['claim_token'] = bin2hex(random_bytes(24));
+            $job['claimed_at'] = gmdate(DATE_ATOM);
+            $job['updated_at'] = $job['claimed_at'];
+            return $job;
+        }, true);
+    }
+
+    public function completeGameInstall(string $jobId, string $claimToken, bool $success, array $result = []): array
+    {
+        $job = $this->withLockedJob($jobId, function (array $job) use ($claimToken, $success, $result): array {
+            if (($job['status'] ?? '') !== 'installing_game') {
+                throw new DwemerPluginPackageException('Package job is not awaiting a launcher result.');
+            }
+            if (!isset($job['claim_token']) || !hash_equals((string)$job['claim_token'], $claimToken)) {
+                throw new DwemerPluginPackageException('Package claim token is invalid.');
+            }
+            unset($job['claim_token']);
+            $job['game_result'] = $result;
+            $job['updated_at'] = gmdate(DATE_ATOM);
+            if (!$success) {
+                $job['status'] = 'failed';
+                $job['error'] = (string)($result['error'] ?? 'The launcher could not install the game component.');
+                return $job;
+            }
+            $job['status'] = !empty($job['has_server']) ? 'activating_server' : 'completed';
+            return $job;
+        });
+
+        if (($job['status'] ?? '') === 'activating_server') {
+            $job = $this->activateAndFinalize($job);
+        } elseif (($job['status'] ?? '') === 'completed') {
+            $this->recordInstalledPackage($job, []);
+            $this->removeDirectory((string)$job['stage_root']);
+        }
+
+        return $this->publicJob($job);
+    }
+
+    public function archivePathForJob(string $jobId): string
+    {
+        $job = $this->readJob($jobId);
+        $path = (string)($job['archive_path'] ?? '');
+        if ($path === '' || !is_file($path)) {
+            throw new DwemerPluginPackageException('Package archive is no longer available.');
+        }
+        return $path;
+    }
+
+    public function recordGameRollback(string $jobId, array $result): array
+    {
+        $job = $this->withLockedJob($jobId, static function (array $job) use ($result): array {
+            if (($job['status'] ?? '') !== 'failed') {
+                throw new DwemerPluginPackageException('Only failed package jobs can record a game rollback.');
+            }
+            $job['game_rollback'] = $result;
+            $job['updated_at'] = gmdate(DATE_ATOM);
+            return $job;
+        });
+        return $this->publicJob($job);
+    }
+
+    public function validateAndExtractArchive(string $archivePath, string $stageRoot): array
+    {
+        $zip = new ZipArchive();
+        $openResult = $zip->open($archivePath);
+        if ($openResult !== true) {
+            throw new DwemerPluginPackageException('Package is not a readable ZIP archive.');
+        }
+
+        try {
+            if ($zip->numFiles < 3 || $zip->numFiles > self::MAX_ENTRIES) {
+                throw new DwemerPluginPackageException('Package has an invalid number of entries.');
+            }
+
+            $totalBytes = 0;
+            $entries = [];
+            for ($index = 0; $index < $zip->numFiles; $index++) {
+                $stat = $zip->statIndex($index);
+                if (!is_array($stat) || !isset($stat['name'])) {
+                    throw new DwemerPluginPackageException('Package contains an unreadable entry.');
+                }
+                $name = self::normalizeArchivePath((string)$stat['name']);
+                $isDirectory = str_ends_with((string)$stat['name'], '/');
+                $totalBytes += (int)($stat['size'] ?? 0);
+                if ($totalBytes > self::MAX_UNCOMPRESSED_BYTES) {
+                    throw new DwemerPluginPackageException('Package exceeds the uncompressed size limit.');
+                }
+                if ($this->zipEntryIsSymlink($zip, $index)) {
+                    throw new DwemerPluginPackageException("Package entry '{$name}' is a symbolic link.");
+                }
+                if (isset($entries[$name])) {
+                    throw new DwemerPluginPackageException("Package contains duplicate path '{$name}'.");
+                }
+                $entries[$name] = ['index' => $index, 'directory' => $isDirectory];
+            }
+
+            foreach (['manifest.json', 'checksums.sha256'] as $required) {
+                if (!isset($entries[$required]) || $entries[$required]['directory']) {
+                    throw new DwemerPluginPackageException("Package is missing {$required}.");
+                }
+            }
+
+            $manifestJson = $zip->getFromIndex($entries['manifest.json']['index']);
+            $manifest = json_decode((string)$manifestJson, true, 64, JSON_THROW_ON_ERROR);
+            $this->validateManifest($manifest, $entries);
+
+            $this->removeDirectory($stageRoot);
+            $this->ensureDirectory($stageRoot);
+            foreach ($entries as $name => $entry) {
+                $destination = $stageRoot . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $name);
+                if ($entry['directory']) {
+                    $this->ensureDirectory($destination);
+                    continue;
+                }
+                $this->ensureDirectory(dirname($destination));
+                $input = $zip->getStream((string)$zip->getNameIndex($entry['index']));
+                if (!is_resource($input)) {
+                    throw new DwemerPluginPackageException("Could not read package entry '{$name}'.");
+                }
+                $output = fopen($destination, 'wb');
+                if (!is_resource($output)) {
+                    fclose($input);
+                    throw new DwemerPluginPackageException("Could not stage package entry '{$name}'.");
+                }
+                stream_copy_to_stream($input, $output);
+                fclose($input);
+                fclose($output);
+            }
+
+            $this->verifyChecksums($stageRoot, $entries);
+            return $manifest;
+        } catch (JsonException $error) {
+            throw new DwemerPluginPackageException('manifest.json is not valid JSON.', 0, $error);
+        } finally {
+            $zip->close();
+        }
+    }
+
+    public static function normalizeArchivePath(string $path): string
+    {
+        if ($path === '' || str_contains($path, "\0") || str_contains($path, '\\')) {
+            throw new DwemerPluginPackageException('Package contains an invalid archive path.');
+        }
+        if ($path[0] === '/' || preg_match('/^[A-Za-z]:/', $path)) {
+            throw new DwemerPluginPackageException("Package path '{$path}' is absolute.");
+        }
+        $trimmed = rtrim($path, '/');
+        if ($trimmed === '') {
+            throw new DwemerPluginPackageException('Package contains an empty archive path.');
+        }
+        foreach (explode('/', $trimmed) as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                throw new DwemerPluginPackageException("Package path '{$path}' is unsafe.");
+            }
+        }
+        return $trimmed;
+    }
+
+    private function validateManifest(array $manifest, array $entries): void
+    {
+        if (($manifest['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+            throw new DwemerPluginPackageException('Unsupported package schema version.');
+        }
+        foreach (['package_id', 'name', 'version', 'components'] as $field) {
+            if (!isset($manifest[$field]) || ($field !== 'components' && trim((string)$manifest[$field]) === '')) {
+                throw new DwemerPluginPackageException("Package manifest is missing '{$field}'.");
+            }
+        }
+        if (!preg_match('/^[a-z0-9][a-z0-9._-]{1,63}$/', (string)$manifest['package_id'])) {
+            throw new DwemerPluginPackageException('package_id must be a stable lowercase identifier.');
+        }
+        if (!is_array($manifest['components']) || empty($manifest['components'])) {
+            throw new DwemerPluginPackageException('Package must contain at least one component.');
+        }
+
+        $components = $manifest['components'];
+        if (isset($components['server'])) {
+            $server = $components['server'];
+            if (!is_array($server) || !preg_match('/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/', (string)($server['install_name'] ?? ''))) {
+                throw new DwemerPluginPackageException('Server component install_name is invalid.');
+            }
+            $this->requirePayloadPrefix($entries, 'server/');
+            $this->validateMutablePaths($server['mutable_paths'] ?? []);
+        }
+
+        if (isset($components['game'])) {
+            $game = $components['game'];
+            if (!is_array($game)) {
+                throw new DwemerPluginPackageException('Game component mod_name is required.');
+            }
+            $this->validateGameModName((string)($game['mod_name'] ?? ''));
+            $variants = $game['variants'] ?? null;
+            if (!is_array($variants) || empty($variants)) {
+                throw new DwemerPluginPackageException('Game component must declare at least one variant.');
+            }
+            foreach ($variants as $variant => $prefix) {
+                if (!in_array($variant, ['skyrim-se', 'skyrim-vr'], true)) {
+                    throw new DwemerPluginPackageException("Unsupported game variant '{$variant}'.");
+                }
+                $normalizedPrefix = self::normalizeArchivePath((string)$prefix) . '/';
+                if (!str_starts_with($normalizedPrefix, 'game/')) {
+                    throw new DwemerPluginPackageException('Game payload paths must be below game/.');
+                }
+                $this->requirePayloadPrefix($entries, $normalizedPrefix);
+            }
+            $this->validateMutablePaths($game['mutable_paths'] ?? []);
+        }
+
+        foreach (array_keys($components) as $componentName) {
+            if (!in_array($componentName, ['server', 'game'], true)) {
+                throw new DwemerPluginPackageException("Unsupported component '{$componentName}'.");
+            }
+        }
+    }
+
+    private function requirePayloadPrefix(array $entries, string $prefix): void
+    {
+        foreach ($entries as $path => $entry) {
+            if (!$entry['directory'] && str_starts_with($path, $prefix)) {
+                return;
+            }
+        }
+        throw new DwemerPluginPackageException("Package payload '{$prefix}' is empty.");
+    }
+
+    private function validateMutablePaths(mixed $paths): void
+    {
+        if (!is_array($paths)) {
+            throw new DwemerPluginPackageException('mutable_paths must be an array.');
+        }
+        foreach ($paths as $path) {
+            self::normalizeArchivePath((string)$path);
+        }
+    }
+
+    private function validateGameModName(string $modName): void
+    {
+        if ($modName === '' || trim($modName) !== $modName || $modName === '.' || $modName === '..') {
+            throw new DwemerPluginPackageException('Game component mod_name is not a safe MO2 folder name.');
+        }
+        if (preg_match('/[\\x00-\\x1F\\\\\\/:*?"<>|]/', $modName) || str_ends_with($modName, '.')) {
+            throw new DwemerPluginPackageException('Game component mod_name contains invalid filename characters.');
+        }
+        $deviceName = strtoupper((string)strtok($modName, '.'));
+        if (preg_match('/^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/', $deviceName)) {
+            throw new DwemerPluginPackageException('Game component mod_name is reserved by Windows.');
+        }
+    }
+
+    private function verifyChecksums(string $stageRoot, array $entries): void
+    {
+        $checksumPath = $stageRoot . DIRECTORY_SEPARATOR . 'checksums.sha256';
+        $lines = file($checksumPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if (!is_array($lines)) {
+            throw new DwemerPluginPackageException('Could not read checksums.sha256.');
+        }
+        $expected = [];
+        foreach ($lines as $line) {
+            if (!preg_match('/^([a-fA-F0-9]{64})\s+\*?(.+)$/', trim($line), $match)) {
+                throw new DwemerPluginPackageException('checksums.sha256 contains an invalid line.');
+            }
+            $path = self::normalizeArchivePath($match[2]);
+            if ($path === 'checksums.sha256' || isset($expected[$path])) {
+                throw new DwemerPluginPackageException("Duplicate or recursive checksum entry '{$path}'.");
+            }
+            $expected[$path] = strtolower($match[1]);
+        }
+
+        foreach ($entries as $path => $entry) {
+            if ($entry['directory'] || $path === 'checksums.sha256') {
+                continue;
+            }
+            if (!isset($expected[$path])) {
+                throw new DwemerPluginPackageException("Package file '{$path}' is not covered by checksums.sha256.");
+            }
+            $filePath = $stageRoot . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $path);
+            if (!hash_equals($expected[$path], hash_file('sha256', $filePath))) {
+                throw new DwemerPluginPackageException("Checksum mismatch for '{$path}'.");
+            }
+            unset($expected[$path]);
+        }
+        if (!empty($expected)) {
+            throw new DwemerPluginPackageException("Checksum references missing file '" . array_key_first($expected) . "'.");
+        }
+    }
+
+    private function activateAndFinalize(array $job): array
+    {
+        try {
+            $serverState = !empty($job['has_server']) ? $this->activateServerComponent($job) : [];
+            $job['status'] = 'completed';
+            $job['updated_at'] = gmdate(DATE_ATOM);
+            $job['error'] = null;
+            $this->writeJob($job);
+            $this->recordInstalledPackage($job, $serverState);
+            $this->removeDirectory((string)$job['stage_root']);
+            return $job;
+        } catch (Throwable $error) {
+            $job['status'] = 'failed';
+            $job['error'] = $error->getMessage();
+            $job['updated_at'] = gmdate(DATE_ATOM);
+            $this->writeJob($job);
+            return $job;
+        }
+    }
+
+    private function activateServerComponent(array $job): array
+    {
+        $component = $job['manifest']['components']['server'];
+        $installName = (string)$component['install_name'];
+        $source = (string)$job['stage_root'] . DIRECTORY_SEPARATOR . 'server';
+        $target = $this->serverRoot . DIRECTORY_SEPARATOR . 'ext' . DIRECTORY_SEPARATOR . $installName;
+        $backup = $this->stateRoot . DIRECTORY_SEPARATOR . 'backups' . DIRECTORY_SEPARATOR . $job['id'] . DIRECTORY_SEPARATOR . $installName;
+        $failed = $this->stateRoot . DIRECTORY_SEPARATOR . 'failed' . DIRECTORY_SEPARATOR . $job['id'] . DIRECTORY_SEPARATOR . $installName;
+
+        if (!is_dir($source)) {
+            throw new DwemerPluginPackageException('Staged server component is missing.');
+        }
+        $this->ensureDirectory(dirname($target));
+        $this->ensureDirectory(dirname($backup));
+        $this->preserveMutablePaths($target, $source, $component['mutable_paths'] ?? []);
+
+        $hadPrevious = is_dir($target);
+        if ($hadPrevious && !rename($target, $backup)) {
+            throw new DwemerPluginPackageException("Could not back up existing server extension '{$installName}'.");
+        }
+
+        try {
+            if (!rename($source, $target)) {
+                throw new DwemerPluginPackageException("Could not activate server extension '{$installName}'.");
+            }
+            $this->runMigrations($target, (string)$job['package_id']);
+        } catch (Throwable $error) {
+            if (is_dir($target)) {
+                $this->ensureDirectory(dirname($failed));
+                @rename($target, $failed);
+                if (is_dir($target)) {
+                    $this->removeDirectory($target);
+                }
+            }
+            if ($hadPrevious && is_dir($backup)) {
+                @rename($backup, $target);
+            }
+            throw new DwemerPluginPackageException('Server activation rolled back: ' . $error->getMessage(), 0, $error);
+        }
+
+        return [
+            'install_name' => $installName,
+            'path' => $target,
+            'backup_path' => $hadPrevious ? $backup : null,
+            'files' => $this->buildFileLedger($target),
+        ];
+    }
+
+    private function preserveMutablePaths(string $oldRoot, string $newRoot, array $mutablePaths): void
+    {
+        if (!is_dir($oldRoot)) {
+            return;
+        }
+        foreach ($mutablePaths as $relativePath) {
+            $normalized = self::normalizeArchivePath((string)$relativePath);
+            $oldPath = $oldRoot . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $normalized);
+            $newPath = $newRoot . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $normalized);
+            if (is_file($oldPath)) {
+                $this->ensureDirectory(dirname($newPath));
+                if (!copy($oldPath, $newPath)) {
+                    throw new DwemerPluginPackageException("Could not preserve mutable file '{$normalized}'.");
+                }
+            } elseif (is_dir($oldPath)) {
+                $this->copyDirectory($oldPath, $newPath);
+            }
+        }
+    }
+
+    private function runMigrations(string $targetDir, string $packageId): void
+    {
+        $migrations = glob($targetDir . DIRECTORY_SEPARATOR . 'migrations' . DIRECTORY_SEPARATOR . '*.sql') ?: [];
+        sort($migrations, SORT_STRING);
+        if (empty($migrations)) {
+            return;
+        }
+        if (is_callable($this->migrationRunner)) {
+            ($this->migrationRunner)($targetDir, $packageId, $migrations);
+            return;
+        }
+        if (!function_exists('pg_connect')) {
+            throw new DwemerPluginPackageException('PostgreSQL support is required to run plugin migrations.');
+        }
+
+        $connection = @pg_connect('host=localhost port=5432 dbname=dwemer user=dwemer password=dwemer');
+        if (!$connection) {
+            throw new DwemerPluginPackageException('Could not connect to PostgreSQL for plugin migrations.');
+        }
+        try {
+            if (!pg_query($connection, 'BEGIN')) {
+                throw new DwemerPluginPackageException('Could not start plugin migration transaction.');
+            }
+            $setupSql = 'CREATE SCHEMA IF NOT EXISTS plugins; CREATE TABLE IF NOT EXISTS plugins.plugin_migrations (plugin_name VARCHAR(255), migration_name VARCHAR(255), executed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (plugin_name, migration_name));';
+            if (!pg_query($connection, $setupSql)) {
+                throw new DwemerPluginPackageException('Could not initialize plugin migration tracking.');
+            }
+            foreach ($migrations as $migrationPath) {
+                $migrationName = basename($migrationPath);
+                $existing = pg_query_params($connection, 'SELECT 1 FROM plugins.plugin_migrations WHERE plugin_name = $1 AND migration_name = $2', [$packageId, $migrationName]);
+                if ($existing && pg_num_rows($existing) > 0) {
+                    continue;
+                }
+                $sql = file_get_contents($migrationPath);
+                if ($sql === false || !pg_query($connection, $sql)) {
+                    throw new DwemerPluginPackageException("Migration '{$migrationName}' failed: " . pg_last_error($connection));
+                }
+                if (!pg_query_params($connection, 'INSERT INTO plugins.plugin_migrations (plugin_name, migration_name) VALUES ($1, $2)', [$packageId, $migrationName])) {
+                    throw new DwemerPluginPackageException("Could not record migration '{$migrationName}'.");
+                }
+            }
+            if (!pg_query($connection, 'COMMIT')) {
+                throw new DwemerPluginPackageException('Could not commit plugin migrations.');
+            }
+        } catch (Throwable $error) {
+            @pg_query($connection, 'ROLLBACK');
+            throw $error;
+        } finally {
+            pg_close($connection);
+        }
+    }
+
+    private function recordInstalledPackage(array $job, array $serverState): void
+    {
+        $state = [
+            'package_id' => $job['package_id'],
+            'name' => $job['package_name'],
+            'version' => $job['version'],
+            'installed_at' => gmdate(DATE_ATOM),
+            'job_id' => $job['id'],
+            'server' => $serverState,
+            'game' => $job['game_result'] ?? null,
+            'manifest' => $job['manifest'],
+        ];
+        $path = $this->stateRoot . DIRECTORY_SEPARATOR . 'packages' . DIRECTORY_SEPARATOR . $job['package_id'] . '.json';
+        $this->atomicWrite($path, json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
+    }
+
+    private function buildFileLedger(string $root): array
+    {
+        $ledger = [];
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS));
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+            $relative = str_replace(DIRECTORY_SEPARATOR, '/', substr($file->getPathname(), strlen($root) + 1));
+            $ledger[$relative] = hash_file('sha256', $file->getPathname());
+        }
+        ksort($ledger, SORT_STRING);
+        return $ledger;
+    }
+
+    private function publicJob(array $job, bool $includeClaim = false): array
+    {
+        $public = [
+            'id' => $job['id'],
+            'status' => $job['status'],
+            'package_id' => $job['package_id'],
+            'package_name' => $job['package_name'],
+            'version' => $job['version'],
+            'has_game' => (bool)$job['has_game'],
+            'has_server' => (bool)$job['has_server'],
+            'game' => $job['manifest']['components']['game'] ?? null,
+            'created_at' => $job['created_at'],
+            'updated_at' => $job['updated_at'],
+            'error' => $job['error'] ?? null,
+            'game_result' => $job['game_result'] ?? null,
+            'game_rollback' => $job['game_rollback'] ?? null,
+        ];
+        if ($includeClaim && isset($job['claim_token'])) {
+            $public['claim_token'] = $job['claim_token'];
+        }
+        return $public;
+    }
+
+    private function withLockedJob(string $jobId, callable $callback, bool $includeClaim = false): array
+    {
+        $path = $this->jobPath($jobId);
+        if (!is_file($path)) {
+            throw new DwemerPluginPackageException('Package job was not found.');
+        }
+        $handle = fopen($path, 'c+');
+        if (!is_resource($handle) || !flock($handle, LOCK_EX)) {
+            throw new DwemerPluginPackageException('Could not lock package job.');
+        }
+        try {
+            rewind($handle);
+            $contents = stream_get_contents($handle);
+            $job = json_decode((string)$contents, true, 64, JSON_THROW_ON_ERROR);
+            $job = $callback($job);
+            rewind($handle);
+            ftruncate($handle, 0);
+            fwrite($handle, json_encode($job, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
+            fflush($handle);
+            return $includeClaim ? $this->publicJob($job, true) : $job;
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    private function writeJob(array $job): void
+    {
+        $this->atomicWrite($this->jobPath((string)$job['id']), json_encode($job, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
+    }
+
+    private function readJob(string $jobId): array
+    {
+        $path = $this->jobPath($jobId);
+        if (!is_file($path)) {
+            throw new DwemerPluginPackageException('Package job was not found.');
+        }
+        return $this->readJsonFile($path);
+    }
+
+    private function jobPath(string $jobId): string
+    {
+        if (!preg_match('/^[a-f0-9]{32}$/', $jobId)) {
+            throw new DwemerPluginPackageException('Package job ID is invalid.');
+        }
+        return $this->stateRoot . DIRECTORY_SEPARATOR . 'jobs' . DIRECTORY_SEPARATOR . $jobId . '.json';
+    }
+
+    private function readJsonFile(string $path): array
+    {
+        $contents = @file_get_contents($path);
+        if ($contents === false) {
+            throw new DwemerPluginPackageException('Could not read package state.');
+        }
+        try {
+            $decoded = json_decode($contents, true, 64, JSON_THROW_ON_ERROR);
+        } catch (JsonException $error) {
+            throw new DwemerPluginPackageException('Package state is corrupted.', 0, $error);
+        }
+        if (!is_array($decoded)) {
+            throw new DwemerPluginPackageException('Package state is invalid.');
+        }
+        return $decoded;
+    }
+
+    private function zipEntryIsSymlink(ZipArchive $zip, int $index): bool
+    {
+        $opsys = 0;
+        $attributes = 0;
+        if (!$zip->getExternalAttributesIndex($index, $opsys, $attributes) || $opsys !== ZipArchive::OPSYS_UNIX) {
+            return false;
+        }
+        return (($attributes >> 16) & 0170000) === 0120000;
+    }
+
+    private function ensureStateDirectories(): void
+    {
+        foreach (['archives', 'backups', 'failed', 'jobs', 'packages', 'staging', 'uploads'] as $directory) {
+            $this->ensureDirectory($this->stateRoot . DIRECTORY_SEPARATOR . $directory);
+        }
+    }
+
+    private function uploadMetadataPath(string $uploadId): string
+    {
+        if (!preg_match('/^[a-f0-9]{32}$/', $uploadId)) {
+            throw new DwemerPluginPackageException('Chunked upload ID is invalid.');
+        }
+        return $this->stateRoot . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . $uploadId . '.json';
+    }
+
+    private function uploadPartPath(string $uploadId): string
+    {
+        $this->uploadMetadataPath($uploadId);
+        return $this->stateRoot . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . $uploadId . '.part';
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        if (!is_dir($path) && !mkdir($path, 0770, true) && !is_dir($path)) {
+            throw new DwemerPluginPackageException("Could not create directory '{$path}'.");
+        }
+    }
+
+    private function atomicWrite(string $path, string $contents, int $mode = 0660): void
+    {
+        $this->ensureDirectory(dirname($path));
+        $temporary = $path . '.tmp-' . bin2hex(random_bytes(6));
+        if (file_put_contents($temporary, $contents, LOCK_EX) === false) {
+            throw new DwemerPluginPackageException("Could not write '{$path}'.");
+        }
+        @chmod($temporary, $mode);
+        if (!rename($temporary, $path)) {
+            @unlink($temporary);
+            throw new DwemerPluginPackageException("Could not publish '{$path}'.");
+        }
+    }
+
+    private function copyDirectory(string $source, string $destination): void
+    {
+        $this->ensureDirectory($destination);
+        foreach (new DirectoryIterator($source) as $entry) {
+            if ($entry->isDot()) {
+                continue;
+            }
+            $target = $destination . DIRECTORY_SEPARATOR . $entry->getFilename();
+            if ($entry->isDir() && !$entry->isLink()) {
+                $this->copyDirectory($entry->getPathname(), $target);
+            } elseif ($entry->isFile()) {
+                $this->ensureDirectory(dirname($target));
+                if (!copy($entry->getPathname(), $target)) {
+                    throw new DwemerPluginPackageException("Could not preserve '{$entry->getFilename()}'.");
+                }
+            }
+        }
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($iterator as $entry) {
+            if ($entry->isDir() && !$entry->isLink()) {
+                @rmdir($entry->getPathname());
+            } else {
+                @unlink($entry->getPathname());
+            }
+        }
+        @rmdir($path);
+    }
+}

--- a/lib/plugin_package_manager.php
+++ b/lib/plugin_package_manager.php
@@ -8,6 +8,8 @@ final class DwemerPluginPackageException extends RuntimeException
 
 final class DwemerPluginPackageManager
 {
+    private const SUPPORTED_ARCHIVE_EXTENSIONS = ['dwpkg', 'zip'];
+
     public const SCHEMA_VERSION = 4;
     public const MAX_ENTRIES = 5000;
     public const MAX_UNCOMPRESSED_BYTES = 1073741824;
@@ -131,8 +133,9 @@ final class DwemerPluginPackageManager
     ): array {
         $this->validatePluginName($name);
         $this->validateVersion($version);
-        if (strtolower(pathinfo($originalName, PATHINFO_EXTENSION)) !== 'dwpkg') {
-            throw new DwemerPluginPackageException('Server plugin packages must use the .dwpkg extension.');
+        $extension = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
+        if (!in_array($extension, self::SUPPORTED_ARCHIVE_EXTENSIONS, true)) {
+            throw new DwemerPluginPackageException('Server plugin packages must use the .dwpkg or .zip extension.');
         }
         if ($size < 1 || $size > self::MAX_ARCHIVE_BYTES) {
             throw new DwemerPluginPackageException('Package archive size is invalid or exceeds 512 MB.');

--- a/lib/plugin_package_manager.php
+++ b/lib/plugin_package_manager.php
@@ -8,7 +8,7 @@ final class DwemerPluginPackageException extends RuntimeException
 
 final class DwemerPluginPackageManager
 {
-    public const SCHEMA_VERSION = 3;
+    public const SCHEMA_VERSION = 4;
     public const MAX_ENTRIES = 5000;
     public const MAX_UNCOMPRESSED_BYTES = 1073741824;
     public const MAX_ARCHIVE_BYTES = 536870912;
@@ -21,38 +21,65 @@ final class DwemerPluginPackageManager
     public function __construct(?string $serverRoot = null, ?string $stateRoot = null, ?callable $migrationRunner = null)
     {
         $this->serverRoot = rtrim($serverRoot ?? dirname(__DIR__), DIRECTORY_SEPARATOR);
-        $this->stateRoot = rtrim($stateRoot ?? ($this->serverRoot . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'plugin_packages'), DIRECTORY_SEPARATOR);
+        $this->stateRoot = rtrim(
+            $stateRoot ?? ($this->serverRoot . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'plugin_packages'),
+            DIRECTORY_SEPARATOR
+        );
         $this->migrationRunner = $migrationRunner;
         $this->ensureStateDirectories();
     }
 
-    public function getBrokerToken(): string
+    public function probe(string $name, string $version): array
     {
-        $path = $this->stateRoot . DIRECTORY_SEPARATOR . 'broker_token';
-        if (is_file($path)) {
-            $token = trim((string)file_get_contents($path));
-            if (preg_match('/^[a-f0-9]{64}$/', $token)) {
-                return $token;
+        $this->validatePluginName($name);
+        $this->validateVersion($version);
+        $installed = $this->installedPackage($name);
+        $current = is_array($installed) && hash_equals($this->canonicalName((string)$installed['name']), $this->canonicalName($name));
+        $sameVersion = $current && hash_equals((string)$installed['version'], $version);
+
+        return [
+            'name' => $name,
+            'requested_version' => $version,
+            'installed_version' => $current ? (string)$installed['version'] : null,
+            'upload_required' => !$sameVersion,
+            'reason' => $sameVersion ? 'current' : ($current ? 'version_changed' : 'not_installed'),
+        ];
+    }
+
+    public function installedPackages(): array
+    {
+        $packages = [];
+        foreach (glob($this->stateRoot . DIRECTORY_SEPARATOR . 'packages' . DIRECTORY_SEPARATOR . '*.json') ?: [] as $path) {
+            try {
+                $package = $this->readJsonFile($path);
+                if (($package['manifest']['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
+                    continue;
+                }
+                $this->validatePluginName((string)($package['name'] ?? ''));
+                $this->validateVersion((string)($package['version'] ?? ''));
+                $packages[] = $package;
+            } catch (Throwable) {
+                continue;
             }
         }
-
-        $token = bin2hex(random_bytes(32));
-        $this->atomicWrite($path, $token . PHP_EOL, 0600);
-        return $token;
+        usort($packages, static fn(array $left, array $right): int => strcasecmp((string)$left['name'], (string)$right['name']));
+        return $packages;
     }
 
-    public function authenticateBrokerToken(?string $token): bool
-    {
-        return is_string($token) && $token !== '' && hash_equals($this->getBrokerToken(), trim($token));
-    }
-
-    public function queueArchive(string $sourceArchive, ?string $originalName = null): array
-    {
+    public function installArchive(
+        string $sourceArchive,
+        ?string $originalName = null,
+        ?string $expectedName = null,
+        ?string $expectedVersion = null
+    ): array {
         if (!is_file($sourceArchive) || !is_readable($sourceArchive)) {
             throw new DwemerPluginPackageException('Package archive is missing or unreadable.');
         }
         if (!class_exists(ZipArchive::class)) {
-            throw new DwemerPluginPackageException('PHP ZipArchive support is required for unified plugin packages.');
+            throw new DwemerPluginPackageException('PHP ZipArchive support is required for server plugin packages.');
+        }
+        if (filesize($sourceArchive) > self::MAX_ARCHIVE_BYTES) {
+            throw new DwemerPluginPackageException('Package archive exceeds 512 MB.');
         }
 
         $jobId = bin2hex(random_bytes(16));
@@ -63,34 +90,31 @@ final class DwemerPluginPackageManager
             if (!copy($sourceArchive, $archivePath)) {
                 throw new DwemerPluginPackageException('Could not copy the package into server staging.');
             }
-
             $manifest = $this->validateAndExtractArchive($archivePath, $stageRoot);
-            $hasGame = isset($manifest['components']['game']);
-            $hasServer = isset($manifest['components']['server']);
+            if ($expectedName !== null && $this->canonicalName($manifest['name']) !== $this->canonicalName($expectedName)) {
+                throw new DwemerPluginPackageException('Uploaded package name does not match its game-side plugin folder.');
+            }
+            if ($expectedVersion !== null && !hash_equals((string)$manifest['version'], $expectedVersion)) {
+                throw new DwemerPluginPackageException('Uploaded package version does not match its game-side filename.');
+            }
+
             $now = gmdate(DATE_ATOM);
             $job = [
                 'id' => $jobId,
-                'status' => $hasGame ? 'awaiting_launcher' : 'activating_server',
-                'package_id' => $manifest['package_id'],
-                'package_name' => $manifest['name'],
-                'version' => $manifest['version'],
+                'status' => 'activating_server',
+                'name' => (string)$manifest['name'],
+                'version' => (string)$manifest['version'],
                 'original_name' => $originalName ?? basename($sourceArchive),
                 'archive_path' => $archivePath,
+                'archive_sha256' => hash_file('sha256', $archivePath),
                 'stage_root' => $stageRoot,
                 'manifest' => $manifest,
-                'has_game' => $hasGame,
-                'has_server' => $hasServer,
                 'created_at' => $now,
                 'updated_at' => $now,
                 'error' => null,
             ];
             $this->writeJob($job);
-
-            if (!$hasGame) {
-                $job = $this->activateAndFinalize($job);
-            }
-
-            return $this->publicJob($job);
+            return $this->activateAndFinalize($job);
         } catch (Throwable $error) {
             $this->removeDirectory($stageRoot);
             @unlink($archivePath);
@@ -98,20 +122,30 @@ final class DwemerPluginPackageManager
         }
     }
 
-    public function startChunkedUpload(string $originalName, int $size, int $totalChunks): array
-    {
+    public function startChunkedUpload(
+        string $name,
+        string $version,
+        string $originalName,
+        int $size,
+        int $totalChunks
+    ): array {
+        $this->validatePluginName($name);
+        $this->validateVersion($version);
         if (strtolower(pathinfo($originalName, PATHINFO_EXTENSION)) !== 'dwpkg') {
-            throw new DwemerPluginPackageException('Unified plugin packages must use the .dwpkg extension.');
+            throw new DwemerPluginPackageException('Server plugin packages must use the .dwpkg extension.');
         }
         if ($size < 1 || $size > self::MAX_ARCHIVE_BYTES) {
             throw new DwemerPluginPackageException('Package archive size is invalid or exceeds 512 MB.');
         }
-        if ($totalChunks < 1 || $totalChunks > 1024) {
+        if ($totalChunks < 1 || $totalChunks > 4096) {
             throw new DwemerPluginPackageException('Package upload chunk count is invalid.');
         }
+
         $uploadId = bin2hex(random_bytes(16));
         $metadata = [
             'id' => $uploadId,
+            'name' => $name,
+            'version' => $version,
             'original_name' => basename($originalName),
             'size' => $size,
             'total_chunks' => $totalChunks,
@@ -119,13 +153,17 @@ final class DwemerPluginPackageManager
             'received_bytes' => 0,
             'created_at' => gmdate(DATE_ATOM),
         ];
-        $this->atomicWrite($this->uploadMetadataPath($uploadId), json_encode($metadata, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR) . PHP_EOL);
+        $this->atomicWrite(
+            $this->uploadMetadataPath($uploadId),
+            json_encode($metadata, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL
+        );
         return ['upload_id' => $uploadId, 'next_index' => 0];
     }
 
     public function appendUploadChunk(string $uploadId, int $index, string $data): array
     {
-        if (strlen($data) < 1 || strlen($data) > self::MAX_UPLOAD_CHUNK_BYTES) {
+        $length = strlen($data);
+        if ($length < 1 || $length > self::MAX_UPLOAD_CHUNK_BYTES) {
             throw new DwemerPluginPackageException('Upload chunk is empty or exceeds the chunk size limit.');
         }
         $metadataPath = $this->uploadMetadataPath($uploadId);
@@ -136,6 +174,7 @@ final class DwemerPluginPackageManager
         if (!is_resource($handle) || !flock($handle, LOCK_EX)) {
             throw new DwemerPluginPackageException('Could not lock chunked upload.');
         }
+
         $complete = false;
         try {
             rewind($handle);
@@ -143,23 +182,22 @@ final class DwemerPluginPackageManager
             if ($index !== (int)$metadata['next_index']) {
                 throw new DwemerPluginPackageException('Upload chunks must arrive once and in order.');
             }
-            $receivedBytes = (int)$metadata['received_bytes'] + strlen($data);
-            if ($receivedBytes > (int)$metadata['size']) {
+            $received = (int)$metadata['received_bytes'] + $length;
+            if ($received > (int)$metadata['size']) {
                 throw new DwemerPluginPackageException('Upload exceeds its declared archive size.');
             }
-            $partPath = $this->uploadPartPath($uploadId);
-            if (file_put_contents($partPath, $data, FILE_APPEND | LOCK_EX) === false) {
+            if (file_put_contents($this->uploadPartPath($uploadId), $data, FILE_APPEND | LOCK_EX) === false) {
                 throw new DwemerPluginPackageException('Could not write upload chunk.');
             }
-            $metadata['received_bytes'] = $receivedBytes;
+            $metadata['received_bytes'] = $received;
             $metadata['next_index'] = $index + 1;
             $complete = $metadata['next_index'] === (int)$metadata['total_chunks'];
-            if ($complete && $receivedBytes !== (int)$metadata['size']) {
+            if ($complete && $received !== (int)$metadata['size']) {
                 throw new DwemerPluginPackageException('Completed upload size does not match the declared archive size.');
             }
             rewind($handle);
             ftruncate($handle, 0);
-            fwrite($handle, json_encode($metadata, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR) . PHP_EOL);
+            fwrite($handle, json_encode($metadata, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
             fflush($handle);
         } finally {
             flock($handle, LOCK_UN);
@@ -172,7 +210,12 @@ final class DwemerPluginPackageManager
 
         try {
             $metadata = $this->readJsonFile($metadataPath);
-            $job = $this->queueArchive($this->uploadPartPath($uploadId), (string)$metadata['original_name']);
+            $job = $this->installArchive(
+                $this->uploadPartPath($uploadId),
+                (string)$metadata['original_name'],
+                (string)$metadata['name'],
+                (string)$metadata['version']
+            );
             return ['complete' => true, 'job' => $job];
         } finally {
             @unlink($metadataPath);
@@ -185,106 +228,10 @@ final class DwemerPluginPackageManager
         return $this->publicJob($this->readJob($jobId));
     }
 
-    public function pendingJobs(): array
-    {
-        $jobs = [];
-        foreach (glob($this->stateRoot . DIRECTORY_SEPARATOR . 'jobs' . DIRECTORY_SEPARATOR . '*.json') ?: [] as $jobPath) {
-            $job = $this->readJsonFile($jobPath);
-            if (($job['status'] ?? '') === 'installing_game' && isset($job['claimed_at'])) {
-                $claimedAt = strtotime((string)$job['claimed_at']);
-                if ($claimedAt !== false && $claimedAt < time() - 600) {
-                    $job = $this->withLockedJob((string)$job['id'], static function (array $lockedJob): array {
-                        if (($lockedJob['status'] ?? '') === 'installing_game') {
-                            $lockedJob['status'] = 'awaiting_launcher';
-                            $lockedJob['updated_at'] = gmdate(DATE_ATOM);
-                            unset($lockedJob['claim_token'], $lockedJob['claimed_at']);
-                        }
-                        return $lockedJob;
-                    });
-                }
-            }
-            if (($job['status'] ?? '') !== 'awaiting_launcher') {
-                continue;
-            }
-            $jobs[] = $this->publicJob($job);
-        }
-        usort($jobs, static fn(array $left, array $right): int => strcmp((string)$left['created_at'], (string)$right['created_at']));
-        return $jobs;
-    }
-
-    public function claimJob(string $jobId): array
-    {
-        return $this->withLockedJob($jobId, function (array $job): array {
-            if (($job['status'] ?? '') !== 'awaiting_launcher') {
-                throw new DwemerPluginPackageException('Package job is not available for launcher installation.');
-            }
-            $job['status'] = 'installing_game';
-            $job['claim_token'] = bin2hex(random_bytes(24));
-            $job['claimed_at'] = gmdate(DATE_ATOM);
-            $job['updated_at'] = $job['claimed_at'];
-            return $job;
-        }, true);
-    }
-
-    public function completeGameInstall(string $jobId, string $claimToken, bool $success, array $result = []): array
-    {
-        $job = $this->withLockedJob($jobId, function (array $job) use ($claimToken, $success, $result): array {
-            if (($job['status'] ?? '') !== 'installing_game') {
-                throw new DwemerPluginPackageException('Package job is not awaiting a launcher result.');
-            }
-            if (!isset($job['claim_token']) || !hash_equals((string)$job['claim_token'], $claimToken)) {
-                throw new DwemerPluginPackageException('Package claim token is invalid.');
-            }
-            unset($job['claim_token']);
-            $job['game_result'] = $result;
-            $job['updated_at'] = gmdate(DATE_ATOM);
-            if (!$success) {
-                $job['status'] = 'failed';
-                $job['error'] = (string)($result['error'] ?? 'The launcher could not install the game component.');
-                return $job;
-            }
-            $job['status'] = !empty($job['has_server']) ? 'activating_server' : 'completed';
-            return $job;
-        });
-
-        if (($job['status'] ?? '') === 'activating_server') {
-            $job = $this->activateAndFinalize($job);
-        } elseif (($job['status'] ?? '') === 'completed') {
-            $this->recordInstalledPackage($job, []);
-            $this->removeDirectory((string)$job['stage_root']);
-        }
-
-        return $this->publicJob($job);
-    }
-
-    public function archivePathForJob(string $jobId): string
-    {
-        $job = $this->readJob($jobId);
-        $path = (string)($job['archive_path'] ?? '');
-        if ($path === '' || !is_file($path)) {
-            throw new DwemerPluginPackageException('Package archive is no longer available.');
-        }
-        return $path;
-    }
-
-    public function recordGameRollback(string $jobId, array $result): array
-    {
-        $job = $this->withLockedJob($jobId, static function (array $job) use ($result): array {
-            if (($job['status'] ?? '') !== 'failed') {
-                throw new DwemerPluginPackageException('Only failed package jobs can record a game rollback.');
-            }
-            $job['game_rollback'] = $result;
-            $job['updated_at'] = gmdate(DATE_ATOM);
-            return $job;
-        });
-        return $this->publicJob($job);
-    }
-
     public function validateAndExtractArchive(string $archivePath, string $stageRoot): array
     {
         $zip = new ZipArchive();
-        $openResult = $zip->open($archivePath);
-        if ($openResult !== true) {
+        if ($zip->open($archivePath) !== true) {
             throw new DwemerPluginPackageException('Package is not a readable ZIP archive.');
         }
 
@@ -292,7 +239,6 @@ final class DwemerPluginPackageManager
             if ($zip->numFiles < 3 || $zip->numFiles > self::MAX_ENTRIES) {
                 throw new DwemerPluginPackageException('Package has an invalid number of entries.');
             }
-
             $totalBytes = 0;
             $entries = [];
             for ($index = 0; $index < $zip->numFiles; $index++) {
@@ -301,7 +247,7 @@ final class DwemerPluginPackageManager
                     throw new DwemerPluginPackageException('Package contains an unreadable entry.');
                 }
                 $name = self::normalizeArchivePath((string)$stat['name']);
-                $isDirectory = str_ends_with((string)$stat['name'], '/');
+                $directory = str_ends_with((string)$stat['name'], '/');
                 $totalBytes += (int)($stat['size'] ?? 0);
                 if ($totalBytes > self::MAX_UNCOMPRESSED_BYTES) {
                     throw new DwemerPluginPackageException('Package exceeds the uncompressed size limit.');
@@ -312,19 +258,19 @@ final class DwemerPluginPackageManager
                 if (isset($entries[$name])) {
                     throw new DwemerPluginPackageException("Package contains duplicate path '{$name}'.");
                 }
-                $entries[$name] = ['index' => $index, 'directory' => $isDirectory];
+                $entries[$name] = ['index' => $index, 'directory' => $directory];
             }
-
             foreach (['manifest.json', 'checksums.sha256'] as $required) {
                 if (!isset($entries[$required]) || $entries[$required]['directory']) {
                     throw new DwemerPluginPackageException("Package is missing {$required}.");
                 }
             }
 
-            $manifestJson = $zip->getFromIndex($entries['manifest.json']['index']);
-            $manifest = json_decode((string)$manifestJson, true, 64, JSON_THROW_ON_ERROR);
+            $manifest = json_decode((string)$zip->getFromIndex($entries['manifest.json']['index']), true, 64, JSON_THROW_ON_ERROR);
+            if (!is_array($manifest)) {
+                throw new DwemerPluginPackageException('manifest.json must contain an object.');
+            }
             $this->validateManifest($manifest, $entries);
-
             $this->removeDirectory($stageRoot);
             $this->ensureDirectory($stageRoot);
             foreach ($entries as $name => $entry) {
@@ -335,19 +281,16 @@ final class DwemerPluginPackageManager
                 }
                 $this->ensureDirectory(dirname($destination));
                 $input = $zip->getStream((string)$zip->getNameIndex($entry['index']));
-                if (!is_resource($input)) {
-                    throw new DwemerPluginPackageException("Could not read package entry '{$name}'.");
-                }
                 $output = fopen($destination, 'wb');
-                if (!is_resource($output)) {
-                    fclose($input);
+                if (!is_resource($input) || !is_resource($output)) {
+                    if (is_resource($input)) fclose($input);
+                    if (is_resource($output)) fclose($output);
                     throw new DwemerPluginPackageException("Could not stage package entry '{$name}'.");
                 }
                 stream_copy_to_stream($input, $output);
                 fclose($input);
                 fclose($output);
             }
-
             $this->verifyChecksums($stageRoot, $entries);
             return $manifest;
         } catch (JsonException $error) {
@@ -382,55 +325,52 @@ final class DwemerPluginPackageManager
         if (($manifest['schema_version'] ?? null) !== self::SCHEMA_VERSION) {
             throw new DwemerPluginPackageException('Unsupported package schema version.');
         }
-        foreach (['package_id', 'name', 'version', 'components'] as $field) {
-            if (!isset($manifest[$field]) || ($field !== 'components' && trim((string)$manifest[$field]) === '')) {
+        foreach (['name', 'version', 'server'] as $field) {
+            if (!array_key_exists($field, $manifest)) {
                 throw new DwemerPluginPackageException("Package manifest is missing '{$field}'.");
             }
         }
-        if (!preg_match('/^[a-z0-9][a-z0-9._-]{1,63}$/', (string)$manifest['package_id'])) {
-            throw new DwemerPluginPackageException('package_id must be a stable lowercase identifier.');
+        $this->validatePluginName((string)$manifest['name']);
+        $this->validateVersion((string)$manifest['version']);
+        if (!is_array($manifest['server'])) {
+            throw new DwemerPluginPackageException('Package server settings must be an object.');
         }
-        if (!is_array($manifest['components']) || empty($manifest['components'])) {
-            throw new DwemerPluginPackageException('Package must contain at least one component.');
+        $this->validateMutablePaths($manifest['server']['mutable_paths'] ?? []);
+        $this->requirePayloadPrefix($entries, 'server/');
+        foreach ($entries as $path => $entry) {
+            if ($entry['directory'] || in_array($path, ['manifest.json', 'checksums.sha256'], true)) {
+                continue;
+            }
+            if (!str_starts_with($path, 'server/')) {
+                throw new DwemerPluginPackageException("Unsupported package payload '{$path}'.");
+            }
         }
+    }
 
-        $components = $manifest['components'];
-        if (isset($components['server'])) {
-            $server = $components['server'];
-            if (!is_array($server) || !preg_match('/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/', (string)($server['install_name'] ?? ''))) {
-                throw new DwemerPluginPackageException('Server component install_name is invalid.');
-            }
-            $this->requirePayloadPrefix($entries, 'server/');
-            $this->validateMutablePaths($server['mutable_paths'] ?? []);
+    private function validatePluginName(string $name): void
+    {
+        if (strlen($name) > 64 || trim($name) !== $name || !preg_match('/^[A-Za-z0-9][A-Za-z0-9 ._-]{0,63}$/', $name)) {
+            throw new DwemerPluginPackageException('Plugin name contains unsupported characters.');
         }
-
-        if (isset($components['game'])) {
-            $game = $components['game'];
-            if (!is_array($game)) {
-                throw new DwemerPluginPackageException('Game component mod_name is required.');
-            }
-            $this->validateGameModName((string)($game['mod_name'] ?? ''));
-            $variants = $game['variants'] ?? null;
-            if (!is_array($variants) || empty($variants)) {
-                throw new DwemerPluginPackageException('Game component must declare at least one variant.');
-            }
-            foreach ($variants as $variant => $prefix) {
-                if (!in_array($variant, ['skyrim-se', 'skyrim-vr'], true)) {
-                    throw new DwemerPluginPackageException("Unsupported game variant '{$variant}'.");
-                }
-                $normalizedPrefix = self::normalizeArchivePath((string)$prefix) . '/';
-                if (!str_starts_with($normalizedPrefix, 'game/')) {
-                    throw new DwemerPluginPackageException('Game payload paths must be below game/.');
-                }
-                $this->requirePayloadPrefix($entries, $normalizedPrefix);
-            }
-            $this->validateMutablePaths($game['mutable_paths'] ?? []);
+        if (str_ends_with($name, '.') || str_ends_with($name, ' ')) {
+            throw new DwemerPluginPackageException('Plugin name cannot end with a dot or space.');
         }
+    }
 
-        foreach (array_keys($components) as $componentName) {
-            if (!in_array($componentName, ['server', 'game'], true)) {
-                throw new DwemerPluginPackageException("Unsupported component '{$componentName}'.");
-            }
+    private function validateVersion(string $version): void
+    {
+        if (!preg_match('/^[0-9A-Za-z][0-9A-Za-z._+-]{0,63}$/', $version)) {
+            throw new DwemerPluginPackageException('Plugin version contains unsupported characters.');
+        }
+    }
+
+    private function validateMutablePaths(mixed $paths): void
+    {
+        if (!is_array($paths)) {
+            throw new DwemerPluginPackageException('mutable_paths must be an array.');
+        }
+        foreach ($paths as $path) {
+            self::normalizeArchivePath((string)$path);
         }
     }
 
@@ -444,34 +384,9 @@ final class DwemerPluginPackageManager
         throw new DwemerPluginPackageException("Package payload '{$prefix}' is empty.");
     }
 
-    private function validateMutablePaths(mixed $paths): void
-    {
-        if (!is_array($paths)) {
-            throw new DwemerPluginPackageException('mutable_paths must be an array.');
-        }
-        foreach ($paths as $path) {
-            self::normalizeArchivePath((string)$path);
-        }
-    }
-
-    private function validateGameModName(string $modName): void
-    {
-        if ($modName === '' || trim($modName) !== $modName || $modName === '.' || $modName === '..') {
-            throw new DwemerPluginPackageException('Game component mod_name is not a safe MO2 folder name.');
-        }
-        if (preg_match('/[\\x00-\\x1F\\\\\\/:*?"<>|]/', $modName) || str_ends_with($modName, '.')) {
-            throw new DwemerPluginPackageException('Game component mod_name contains invalid filename characters.');
-        }
-        $deviceName = strtoupper((string)strtok($modName, '.'));
-        if (preg_match('/^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/', $deviceName)) {
-            throw new DwemerPluginPackageException('Game component mod_name is reserved by Windows.');
-        }
-    }
-
     private function verifyChecksums(string $stageRoot, array $entries): void
     {
-        $checksumPath = $stageRoot . DIRECTORY_SEPARATOR . 'checksums.sha256';
-        $lines = file($checksumPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        $lines = file($stageRoot . DIRECTORY_SEPARATOR . 'checksums.sha256', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         if (!is_array($lines)) {
             throw new DwemerPluginPackageException('Could not read checksums.sha256.');
         }
@@ -486,11 +401,8 @@ final class DwemerPluginPackageManager
             }
             $expected[$path] = strtolower($match[1]);
         }
-
         foreach ($entries as $path => $entry) {
-            if ($entry['directory'] || $path === 'checksums.sha256') {
-                continue;
-            }
+            if ($entry['directory'] || $path === 'checksums.sha256') continue;
             if (!isset($expected[$path])) {
                 throw new DwemerPluginPackageException("Package file '{$path}' is not covered by checksums.sha256.");
             }
@@ -500,7 +412,7 @@ final class DwemerPluginPackageManager
             }
             unset($expected[$path]);
         }
-        if (!empty($expected)) {
+        if ($expected) {
             throw new DwemerPluginPackageException("Checksum references missing file '" . array_key_first($expected) . "'.");
         }
     }
@@ -508,65 +420,57 @@ final class DwemerPluginPackageManager
     private function activateAndFinalize(array $job): array
     {
         try {
-            $serverState = !empty($job['has_server']) ? $this->activateServerComponent($job) : [];
+            $serverState = $this->activateServerComponent($job);
             $job['status'] = 'completed';
             $job['updated_at'] = gmdate(DATE_ATOM);
             $job['error'] = null;
             $this->writeJob($job);
             $this->recordInstalledPackage($job, $serverState);
             $this->removeDirectory((string)$job['stage_root']);
-            return $job;
+            @unlink((string)$job['archive_path']);
+            return $this->publicJob($job);
         } catch (Throwable $error) {
             $job['status'] = 'failed';
             $job['error'] = $error->getMessage();
             $job['updated_at'] = gmdate(DATE_ATOM);
             $this->writeJob($job);
-            return $job;
+            return $this->publicJob($job);
         }
     }
 
     private function activateServerComponent(array $job): array
     {
-        $component = $job['manifest']['components']['server'];
-        $installName = (string)$component['install_name'];
+        $name = (string)$job['name'];
         $source = (string)$job['stage_root'] . DIRECTORY_SEPARATOR . 'server';
-        $target = $this->serverRoot . DIRECTORY_SEPARATOR . 'ext' . DIRECTORY_SEPARATOR . $installName;
-        $backup = $this->stateRoot . DIRECTORY_SEPARATOR . 'backups' . DIRECTORY_SEPARATOR . $job['id'] . DIRECTORY_SEPARATOR . $installName;
-        $failed = $this->stateRoot . DIRECTORY_SEPARATOR . 'failed' . DIRECTORY_SEPARATOR . $job['id'] . DIRECTORY_SEPARATOR . $installName;
-
+        $target = $this->serverRoot . DIRECTORY_SEPARATOR . 'ext' . DIRECTORY_SEPARATOR . $name;
+        $backup = $this->stateRoot . DIRECTORY_SEPARATOR . 'backups' . DIRECTORY_SEPARATOR . $job['id'] . DIRECTORY_SEPARATOR . $name;
+        $failed = $this->stateRoot . DIRECTORY_SEPARATOR . 'failed' . DIRECTORY_SEPARATOR . $job['id'] . DIRECTORY_SEPARATOR . $name;
         if (!is_dir($source)) {
-            throw new DwemerPluginPackageException('Staged server component is missing.');
+            throw new DwemerPluginPackageException('Staged server payload is missing.');
         }
         $this->ensureDirectory(dirname($target));
         $this->ensureDirectory(dirname($backup));
-        $this->preserveMutablePaths($target, $source, $component['mutable_paths'] ?? []);
-
+        $this->preserveMutablePaths($target, $source, $job['manifest']['server']['mutable_paths'] ?? []);
         $hadPrevious = is_dir($target);
         if ($hadPrevious && !rename($target, $backup)) {
-            throw new DwemerPluginPackageException("Could not back up existing server extension '{$installName}'.");
+            throw new DwemerPluginPackageException("Could not back up existing server extension '{$name}'.");
         }
-
         try {
             if (!rename($source, $target)) {
-                throw new DwemerPluginPackageException("Could not activate server extension '{$installName}'.");
+                throw new DwemerPluginPackageException("Could not activate server extension '{$name}'.");
             }
-            $this->runMigrations($target, (string)$job['package_id']);
+            $this->runMigrations($target, $name);
         } catch (Throwable $error) {
             if (is_dir($target)) {
                 $this->ensureDirectory(dirname($failed));
                 @rename($target, $failed);
-                if (is_dir($target)) {
-                    $this->removeDirectory($target);
-                }
+                if (is_dir($target)) $this->removeDirectory($target);
             }
-            if ($hadPrevious && is_dir($backup)) {
-                @rename($backup, $target);
-            }
+            if ($hadPrevious && is_dir($backup)) @rename($backup, $target);
             throw new DwemerPluginPackageException('Server activation rolled back: ' . $error->getMessage(), 0, $error);
         }
-
         return [
-            'install_name' => $installName,
+            'install_name' => $name,
             'path' => $target,
             'backup_path' => $hadPrevious ? $backup : null,
             'files' => $this->buildFileLedger($target),
@@ -575,9 +479,7 @@ final class DwemerPluginPackageManager
 
     private function preserveMutablePaths(string $oldRoot, string $newRoot, array $mutablePaths): void
     {
-        if (!is_dir($oldRoot)) {
-            return;
-        }
+        if (!is_dir($oldRoot)) return;
         foreach ($mutablePaths as $relativePath) {
             $normalized = self::normalizeArchivePath((string)$relativePath);
             $oldPath = $oldRoot . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $normalized);
@@ -593,50 +495,37 @@ final class DwemerPluginPackageManager
         }
     }
 
-    private function runMigrations(string $targetDir, string $packageId): void
+    private function runMigrations(string $targetDir, string $pluginName): void
     {
         $migrations = glob($targetDir . DIRECTORY_SEPARATOR . 'migrations' . DIRECTORY_SEPARATOR . '*.sql') ?: [];
         sort($migrations, SORT_STRING);
-        if (empty($migrations)) {
-            return;
-        }
+        if (!$migrations) return;
         if (is_callable($this->migrationRunner)) {
-            ($this->migrationRunner)($targetDir, $packageId, $migrations);
+            ($this->migrationRunner)($targetDir, $pluginName, $migrations);
             return;
         }
         if (!function_exists('pg_connect')) {
             throw new DwemerPluginPackageException('PostgreSQL support is required to run plugin migrations.');
         }
-
         $connection = @pg_connect('host=localhost port=5432 dbname=dwemer user=dwemer password=dwemer');
-        if (!$connection) {
-            throw new DwemerPluginPackageException('Could not connect to PostgreSQL for plugin migrations.');
-        }
+        if (!$connection) throw new DwemerPluginPackageException('Could not connect to PostgreSQL for plugin migrations.');
         try {
-            if (!pg_query($connection, 'BEGIN')) {
-                throw new DwemerPluginPackageException('Could not start plugin migration transaction.');
-            }
-            $setupSql = 'CREATE SCHEMA IF NOT EXISTS plugins; CREATE TABLE IF NOT EXISTS plugins.plugin_migrations (plugin_name VARCHAR(255), migration_name VARCHAR(255), executed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (plugin_name, migration_name));';
-            if (!pg_query($connection, $setupSql)) {
-                throw new DwemerPluginPackageException('Could not initialize plugin migration tracking.');
-            }
+            if (!pg_query($connection, 'BEGIN')) throw new DwemerPluginPackageException('Could not start plugin migration transaction.');
+            $setup = 'CREATE SCHEMA IF NOT EXISTS plugins; CREATE TABLE IF NOT EXISTS plugins.plugin_migrations (plugin_name VARCHAR(255), migration_name VARCHAR(255), executed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (plugin_name, migration_name));';
+            if (!pg_query($connection, $setup)) throw new DwemerPluginPackageException('Could not initialize plugin migration tracking.');
             foreach ($migrations as $migrationPath) {
                 $migrationName = basename($migrationPath);
-                $existing = pg_query_params($connection, 'SELECT 1 FROM plugins.plugin_migrations WHERE plugin_name = $1 AND migration_name = $2', [$packageId, $migrationName]);
-                if ($existing && pg_num_rows($existing) > 0) {
-                    continue;
-                }
+                $existing = pg_query_params($connection, 'SELECT 1 FROM plugins.plugin_migrations WHERE plugin_name = $1 AND migration_name = $2', [$pluginName, $migrationName]);
+                if ($existing && pg_num_rows($existing) > 0) continue;
                 $sql = file_get_contents($migrationPath);
                 if ($sql === false || !pg_query($connection, $sql)) {
                     throw new DwemerPluginPackageException("Migration '{$migrationName}' failed: " . pg_last_error($connection));
                 }
-                if (!pg_query_params($connection, 'INSERT INTO plugins.plugin_migrations (plugin_name, migration_name) VALUES ($1, $2)', [$packageId, $migrationName])) {
+                if (!pg_query_params($connection, 'INSERT INTO plugins.plugin_migrations (plugin_name, migration_name) VALUES ($1, $2)', [$pluginName, $migrationName])) {
                     throw new DwemerPluginPackageException("Could not record migration '{$migrationName}'.");
                 }
             }
-            if (!pg_query($connection, 'COMMIT')) {
-                throw new DwemerPluginPackageException('Could not commit plugin migrations.');
-            }
+            if (!pg_query($connection, 'COMMIT')) throw new DwemerPluginPackageException('Could not commit plugin migrations.');
         } catch (Throwable $error) {
             @pg_query($connection, 'ROLLBACK');
             throw $error;
@@ -648,17 +537,34 @@ final class DwemerPluginPackageManager
     private function recordInstalledPackage(array $job, array $serverState): void
     {
         $state = [
-            'package_id' => $job['package_id'],
-            'name' => $job['package_name'],
+            'name' => $job['name'],
             'version' => $job['version'],
             'installed_at' => gmdate(DATE_ATOM),
             'job_id' => $job['id'],
+            'archive_sha256' => $job['archive_sha256'],
             'server' => $serverState,
-            'game' => $job['game_result'] ?? null,
             'manifest' => $job['manifest'],
         ];
-        $path = $this->stateRoot . DIRECTORY_SEPARATOR . 'packages' . DIRECTORY_SEPARATOR . $job['package_id'] . '.json';
-        $this->atomicWrite($path, json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
+        $this->atomicWrite(
+            $this->installedPackagePath((string)$job['name']),
+            json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL
+        );
+    }
+
+    private function installedPackage(string $name): ?array
+    {
+        $path = $this->installedPackagePath($name);
+        return is_file($path) ? $this->readJsonFile($path) : null;
+    }
+
+    private function installedPackagePath(string $name): string
+    {
+        return $this->stateRoot . DIRECTORY_SEPARATOR . 'packages' . DIRECTORY_SEPARATOR . hash('sha256', $this->canonicalName($name)) . '.json';
+    }
+
+    private function canonicalName(string $name): string
+    {
+        return strtolower($name);
     }
 
     private function buildFileLedger(string $root): array
@@ -666,9 +572,7 @@ final class DwemerPluginPackageManager
         $ledger = [];
         $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS));
         foreach ($iterator as $file) {
-            if (!$file->isFile()) {
-                continue;
-            }
+            if (!$file->isFile()) continue;
             $relative = str_replace(DIRECTORY_SEPARATOR, '/', substr($file->getPathname(), strlen($root) + 1));
             $ledger[$relative] = hash_file('sha256', $file->getPathname());
         }
@@ -676,53 +580,17 @@ final class DwemerPluginPackageManager
         return $ledger;
     }
 
-    private function publicJob(array $job, bool $includeClaim = false): array
+    private function publicJob(array $job): array
     {
-        $public = [
+        return [
             'id' => $job['id'],
             'status' => $job['status'],
-            'package_id' => $job['package_id'],
-            'package_name' => $job['package_name'],
+            'name' => $job['name'],
             'version' => $job['version'],
-            'has_game' => (bool)$job['has_game'],
-            'has_server' => (bool)$job['has_server'],
-            'game' => $job['manifest']['components']['game'] ?? null,
             'created_at' => $job['created_at'],
             'updated_at' => $job['updated_at'],
             'error' => $job['error'] ?? null,
-            'game_result' => $job['game_result'] ?? null,
-            'game_rollback' => $job['game_rollback'] ?? null,
         ];
-        if ($includeClaim && isset($job['claim_token'])) {
-            $public['claim_token'] = $job['claim_token'];
-        }
-        return $public;
-    }
-
-    private function withLockedJob(string $jobId, callable $callback, bool $includeClaim = false): array
-    {
-        $path = $this->jobPath($jobId);
-        if (!is_file($path)) {
-            throw new DwemerPluginPackageException('Package job was not found.');
-        }
-        $handle = fopen($path, 'c+');
-        if (!is_resource($handle) || !flock($handle, LOCK_EX)) {
-            throw new DwemerPluginPackageException('Could not lock package job.');
-        }
-        try {
-            rewind($handle);
-            $contents = stream_get_contents($handle);
-            $job = json_decode((string)$contents, true, 64, JSON_THROW_ON_ERROR);
-            $job = $callback($job);
-            rewind($handle);
-            ftruncate($handle, 0);
-            fwrite($handle, json_encode($job, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
-            fflush($handle);
-            return $includeClaim ? $this->publicJob($job, true) : $job;
-        } finally {
-            flock($handle, LOCK_UN);
-            fclose($handle);
-        }
     }
 
     private function writeJob(array $job): void
@@ -733,34 +601,26 @@ final class DwemerPluginPackageManager
     private function readJob(string $jobId): array
     {
         $path = $this->jobPath($jobId);
-        if (!is_file($path)) {
-            throw new DwemerPluginPackageException('Package job was not found.');
-        }
+        if (!is_file($path)) throw new DwemerPluginPackageException('Package job was not found.');
         return $this->readJsonFile($path);
     }
 
     private function jobPath(string $jobId): string
     {
-        if (!preg_match('/^[a-f0-9]{32}$/', $jobId)) {
-            throw new DwemerPluginPackageException('Package job ID is invalid.');
-        }
+        if (!preg_match('/^[a-f0-9]{32}$/', $jobId)) throw new DwemerPluginPackageException('Package job ID is invalid.');
         return $this->stateRoot . DIRECTORY_SEPARATOR . 'jobs' . DIRECTORY_SEPARATOR . $jobId . '.json';
     }
 
     private function readJsonFile(string $path): array
     {
         $contents = @file_get_contents($path);
-        if ($contents === false) {
-            throw new DwemerPluginPackageException('Could not read package state.');
-        }
+        if ($contents === false) throw new DwemerPluginPackageException('Could not read package state.');
         try {
             $decoded = json_decode($contents, true, 64, JSON_THROW_ON_ERROR);
         } catch (JsonException $error) {
             throw new DwemerPluginPackageException('Package state is corrupted.', 0, $error);
         }
-        if (!is_array($decoded)) {
-            throw new DwemerPluginPackageException('Package state is invalid.');
-        }
+        if (!is_array($decoded)) throw new DwemerPluginPackageException('Package state is invalid.');
         return $decoded;
     }
 
@@ -768,9 +628,7 @@ final class DwemerPluginPackageManager
     {
         $opsys = 0;
         $attributes = 0;
-        if (!$zip->getExternalAttributesIndex($index, $opsys, $attributes) || $opsys !== ZipArchive::OPSYS_UNIX) {
-            return false;
-        }
+        if (!$zip->getExternalAttributesIndex($index, $opsys, $attributes) || $opsys !== ZipArchive::OPSYS_UNIX) return false;
         return (($attributes >> 16) & 0170000) === 0120000;
     }
 
@@ -783,9 +641,7 @@ final class DwemerPluginPackageManager
 
     private function uploadMetadataPath(string $uploadId): string
     {
-        if (!preg_match('/^[a-f0-9]{32}$/', $uploadId)) {
-            throw new DwemerPluginPackageException('Chunked upload ID is invalid.');
-        }
+        if (!preg_match('/^[a-f0-9]{32}$/', $uploadId)) throw new DwemerPluginPackageException('Chunked upload ID is invalid.');
         return $this->stateRoot . DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . $uploadId . '.json';
     }
 
@@ -806,9 +662,7 @@ final class DwemerPluginPackageManager
     {
         $this->ensureDirectory(dirname($path));
         $temporary = $path . '.tmp-' . bin2hex(random_bytes(6));
-        if (file_put_contents($temporary, $contents, LOCK_EX) === false) {
-            throw new DwemerPluginPackageException("Could not write '{$path}'.");
-        }
+        if (file_put_contents($temporary, $contents, LOCK_EX) === false) throw new DwemerPluginPackageException("Could not write '{$path}'.");
         @chmod($temporary, $mode);
         if (!rename($temporary, $path)) {
             @unlink($temporary);
@@ -820,36 +674,26 @@ final class DwemerPluginPackageManager
     {
         $this->ensureDirectory($destination);
         foreach (new DirectoryIterator($source) as $entry) {
-            if ($entry->isDot()) {
-                continue;
-            }
+            if ($entry->isDot()) continue;
             $target = $destination . DIRECTORY_SEPARATOR . $entry->getFilename();
             if ($entry->isDir() && !$entry->isLink()) {
                 $this->copyDirectory($entry->getPathname(), $target);
             } elseif ($entry->isFile()) {
                 $this->ensureDirectory(dirname($target));
-                if (!copy($entry->getPathname(), $target)) {
-                    throw new DwemerPluginPackageException("Could not preserve '{$entry->getFilename()}'.");
-                }
+                if (!copy($entry->getPathname(), $target)) throw new DwemerPluginPackageException("Could not preserve '{$entry->getFilename()}'.");
             }
         }
     }
 
     private function removeDirectory(string $path): void
     {
-        if (!is_dir($path)) {
-            return;
-        }
+        if (!is_dir($path)) return;
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
             RecursiveIteratorIterator::CHILD_FIRST
         );
         foreach ($iterator as $entry) {
-            if ($entry->isDir() && !$entry->isLink()) {
-                @rmdir($entry->getPathname());
-            } else {
-                @unlink($entry->getPathname());
-            }
+            $entry->isDir() && !$entry->isLink() ? @rmdir($entry->getPathname()) : @unlink($entry->getPathname());
         }
         @rmdir($path);
     }

--- a/ui/api/plugin_packages.php
+++ b/ui/api/plugin_packages.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/lib/plugin_package_manager.php';
+
+header('Cache-Control: no-store');
+
+function pluginPackageJson(array $payload, int $status = 200): never
+{
+    http_response_code($status);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    exit;
+}
+
+function pluginPackageInput(): array
+{
+    $input = json_decode((string)file_get_contents('php://input'), true);
+    return is_array($input) ? $input : [];
+}
+
+function pluginPackageRequireBroker(DwemerPluginPackageManager $manager): void
+{
+    $token = $_SERVER['HTTP_X_DWEMER_PLUGIN_TOKEN'] ?? null;
+    if (!$manager->authenticateBrokerToken(is_string($token) ? $token : null)) {
+        pluginPackageJson(['ok' => false, 'error' => 'Launcher authentication failed.'], 401);
+    }
+}
+
+try {
+    $manager = new DwemerPluginPackageManager();
+    $action = (string)($_GET['action'] ?? $_POST['action'] ?? '');
+
+    if ($action === 'upload' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+        if (!isset($_FILES['package']) || !is_array($_FILES['package'])) {
+            pluginPackageJson(['ok' => false, 'error' => 'No .dwpkg file was uploaded.'], 400);
+        }
+        $upload = $_FILES['package'];
+        if (($upload['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+            pluginPackageJson(['ok' => false, 'error' => 'Package upload failed with code ' . (int)$upload['error'] . '.'], 400);
+        }
+        $name = (string)($upload['name'] ?? 'package.dwpkg');
+        if (strtolower(pathinfo($name, PATHINFO_EXTENSION)) !== 'dwpkg') {
+            pluginPackageJson(['ok' => false, 'error' => 'Unified plugin packages must use the .dwpkg extension.'], 400);
+        }
+        $job = $manager->queueArchive((string)$upload['tmp_name'], $name);
+        pluginPackageJson(['ok' => true, 'job' => $job], 202);
+    }
+
+    if ($action === 'start-upload' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+        $input = pluginPackageInput();
+        $upload = $manager->startChunkedUpload(
+            (string)($input['name'] ?? ''),
+            (int)($input['size'] ?? 0),
+            (int)($input['total_chunks'] ?? 0)
+        );
+        pluginPackageJson(['ok' => true, 'upload' => $upload], 201);
+    }
+
+    if ($action === 'upload-chunk' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+        $data = (string)file_get_contents('php://input');
+        $upload = $manager->appendUploadChunk(
+            (string)($_GET['upload_id'] ?? ''),
+            (int)($_GET['index'] ?? -1),
+            $data
+        );
+        pluginPackageJson(['ok' => true, 'upload' => $upload], $upload['complete'] ? 202 : 200);
+    }
+
+    if ($action === 'status' && $_SERVER['REQUEST_METHOD'] === 'GET') {
+        pluginPackageJson(['ok' => true, 'job' => $manager->getJob((string)($_GET['job_id'] ?? ''))]);
+    }
+
+    if ($action === 'pending' && $_SERVER['REQUEST_METHOD'] === 'GET') {
+        pluginPackageRequireBroker($manager);
+        pluginPackageJson(['ok' => true, 'jobs' => $manager->pendingJobs()]);
+    }
+
+    if ($action === 'claim' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+        pluginPackageRequireBroker($manager);
+        $input = pluginPackageInput();
+        pluginPackageJson(['ok' => true, 'job' => $manager->claimJob((string)($input['job_id'] ?? ''))]);
+    }
+
+    if ($action === 'download' && $_SERVER['REQUEST_METHOD'] === 'GET') {
+        pluginPackageRequireBroker($manager);
+        $path = $manager->archivePathForJob((string)($_GET['job_id'] ?? ''));
+        header('Content-Type: application/octet-stream');
+        header('Content-Disposition: attachment; filename="plugin-package.dwpkg"');
+        header('Content-Length: ' . filesize($path));
+        readfile($path);
+        exit;
+    }
+
+    if ($action === 'complete' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+        pluginPackageRequireBroker($manager);
+        $input = pluginPackageInput();
+        $job = $manager->completeGameInstall(
+            (string)($input['job_id'] ?? ''),
+            (string)($input['claim_token'] ?? ''),
+            (bool)($input['success'] ?? false),
+            is_array($input['result'] ?? null) ? $input['result'] : []
+        );
+        pluginPackageJson(['ok' => true, 'job' => $job]);
+    }
+
+    if ($action === 'rollback' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+        pluginPackageRequireBroker($manager);
+        $input = pluginPackageInput();
+        $job = $manager->recordGameRollback(
+            (string)($input['job_id'] ?? ''),
+            is_array($input['result'] ?? null) ? $input['result'] : []
+        );
+        pluginPackageJson(['ok' => true, 'job' => $job]);
+    }
+
+    pluginPackageJson(['ok' => false, 'error' => 'Unsupported package API action.'], 404);
+} catch (DwemerPluginPackageException $error) {
+    pluginPackageJson(['ok' => false, 'error' => $error->getMessage()], 400);
+} catch (Throwable $error) {
+    error_log('[PLUGIN-PACKAGE] ' . $error->getMessage());
+    pluginPackageJson(['ok' => false, 'error' => 'Unexpected package service failure.'], 500);
+}

--- a/ui/api/plugin_packages.php
+++ b/ui/api/plugin_packages.php
@@ -20,38 +20,24 @@ function pluginPackageInput(): array
     return is_array($input) ? $input : [];
 }
 
-function pluginPackageRequireBroker(DwemerPluginPackageManager $manager): void
-{
-    $token = $_SERVER['HTTP_X_DWEMER_PLUGIN_TOKEN'] ?? null;
-    if (!$manager->authenticateBrokerToken(is_string($token) ? $token : null)) {
-        pluginPackageJson(['ok' => false, 'error' => 'Launcher authentication failed.'], 401);
-    }
-}
-
 try {
     $manager = new DwemerPluginPackageManager();
     $action = (string)($_GET['action'] ?? $_POST['action'] ?? '');
 
-    if ($action === 'upload' && $_SERVER['REQUEST_METHOD'] === 'POST') {
-        if (!isset($_FILES['package']) || !is_array($_FILES['package'])) {
-            pluginPackageJson(['ok' => false, 'error' => 'No .dwpkg file was uploaded.'], 400);
-        }
-        $upload = $_FILES['package'];
-        if (($upload['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
-            pluginPackageJson(['ok' => false, 'error' => 'Package upload failed with code ' . (int)$upload['error'] . '.'], 400);
-        }
-        $name = (string)($upload['name'] ?? 'package.dwpkg');
-        if (strtolower(pathinfo($name, PATHINFO_EXTENSION)) !== 'dwpkg') {
-            pluginPackageJson(['ok' => false, 'error' => 'Unified plugin packages must use the .dwpkg extension.'], 400);
-        }
-        $job = $manager->queueArchive((string)$upload['tmp_name'], $name);
-        pluginPackageJson(['ok' => true, 'job' => $job], 202);
+    if ($action === 'probe' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+        $input = pluginPackageInput();
+        pluginPackageJson([
+            'ok' => true,
+            'package' => $manager->probe((string)($input['name'] ?? ''), (string)($input['version'] ?? '')),
+        ]);
     }
 
     if ($action === 'start-upload' && $_SERVER['REQUEST_METHOD'] === 'POST') {
         $input = pluginPackageInput();
         $upload = $manager->startChunkedUpload(
             (string)($input['name'] ?? ''),
+            (string)($input['version'] ?? ''),
+            (string)($input['archive_name'] ?? ''),
             (int)($input['size'] ?? 0),
             (int)($input['total_chunks'] ?? 0)
         );
@@ -59,60 +45,20 @@ try {
     }
 
     if ($action === 'upload-chunk' && $_SERVER['REQUEST_METHOD'] === 'POST') {
-        $data = (string)file_get_contents('php://input');
         $upload = $manager->appendUploadChunk(
             (string)($_GET['upload_id'] ?? ''),
             (int)($_GET['index'] ?? -1),
-            $data
+            (string)file_get_contents('php://input')
         );
-        pluginPackageJson(['ok' => true, 'upload' => $upload], $upload['complete'] ? 202 : 200);
+        pluginPackageJson(['ok' => true, 'upload' => $upload], $upload['complete'] ? 201 : 200);
     }
 
     if ($action === 'status' && $_SERVER['REQUEST_METHOD'] === 'GET') {
         pluginPackageJson(['ok' => true, 'job' => $manager->getJob((string)($_GET['job_id'] ?? ''))]);
     }
 
-    if ($action === 'pending' && $_SERVER['REQUEST_METHOD'] === 'GET') {
-        pluginPackageRequireBroker($manager);
-        pluginPackageJson(['ok' => true, 'jobs' => $manager->pendingJobs()]);
-    }
-
-    if ($action === 'claim' && $_SERVER['REQUEST_METHOD'] === 'POST') {
-        pluginPackageRequireBroker($manager);
-        $input = pluginPackageInput();
-        pluginPackageJson(['ok' => true, 'job' => $manager->claimJob((string)($input['job_id'] ?? ''))]);
-    }
-
-    if ($action === 'download' && $_SERVER['REQUEST_METHOD'] === 'GET') {
-        pluginPackageRequireBroker($manager);
-        $path = $manager->archivePathForJob((string)($_GET['job_id'] ?? ''));
-        header('Content-Type: application/octet-stream');
-        header('Content-Disposition: attachment; filename="plugin-package.dwpkg"');
-        header('Content-Length: ' . filesize($path));
-        readfile($path);
-        exit;
-    }
-
-    if ($action === 'complete' && $_SERVER['REQUEST_METHOD'] === 'POST') {
-        pluginPackageRequireBroker($manager);
-        $input = pluginPackageInput();
-        $job = $manager->completeGameInstall(
-            (string)($input['job_id'] ?? ''),
-            (string)($input['claim_token'] ?? ''),
-            (bool)($input['success'] ?? false),
-            is_array($input['result'] ?? null) ? $input['result'] : []
-        );
-        pluginPackageJson(['ok' => true, 'job' => $job]);
-    }
-
-    if ($action === 'rollback' && $_SERVER['REQUEST_METHOD'] === 'POST') {
-        pluginPackageRequireBroker($manager);
-        $input = pluginPackageInput();
-        $job = $manager->recordGameRollback(
-            (string)($input['job_id'] ?? ''),
-            is_array($input['result'] ?? null) ? $input['result'] : []
-        );
-        pluginPackageJson(['ok' => true, 'job' => $job]);
+    if ($action === 'packages' && $_SERVER['REQUEST_METHOD'] === 'GET') {
+        pluginPackageJson(['ok' => true, 'packages' => $manager->installedPackages()]);
     }
 
     pluginPackageJson(['ok' => false, 'error' => 'Unsupported package API action.'], 404);

--- a/ui/server_plugins.php
+++ b/ui/server_plugins.php
@@ -222,6 +222,37 @@ tr.featured-plugin-row td {
     color: #FDF5D0;
     animation: sharmatNeonPulse 3s ease-in-out infinite alternate;
 }
+.package-installer-card {
+    display: grid;
+    grid-template-columns: minmax(260px, 1fr) auto;
+    gap: 14px;
+    align-items: end;
+    margin-bottom: 20px;
+    padding: 16px;
+    border: 1px solid #3a3a3a;
+    border-radius: 8px;
+    background: #242424;
+}
+.package-installer-card h2 { margin: 0 0 5px; color: #f27c11; }
+.package-installer-card p { margin: 0; color: #bbb; }
+.package-installer-controls { display: flex; gap: 8px; align-items: center; }
+.package-installer-controls input[type="file"] {
+    min-width: 300px;
+    padding: 7px;
+    color: #eee;
+    border: 1px solid #4a4a4a;
+    border-radius: 5px;
+    background: #191919;
+}
+.package-install-status { grid-column: 1 / -1; display: none; padding: 10px 12px; border-radius: 5px; background: #181818; color: #ddd; }
+.package-install-status.is-visible { display: block; }
+.package-install-status.is-error { color: #ff9a9a; border: 1px solid #7b3030; }
+.package-install-status.is-success { color: #a9e7b7; border: 1px solid #2d6b3d; }
+@media (max-width: 900px) {
+    .package-installer-card { grid-template-columns: 1fr; }
+    .package-installer-controls { flex-wrap: wrap; }
+    .package-installer-controls input[type="file"] { min-width: 0; width: 100%; }
+}
 </style>
 
 <main>
@@ -229,6 +260,18 @@ tr.featured-plugin-row td {
         <h1 id="page-title"><span id="title-text">Server Plugins</span></h1>
         <p class="page-subtitle">Manage and install plugins to extend CHIM functionality</p>
     </div>
+
+    <form id="unified-package-form" class="package-installer-card" enctype="multipart/form-data">
+        <div>
+            <h2>Unified Plugin Package</h2>
+            <p>Install one verified <code>.dwpkg</code> containing both the CHIM server extension and its separate Mod Organizer 2 mod.</p>
+        </div>
+        <div class="package-installer-controls">
+            <input id="unified-package-file" type="file" name="package" accept=".dwpkg" required>
+            <button id="unified-package-submit" type="submit" class="btn-base btn-save">Install Package</button>
+        </div>
+        <div id="unified-package-status" class="package-install-status" role="status" aria-live="polite"></div>
+    </form>
 
     <div class="table-container">
         <?php
@@ -647,6 +690,93 @@ tr.featured-plugin-row td {
         ?>
     </div>
 </main>
+
+<script>
+(() => {
+    const form = document.getElementById('unified-package-form');
+    const fileInput = document.getElementById('unified-package-file');
+    const submit = document.getElementById('unified-package-submit');
+    const status = document.getElementById('unified-package-status');
+    const endpoint = <?php echo json_encode($webRoot . '/ui/api/plugin_packages.php'); ?>;
+    let pollTimer = null;
+
+    const showStatus = (message, state = '') => {
+        status.textContent = message;
+        status.className = 'package-install-status is-visible' + (state ? ` is-${state}` : '');
+    };
+
+    const describe = job => {
+        if (job.status === 'awaiting_launcher') return `${job.package_name} ${job.version} is verified. Waiting for DwemerDistro Launcher to install the MO2 mod.`;
+        if (job.status === 'installing_game') return `${job.package_name} ${job.version}: installing the MO2 mod.`;
+        if (job.status === 'activating_server') return `${job.package_name} ${job.version}: activating the server extension.`;
+        if (job.status === 'completed') return `${job.package_name} ${job.version} installed successfully.`;
+        if (job.status === 'failed') return `${job.package_name} ${job.version} failed: ${job.error || 'unknown error'}`;
+        return `${job.package_name} ${job.version}: ${job.status}`;
+    };
+
+    const poll = async jobId => {
+        try {
+            const response = await fetch(`${endpoint}?action=status&job_id=${encodeURIComponent(jobId)}`, { cache: 'no-store' });
+            const payload = await response.json();
+            if (!response.ok || !payload.ok) throw new Error(payload.error || 'Could not read package status.');
+            const final = ['completed', 'failed'].includes(payload.job.status);
+            showStatus(describe(payload.job), payload.job.status === 'completed' ? 'success' : (payload.job.status === 'failed' ? 'error' : ''));
+            if (final) {
+                submit.disabled = false;
+                return;
+            }
+            pollTimer = window.setTimeout(() => poll(jobId), 1500);
+        } catch (error) {
+            showStatus(error.message, 'error');
+            submit.disabled = false;
+        }
+    };
+
+    form.addEventListener('submit', async event => {
+        event.preventDefault();
+        if (!fileInput.files.length) return;
+        if (pollTimer) window.clearTimeout(pollTimer);
+        submit.disabled = true;
+        const file = fileInput.files[0];
+        const chunkSize = 1024 * 1024;
+        const totalChunks = Math.ceil(file.size / chunkSize);
+        showStatus(`Preparing ${totalChunks} upload chunk${totalChunks === 1 ? '' : 's'}...`);
+        try {
+            const startResponse = await fetch(`${endpoint}?action=start-upload`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: file.name, size: file.size, total_chunks: totalChunks })
+            });
+            const startPayload = await startResponse.json();
+            if (!startResponse.ok || !startPayload.ok) throw new Error(startPayload.error || 'Could not start package upload.');
+
+            let job = null;
+            for (let index = 0; index < totalChunks; index++) {
+                showStatus(`Uploading package: ${index + 1} of ${totalChunks} chunks...`);
+                const chunk = file.slice(index * chunkSize, Math.min(file.size, (index + 1) * chunkSize));
+                const chunkResponse = await fetch(`${endpoint}?action=upload-chunk&upload_id=${encodeURIComponent(startPayload.upload.upload_id)}&index=${index}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/octet-stream' },
+                    body: chunk
+                });
+                const chunkPayload = await chunkResponse.json();
+                if (!chunkResponse.ok || !chunkPayload.ok) throw new Error(chunkPayload.error || `Package chunk ${index + 1} failed.`);
+                if (chunkPayload.upload.complete) job = chunkPayload.upload.job;
+            }
+            if (!job) throw new Error('Package upload completed without creating an install job.');
+            showStatus(describe(job), job.status === 'failed' ? 'error' : '');
+            if (['completed', 'failed'].includes(job.status)) {
+                submit.disabled = false;
+                return;
+            }
+            poll(job.id);
+        } catch (error) {
+            showStatus(error.message, 'error');
+            submit.disabled = false;
+        }
+    });
+})();
+</script>
 
 <?php
 include(__DIR__.DIRECTORY_SEPARATOR."tmpl".DIRECTORY_SEPARATOR."footer.html");

--- a/ui/server_plugins.php
+++ b/ui/server_plugins.php
@@ -222,7 +222,7 @@ tr.featured-plugin-row td {
     color: #FDF5D0;
     animation: sharmatNeonPulse 3s ease-in-out infinite alternate;
 }
-.package-installer-card {
+.package-sync-card {
     display: grid;
     grid-template-columns: minmax(260px, 1fr) auto;
     gap: 14px;
@@ -233,25 +233,14 @@ tr.featured-plugin-row td {
     border-radius: 8px;
     background: #242424;
 }
-.package-installer-card h2 { margin: 0 0 5px; color: #f27c11; }
-.package-installer-card p { margin: 0; color: #bbb; }
-.package-installer-controls { display: flex; gap: 8px; align-items: center; }
-.package-installer-controls input[type="file"] {
-    min-width: 300px;
-    padding: 7px;
-    color: #eee;
-    border: 1px solid #4a4a4a;
-    border-radius: 5px;
-    background: #191919;
-}
-.package-install-status { grid-column: 1 / -1; display: none; padding: 10px 12px; border-radius: 5px; background: #181818; color: #ddd; }
-.package-install-status.is-visible { display: block; }
-.package-install-status.is-error { color: #ff9a9a; border: 1px solid #7b3030; }
-.package-install-status.is-success { color: #a9e7b7; border: 1px solid #2d6b3d; }
+.package-sync-card h2 { margin: 0 0 5px; color: #f27c11; }
+.package-sync-card p { margin: 0; color: #bbb; }
+.package-sync-status { grid-column: 1 / -1; padding: 10px 12px; border-radius: 5px; background: #181818; color: #ddd; }
+.package-sync-list { display: grid; gap: 6px; margin-top: 8px; }
+.package-sync-row { display: flex; justify-content: space-between; gap: 16px; padding: 7px 9px; background: #202020; border: 1px solid #363636; border-radius: 4px; }
+.package-sync-version { color: #a9e7b7; white-space: nowrap; }
 @media (max-width: 900px) {
-    .package-installer-card { grid-template-columns: 1fr; }
-    .package-installer-controls { flex-wrap: wrap; }
-    .package-installer-controls input[type="file"] { min-width: 0; width: 100%; }
+    .package-sync-card { grid-template-columns: 1fr; }
 }
 </style>
 
@@ -261,17 +250,14 @@ tr.featured-plugin-row td {
         <p class="page-subtitle">Manage and install plugins to extend CHIM functionality</p>
     </div>
 
-    <form id="unified-package-form" class="package-installer-card" enctype="multipart/form-data">
+    <section class="package-sync-card">
         <div>
-            <h2>Unified Plugin Package</h2>
-            <p>Install one verified <code>.dwpkg</code> containing both the CHIM server extension and its separate Mod Organizer 2 mod.</p>
+            <h2>Automatic Game Plugin Sync</h2>
+            <p>CHIM transfers bundled server plugins automatically when a save is loaded. No manual upload is required.</p>
         </div>
-        <div class="package-installer-controls">
-            <input id="unified-package-file" type="file" name="package" accept=".dwpkg" required>
-            <button id="unified-package-submit" type="submit" class="btn-base btn-save">Install Package</button>
-        </div>
-        <div id="unified-package-status" class="package-install-status" role="status" aria-live="polite"></div>
-    </form>
+        <button id="package-sync-refresh" type="button" class="btn-base btn-primary">Refresh Status</button>
+        <div id="package-sync-status" class="package-sync-status" role="status" aria-live="polite">Loading installed packages...</div>
+    </section>
 
     <div class="table-container">
         <?php
@@ -693,88 +679,42 @@ tr.featured-plugin-row td {
 
 <script>
 (() => {
-    const form = document.getElementById('unified-package-form');
-    const fileInput = document.getElementById('unified-package-file');
-    const submit = document.getElementById('unified-package-submit');
-    const status = document.getElementById('unified-package-status');
+    const refresh = document.getElementById('package-sync-refresh');
+    const status = document.getElementById('package-sync-status');
     const endpoint = <?php echo json_encode($webRoot . '/ui/api/plugin_packages.php'); ?>;
-    let pollTimer = null;
 
-    const showStatus = (message, state = '') => {
-        status.textContent = message;
-        status.className = 'package-install-status is-visible' + (state ? ` is-${state}` : '');
-    };
-
-    const describe = job => {
-        if (job.status === 'awaiting_launcher') return `${job.package_name} ${job.version} is verified. Waiting for DwemerDistro Launcher to install the MO2 mod.`;
-        if (job.status === 'installing_game') return `${job.package_name} ${job.version}: installing the MO2 mod.`;
-        if (job.status === 'activating_server') return `${job.package_name} ${job.version}: activating the server extension.`;
-        if (job.status === 'completed') return `${job.package_name} ${job.version} installed successfully.`;
-        if (job.status === 'failed') return `${job.package_name} ${job.version} failed: ${job.error || 'unknown error'}`;
-        return `${job.package_name} ${job.version}: ${job.status}`;
-    };
-
-    const poll = async jobId => {
+    const loadPackages = async () => {
+        refresh.disabled = true;
+        status.textContent = 'Loading installed packages...';
         try {
-            const response = await fetch(`${endpoint}?action=status&job_id=${encodeURIComponent(jobId)}`, { cache: 'no-store' });
+            const response = await fetch(`${endpoint}?action=packages`, { cache: 'no-store' });
             const payload = await response.json();
-            if (!response.ok || !payload.ok) throw new Error(payload.error || 'Could not read package status.');
-            const final = ['completed', 'failed'].includes(payload.job.status);
-            showStatus(describe(payload.job), payload.job.status === 'completed' ? 'success' : (payload.job.status === 'failed' ? 'error' : ''));
-            if (final) {
-                submit.disabled = false;
-                return;
+            if (!response.ok || !payload.ok) throw new Error(payload.error || 'Could not read automatic package status.');
+            if (!payload.packages.length) {
+                status.textContent = 'No game-bundled server plugins have synchronized yet.';
+            } else {
+                status.innerHTML = '<strong>Installed from game:</strong><div class="package-sync-list"></div>';
+                const list = status.querySelector('.package-sync-list');
+                for (const plugin of payload.packages) {
+                    const row = document.createElement('div');
+                    row.className = 'package-sync-row';
+                    const name = document.createElement('span');
+                    name.textContent = plugin.name;
+                    const version = document.createElement('span');
+                    version.className = 'package-sync-version';
+                    version.textContent = plugin.version;
+                    row.append(name, version);
+                    list.append(row);
+                }
             }
-            pollTimer = window.setTimeout(() => poll(jobId), 1500);
         } catch (error) {
-            showStatus(error.message, 'error');
-            submit.disabled = false;
+            status.textContent = error.message;
+        } finally {
+            refresh.disabled = false;
         }
     };
-
-    form.addEventListener('submit', async event => {
-        event.preventDefault();
-        if (!fileInput.files.length) return;
-        if (pollTimer) window.clearTimeout(pollTimer);
-        submit.disabled = true;
-        const file = fileInput.files[0];
-        const chunkSize = 1024 * 1024;
-        const totalChunks = Math.ceil(file.size / chunkSize);
-        showStatus(`Preparing ${totalChunks} upload chunk${totalChunks === 1 ? '' : 's'}...`);
-        try {
-            const startResponse = await fetch(`${endpoint}?action=start-upload`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name: file.name, size: file.size, total_chunks: totalChunks })
-            });
-            const startPayload = await startResponse.json();
-            if (!startResponse.ok || !startPayload.ok) throw new Error(startPayload.error || 'Could not start package upload.');
-
-            let job = null;
-            for (let index = 0; index < totalChunks; index++) {
-                showStatus(`Uploading package: ${index + 1} of ${totalChunks} chunks...`);
-                const chunk = file.slice(index * chunkSize, Math.min(file.size, (index + 1) * chunkSize));
-                const chunkResponse = await fetch(`${endpoint}?action=upload-chunk&upload_id=${encodeURIComponent(startPayload.upload.upload_id)}&index=${index}`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/octet-stream' },
-                    body: chunk
-                });
-                const chunkPayload = await chunkResponse.json();
-                if (!chunkResponse.ok || !chunkPayload.ok) throw new Error(chunkPayload.error || `Package chunk ${index + 1} failed.`);
-                if (chunkPayload.upload.complete) job = chunkPayload.upload.job;
-            }
-            if (!job) throw new Error('Package upload completed without creating an install job.');
-            showStatus(describe(job), job.status === 'failed' ? 'error' : '');
-            if (['completed', 'failed'].includes(job.status)) {
-                submit.disabled = false;
-                return;
-            }
-            poll(job.id);
-        } catch (error) {
-            showStatus(error.message, 'error');
-            submit.disabled = false;
-        }
-    });
+    refresh.addEventListener('click', loadPackages);
+    loadPackages();
 })();
 </script>
 

--- a/unittests/tests/PluginPackageManagerTest.php
+++ b/unittests/tests/PluginPackageManagerTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/plugin_package_manager.php';
+
+final class PluginPackageManagerTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'chim-package-test-' . bin2hex(random_bytes(6));
+        mkdir($this->root, 0770, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->root);
+    }
+
+    public function testRejectsTraversalBeforeExtraction(): void
+    {
+        $archive = $this->root . DIRECTORY_SEPARATOR . 'unsafe.dwpkg';
+        $zip = new ZipArchive();
+        $zip->open($archive, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFromString('manifest.json', '{}');
+        $zip->addFromString('checksums.sha256', str_repeat('0', 64) . "  manifest.json\n");
+        $zip->addFromString('../escape.txt', 'unsafe');
+        $zip->close();
+
+        $manager = $this->manager();
+        $this->expectException(DwemerPluginPackageException::class);
+        $this->expectExceptionMessage('unsafe');
+        $manager->queueArchive($archive);
+    }
+
+    public function testGamePackageWaitsForLauncherAndCanFailCleanly(): void
+    {
+        $archive = $this->buildPackage(
+            $this->manifest(['game' => $this->gameComponent()]),
+            ['game/skyrim-se/SKSE/Plugins/TestPlugin.ini' => 'enabled=true']
+        );
+        $manager = $this->manager();
+
+        $queued = $manager->queueArchive($archive, 'test.dwpkg');
+        $this->assertSame('awaiting_launcher', $queued['status']);
+        $this->assertCount(1, $manager->pendingJobs());
+
+        $claimed = $manager->claimJob($queued['id']);
+        $this->assertSame('installing_game', $claimed['status']);
+        $this->assertNotEmpty($claimed['claim_token']);
+
+        $completed = $manager->completeGameInstall(
+            $queued['id'],
+            $claimed['claim_token'],
+            false,
+            ['error' => 'MO2 profile was not selected.']
+        );
+        $this->assertSame('failed', $completed['status']);
+        $this->assertSame('MO2 profile was not selected.', $completed['error']);
+    }
+
+    public function testRejectsUnsafeMo2ModFolderName(): void
+    {
+        $archive = $this->buildPackage(
+            $this->manifest(['game' => [
+                'mod_name' => '..',
+                'variants' => ['skyrim-se' => 'game/skyrim-se'],
+                'mutable_paths' => [],
+            ]]),
+            ['game/skyrim-se/payload.txt' => 'unsafe']
+        );
+
+        $this->expectException(DwemerPluginPackageException::class);
+        $this->expectExceptionMessage('safe MO2 folder name');
+        $this->manager()->queueArchive($archive);
+    }
+
+    public function testChunkedUploadReassemblesAndQueuesPackage(): void
+    {
+        $archive = $this->buildPackage(
+            $this->manifest(['game' => $this->gameComponent()]),
+            ['game/skyrim-se/SKSE/Plugins/TestPlugin.ini' => str_repeat('x', 2048)]
+        );
+        $contents = file_get_contents($archive);
+        $this->assertIsString($contents);
+        $chunks = str_split($contents, 512);
+        $manager = $this->manager();
+        $upload = $manager->startChunkedUpload('chunked.dwpkg', strlen($contents), count($chunks));
+
+        $result = null;
+        foreach ($chunks as $index => $chunk) {
+            $result = $manager->appendUploadChunk($upload['upload_id'], $index, $chunk);
+        }
+
+        $this->assertTrue($result['complete']);
+        $this->assertSame('awaiting_launcher', $result['job']['status']);
+        $this->assertSame('Test Package', $result['job']['package_name']);
+    }
+
+    public function testServerActivationPreservesDeclaredMutableFiles(): void
+    {
+        $manager = $this->manager();
+        $component = [
+            'install_name' => 'ExamplePlugin',
+            'mutable_paths' => ['conf/conf.php'],
+        ];
+        $first = $this->buildPackage(
+            $this->manifest(['server' => $component], '1.0.0'),
+            [
+                'server/manifest.json' => '{"name":"ExamplePlugin","version":"1.0.0"}',
+                'server/conf/conf.php' => 'default-v1',
+                'server/plugin.php' => 'version-one',
+            ]
+        );
+        $installed = $manager->queueArchive($first);
+        $this->assertSame('completed', $installed['status']);
+
+        $target = $this->root . DIRECTORY_SEPARATOR . 'server' . DIRECTORY_SEPARATOR . 'ext' . DIRECTORY_SEPARATOR . 'ExamplePlugin';
+        file_put_contents($target . DIRECTORY_SEPARATOR . 'conf' . DIRECTORY_SEPARATOR . 'conf.php', 'user-config');
+
+        $second = $this->buildPackage(
+            $this->manifest(['server' => $component], '2.0.0'),
+            [
+                'server/manifest.json' => '{"name":"ExamplePlugin","version":"2.0.0"}',
+                'server/conf/conf.php' => 'default-v2',
+                'server/plugin.php' => 'version-two',
+            ]
+        );
+        $updated = $manager->queueArchive($second);
+
+        $this->assertSame('completed', $updated['status']);
+        $this->assertSame('version-two', file_get_contents($target . DIRECTORY_SEPARATOR . 'plugin.php'));
+        $this->assertSame('user-config', file_get_contents($target . DIRECTORY_SEPARATOR . 'conf' . DIRECTORY_SEPARATOR . 'conf.php'));
+    }
+
+    public function testMigrationFailureRestoresPreviousServerExtension(): void
+    {
+        $migrationRunner = static function (string $targetDir, string $packageId, array $migrations): void {
+            throw new RuntimeException('forced migration failure');
+        };
+        $manager = $this->manager($migrationRunner);
+        $component = ['install_name' => 'RollbackPlugin', 'mutable_paths' => []];
+        $first = $this->buildPackage(
+            $this->manifest(['server' => $component], '1.0.0'),
+            [
+                'server/manifest.json' => '{"name":"RollbackPlugin","version":"1.0.0"}',
+                'server/plugin.php' => 'stable-version',
+            ]
+        );
+        $this->assertSame('completed', $manager->queueArchive($first)['status']);
+
+        $second = $this->buildPackage(
+            $this->manifest(['server' => $component], '2.0.0'),
+            [
+                'server/manifest.json' => '{"name":"RollbackPlugin","version":"2.0.0"}',
+                'server/plugin.php' => 'broken-version',
+                'server/migrations/001_break.sql' => 'SELECT 1;',
+            ]
+        );
+        $result = $manager->queueArchive($second);
+        $target = $this->root . DIRECTORY_SEPARATOR . 'server' . DIRECTORY_SEPARATOR . 'ext' . DIRECTORY_SEPARATOR . 'RollbackPlugin' . DIRECTORY_SEPARATOR . 'plugin.php';
+
+        $this->assertSame('failed', $result['status']);
+        $this->assertStringContainsString('rolled back', $result['error']);
+        $this->assertSame('stable-version', file_get_contents($target));
+    }
+
+    private function manager(?callable $migrationRunner = null): DwemerPluginPackageManager
+    {
+        return new DwemerPluginPackageManager(
+            $this->root . DIRECTORY_SEPARATOR . 'server',
+            $this->root . DIRECTORY_SEPARATOR . 'state',
+            $migrationRunner ?? static fn() => null
+        );
+    }
+
+    private function manifest(array $components, string $version = '1.0.0'): array
+    {
+        return [
+            'schema_version' => 3,
+            'package_id' => 'test-package',
+            'name' => 'Test Package',
+            'version' => $version,
+            'description' => 'Unit test package',
+            'components' => $components,
+        ];
+    }
+
+    private function gameComponent(): array
+    {
+        return [
+            'mod_name' => 'CHIM Plugin - Test Package',
+            'variants' => ['skyrim-se' => 'game/skyrim-se'],
+            'mutable_paths' => [],
+        ];
+    }
+
+    private function buildPackage(array $manifest, array $payload): string
+    {
+        $archive = $this->root . DIRECTORY_SEPARATOR . 'package-' . bin2hex(random_bytes(4)) . '.dwpkg';
+        $files = ['manifest.json' => json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)] + $payload;
+        $checksums = [];
+        foreach ($files as $path => $contents) {
+            $checksums[] = hash('sha256', $contents) . '  ' . $path;
+        }
+        $files['checksums.sha256'] = implode("\n", $checksums) . "\n";
+
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($archive, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+        foreach ($files as $path => $contents) {
+            $this->assertTrue($zip->addFromString($path, $contents));
+        }
+        $zip->close();
+        return $archive;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($iterator as $entry) {
+            $entry->isDir() ? @rmdir($entry->getPathname()) : @unlink($entry->getPathname());
+        }
+        @rmdir($path);
+    }
+}

--- a/unittests/tests/PluginPackageManagerTest.php
+++ b/unittests/tests/PluginPackageManagerTest.php
@@ -94,7 +94,7 @@ final class PluginPackageManagerTest extends TestCase
         $this->assertIsString($contents);
         $chunks = str_split($contents, 512);
         $manager = $this->manager();
-        $upload = $manager->startChunkedUpload('Chunked Plugin', '2.1.0', '2.1.0.dwpkg', strlen($contents), count($chunks));
+        $upload = $manager->startChunkedUpload('Chunked Plugin', '2.1.0', '2.1.0.zip', strlen($contents), count($chunks));
 
         $result = null;
         foreach ($chunks as $index => $chunk) {
@@ -105,6 +105,23 @@ final class PluginPackageManagerTest extends TestCase
         $this->assertSame('completed', $result['job']['status']);
         $this->assertSame('Chunked Plugin', $result['job']['name']);
         $this->assertFileExists($this->root . '/server/ext/Chunked Plugin/payload.txt');
+    }
+
+    public function testChunkedUploadAcceptsDwpkgAndZipExtensions(): void
+    {
+        $manager = $this->manager();
+
+        foreach (['1.0.0.dwpkg', '1.0.0.zip', '1.0.0.ZIP'] as $archiveName) {
+            $upload = $manager->startChunkedUpload('Extension Plugin', '1.0.0', $archiveName, 1, 1);
+            $this->assertNotEmpty($upload['upload_id']);
+        }
+    }
+
+    public function testChunkedUploadRejectsUnsupportedArchiveExtension(): void
+    {
+        $this->expectException(DwemerPluginPackageException::class);
+        $this->expectExceptionMessage('.dwpkg or .zip');
+        $this->manager()->startChunkedUpload('Extension Plugin', '1.0.0', '1.0.0.7z', 1, 1);
     }
 
     public function testServerActivationPreservesDeclaredMutableFiles(): void

--- a/unittests/tests/PluginPackageManagerTest.php
+++ b/unittests/tests/PluginPackageManagerTest.php
@@ -21,6 +21,41 @@ final class PluginPackageManagerTest extends TestCase
         $this->removeDirectory($this->root);
     }
 
+    public function testProbeRequestsOnlyMissingOrChangedVersions(): void
+    {
+        $manager = $this->manager();
+        $this->assertTrue($manager->probe('Example Plugin', '1.0.0')['upload_required']);
+
+        $installed = $manager->installArchive($this->buildPackage('Example Plugin', '1.0.0'));
+        $this->assertSame('completed', $installed['status']);
+
+        $current = $manager->probe('example plugin', '1.0.0');
+        $this->assertFalse($current['upload_required']);
+        $this->assertSame('current', $current['reason']);
+
+        $changed = $manager->probe('Example Plugin', '1.1.0');
+        $this->assertTrue($changed['upload_required']);
+        $this->assertSame('version_changed', $changed['reason']);
+    }
+
+    public function testInstalledPackagesIgnoreLegacyPackageIdRecords(): void
+    {
+        $manager = $this->manager();
+        file_put_contents($this->root . '/state/packages/legacy.json', json_encode([
+            'package_id' => 'example-plugin',
+            'name' => 'Example Plugin',
+            'version' => '1.0.0',
+            'manifest' => ['schema_version' => 3],
+        ], JSON_THROW_ON_ERROR));
+        $manager->installArchive($this->buildPackage('Example-Plugin', '2.0.0'));
+
+        $installed = $manager->installedPackages();
+
+        $this->assertCount(1, $installed);
+        $this->assertSame('Example-Plugin', $installed[0]['name']);
+        $this->assertSame('2.0.0', $installed[0]['version']);
+    }
+
     public function testRejectsTraversalBeforeExtraction(): void
     {
         $archive = $this->root . DIRECTORY_SEPARATOR . 'unsafe.dwpkg';
@@ -31,65 +66,35 @@ final class PluginPackageManagerTest extends TestCase
         $zip->addFromString('../escape.txt', 'unsafe');
         $zip->close();
 
-        $manager = $this->manager();
         $this->expectException(DwemerPluginPackageException::class);
         $this->expectExceptionMessage('unsafe');
-        $manager->queueArchive($archive);
+        $this->manager()->installArchive($archive);
     }
 
-    public function testGamePackageWaitsForLauncherAndCanFailCleanly(): void
+    public function testRejectsGamePayloadAndMismatchedFolderIdentity(): void
     {
-        $archive = $this->buildPackage(
-            $this->manifest(['game' => $this->gameComponent()]),
-            ['game/skyrim-se/SKSE/Plugins/TestPlugin.ini' => 'enabled=true']
-        );
-        $manager = $this->manager();
+        $archive = $this->buildPackage('Example Plugin', '1.0.0', ['game/plugin.dll' => 'not allowed']);
+        try {
+            $this->manager()->installArchive($archive);
+            $this->fail('Game payload was accepted.');
+        } catch (DwemerPluginPackageException $error) {
+            $this->assertStringContainsString('Unsupported package payload', $error->getMessage());
+        }
 
-        $queued = $manager->queueArchive($archive, 'test.dwpkg');
-        $this->assertSame('awaiting_launcher', $queued['status']);
-        $this->assertCount(1, $manager->pendingJobs());
-
-        $claimed = $manager->claimJob($queued['id']);
-        $this->assertSame('installing_game', $claimed['status']);
-        $this->assertNotEmpty($claimed['claim_token']);
-
-        $completed = $manager->completeGameInstall(
-            $queued['id'],
-            $claimed['claim_token'],
-            false,
-            ['error' => 'MO2 profile was not selected.']
-        );
-        $this->assertSame('failed', $completed['status']);
-        $this->assertSame('MO2 profile was not selected.', $completed['error']);
-    }
-
-    public function testRejectsUnsafeMo2ModFolderName(): void
-    {
-        $archive = $this->buildPackage(
-            $this->manifest(['game' => [
-                'mod_name' => '..',
-                'variants' => ['skyrim-se' => 'game/skyrim-se'],
-                'mutable_paths' => [],
-            ]]),
-            ['game/skyrim-se/payload.txt' => 'unsafe']
-        );
-
+        $archive = $this->buildPackage('Example Plugin', '1.0.0');
         $this->expectException(DwemerPluginPackageException::class);
-        $this->expectExceptionMessage('safe MO2 folder name');
-        $this->manager()->queueArchive($archive);
+        $this->expectExceptionMessage('game-side plugin folder');
+        $this->manager()->installArchive($archive, '1.0.0.dwpkg', 'Different Plugin', '1.0.0');
     }
 
-    public function testChunkedUploadReassemblesAndQueuesPackage(): void
+    public function testChunkedUploadReassemblesAndActivatesPackage(): void
     {
-        $archive = $this->buildPackage(
-            $this->manifest(['game' => $this->gameComponent()]),
-            ['game/skyrim-se/SKSE/Plugins/TestPlugin.ini' => str_repeat('x', 2048)]
-        );
+        $archive = $this->buildPackage('Chunked Plugin', '2.1.0', ['server/payload.txt' => str_repeat('x', 4096)]);
         $contents = file_get_contents($archive);
         $this->assertIsString($contents);
         $chunks = str_split($contents, 512);
         $manager = $this->manager();
-        $upload = $manager->startChunkedUpload('chunked.dwpkg', strlen($contents), count($chunks));
+        $upload = $manager->startChunkedUpload('Chunked Plugin', '2.1.0', '2.1.0.dwpkg', strlen($contents), count($chunks));
 
         $result = null;
         foreach ($chunks as $index => $chunk) {
@@ -97,139 +102,103 @@ final class PluginPackageManagerTest extends TestCase
         }
 
         $this->assertTrue($result['complete']);
-        $this->assertSame('awaiting_launcher', $result['job']['status']);
-        $this->assertSame('Test Package', $result['job']['package_name']);
+        $this->assertSame('completed', $result['job']['status']);
+        $this->assertSame('Chunked Plugin', $result['job']['name']);
+        $this->assertFileExists($this->root . '/server/ext/Chunked Plugin/payload.txt');
     }
 
     public function testServerActivationPreservesDeclaredMutableFiles(): void
     {
         $manager = $this->manager();
-        $component = [
-            'install_name' => 'ExamplePlugin',
-            'mutable_paths' => ['conf/conf.php'],
-        ];
-        $first = $this->buildPackage(
-            $this->manifest(['server' => $component], '1.0.0'),
-            [
-                'server/manifest.json' => '{"name":"ExamplePlugin","version":"1.0.0"}',
-                'server/conf/conf.php' => 'default-v1',
-                'server/plugin.php' => 'version-one',
-            ]
-        );
-        $installed = $manager->queueArchive($first);
-        $this->assertSame('completed', $installed['status']);
+        $first = $this->buildPackage('ExamplePlugin', '1.0.0', [
+            'server/conf/conf.php' => 'default-v1',
+            'server/plugin.php' => 'version-one',
+        ], ['conf/conf.php']);
+        $this->assertSame('completed', $manager->installArchive($first)['status']);
 
-        $target = $this->root . DIRECTORY_SEPARATOR . 'server' . DIRECTORY_SEPARATOR . 'ext' . DIRECTORY_SEPARATOR . 'ExamplePlugin';
-        file_put_contents($target . DIRECTORY_SEPARATOR . 'conf' . DIRECTORY_SEPARATOR . 'conf.php', 'user-config');
-
-        $second = $this->buildPackage(
-            $this->manifest(['server' => $component], '2.0.0'),
-            [
-                'server/manifest.json' => '{"name":"ExamplePlugin","version":"2.0.0"}',
-                'server/conf/conf.php' => 'default-v2',
-                'server/plugin.php' => 'version-two',
-            ]
-        );
-        $updated = $manager->queueArchive($second);
+        $target = $this->root . '/server/ext/ExamplePlugin';
+        file_put_contents($target . '/conf/conf.php', 'user-config');
+        $second = $this->buildPackage('ExamplePlugin', '2.0.0', [
+            'server/conf/conf.php' => 'default-v2',
+            'server/plugin.php' => 'version-two',
+        ], ['conf/conf.php']);
+        $updated = $manager->installArchive($second);
 
         $this->assertSame('completed', $updated['status']);
-        $this->assertSame('version-two', file_get_contents($target . DIRECTORY_SEPARATOR . 'plugin.php'));
-        $this->assertSame('user-config', file_get_contents($target . DIRECTORY_SEPARATOR . 'conf' . DIRECTORY_SEPARATOR . 'conf.php'));
+        $this->assertSame('version-two', file_get_contents($target . '/plugin.php'));
+        $this->assertSame('user-config', file_get_contents($target . '/conf/conf.php'));
     }
 
     public function testMigrationFailureRestoresPreviousServerExtension(): void
     {
-        $migrationRunner = static function (string $targetDir, string $packageId, array $migrations): void {
-            throw new RuntimeException('forced migration failure');
+        $migrationRunner = static function (string $targetDir, string $pluginName, array $migrations): void {
+            if (str_contains((string)file_get_contents($targetDir . '/plugin.php'), 'broken')) {
+                throw new RuntimeException('forced migration failure');
+            }
         };
         $manager = $this->manager($migrationRunner);
-        $component = ['install_name' => 'RollbackPlugin', 'mutable_paths' => []];
-        $first = $this->buildPackage(
-            $this->manifest(['server' => $component], '1.0.0'),
-            [
-                'server/manifest.json' => '{"name":"RollbackPlugin","version":"1.0.0"}',
-                'server/plugin.php' => 'stable-version',
-            ]
-        );
-        $this->assertSame('completed', $manager->queueArchive($first)['status']);
+        $first = $this->buildPackage('RollbackPlugin', '1.0.0', ['server/plugin.php' => 'stable-version']);
+        $this->assertSame('completed', $manager->installArchive($first)['status']);
 
-        $second = $this->buildPackage(
-            $this->manifest(['server' => $component], '2.0.0'),
-            [
-                'server/manifest.json' => '{"name":"RollbackPlugin","version":"2.0.0"}',
-                'server/plugin.php' => 'broken-version',
-                'server/migrations/001_break.sql' => 'SELECT 1;',
-            ]
-        );
-        $result = $manager->queueArchive($second);
-        $target = $this->root . DIRECTORY_SEPARATOR . 'server' . DIRECTORY_SEPARATOR . 'ext' . DIRECTORY_SEPARATOR . 'RollbackPlugin' . DIRECTORY_SEPARATOR . 'plugin.php';
+        $second = $this->buildPackage('RollbackPlugin', '2.0.0', [
+            'server/plugin.php' => 'broken-version',
+            'server/migrations/001_break.sql' => 'SELECT 1;',
+        ]);
+        $result = $manager->installArchive($second);
 
         $this->assertSame('failed', $result['status']);
         $this->assertStringContainsString('rolled back', $result['error']);
-        $this->assertSame('stable-version', file_get_contents($target));
+        $this->assertSame('stable-version', file_get_contents($this->root . '/server/ext/RollbackPlugin/plugin.php'));
+        $this->assertSame('1.0.0', $manager->probe('RollbackPlugin', '1.0.0')['installed_version']);
     }
 
     private function manager(?callable $migrationRunner = null): DwemerPluginPackageManager
     {
         return new DwemerPluginPackageManager(
-            $this->root . DIRECTORY_SEPARATOR . 'server',
-            $this->root . DIRECTORY_SEPARATOR . 'state',
+            $this->root . '/server',
+            $this->root . '/state',
             $migrationRunner ?? static fn() => null
         );
     }
 
-    private function manifest(array $components, string $version = '1.0.0'): array
-    {
-        return [
-            'schema_version' => 3,
-            'package_id' => 'test-package',
-            'name' => 'Test Package',
+    private function buildPackage(
+        string $name,
+        string $version,
+        array $extraFiles = [],
+        array $mutablePaths = []
+    ): string {
+        $archive = $this->root . '/package-' . bin2hex(random_bytes(4)) . '.dwpkg';
+        $manifest = [
+            'schema_version' => 4,
+            'name' => $name,
             'version' => $version,
             'description' => 'Unit test package',
-            'components' => $components,
+            'server' => ['mutable_paths' => $mutablePaths],
         ];
-    }
-
-    private function gameComponent(): array
-    {
-        return [
-            'mod_name' => 'CHIM Plugin - Test Package',
-            'variants' => ['skyrim-se' => 'game/skyrim-se'],
-            'mutable_paths' => [],
+        $files = [
+            'manifest.json' => json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+            'server/manifest.json' => json_encode(['name' => $name, 'version' => $version], JSON_THROW_ON_ERROR),
         ];
-    }
-
-    private function buildPackage(array $manifest, array $payload): string
-    {
-        $archive = $this->root . DIRECTORY_SEPARATOR . 'package-' . bin2hex(random_bytes(4)) . '.dwpkg';
-        $files = ['manifest.json' => json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)] + $payload;
+        foreach ($extraFiles as $path => $contents) $files[$path] = $contents;
         $checksums = [];
-        foreach ($files as $path => $contents) {
-            $checksums[] = hash('sha256', $contents) . '  ' . $path;
-        }
+        foreach ($files as $path => $contents) $checksums[] = hash('sha256', $contents) . '  ' . $path;
         $files['checksums.sha256'] = implode("\n", $checksums) . "\n";
 
         $zip = new ZipArchive();
         $this->assertTrue($zip->open($archive, ZipArchive::CREATE | ZipArchive::OVERWRITE));
-        foreach ($files as $path => $contents) {
-            $this->assertTrue($zip->addFromString($path, $contents));
-        }
+        foreach ($files as $path => $contents) $this->assertTrue($zip->addFromString($path, $contents));
         $zip->close();
         return $archive;
     }
 
     private function removeDirectory(string $path): void
     {
-        if (!is_dir($path)) {
-            return;
-        }
+        if (!is_dir($path)) return;
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
             RecursiveIteratorIterator::CHILD_FIRST
         );
-        foreach ($iterator as $entry) {
-            $entry->isDir() ? @rmdir($entry->getPathname()) : @unlink($entry->getPathname());
-        }
+        foreach ($iterator as $entry) $entry->isDir() ? @rmdir($entry->getPathname()) : @unlink($entry->getPathname());
         @rmdir($path);
     }
 }


### PR DESCRIPTION
## Summary
- replace the launcher/manual package broker with a game-driven package API
- use the plugin name as the canonical identity and install to `ext/<Plugin Name>`
- accept ordinary `.zip` packages and retain `.dwpkg` for backward compatibility
- support probe, sequential chunk upload, transactional activation, mutable paths, SQL migrations, and rollback
- reject traversal, symlinks, unsupported payloads, checksum mismatches, identity mismatches, oversized archives, and out-of-order chunks
- show automatically installed packages in Server Plugins without a manual upload control

## Package contract
A schema-v4 package is a standard ZIP archive named `<version>.zip` or `<version>.dwpkg` and contains only:
- `manifest.json`
- `checksums.sha256`
- `server/**`

The game-side folder name and archive filename provide the expected plugin name and version. No package ID is required.

## Validation
- PHP lint passed for all changed PHP files
- focused PHPUnit suite: 9 tests, 78 assertions
- live Apache package API returned HTTP 200 with the updated ZIP gate deployed
- local Apache chunk uploads installed CHIM-Custom and `aiagent_nsfw`
- CHIM-Custom migrations completed and case-insensitive probes reported installed versions as current

## Security review
Package integrity and extraction safety are enforced identically for `.zip` and `.dwpkg`, but publisher authenticity is not yet cryptographically signed. Keep this draft until the package trust boundary is approved.