### PR TITLE
Add persistent visual context

### DIFF
--- a/conf/conf_schema.json
+++ b/conf/conf_schema.json
@@ -107,6 +107,9 @@
   "POWER_AWARENESS_ENABLED": {"userlvl":"basic","type":"boolean","scope":"global","description":"NPCs will be aware of relative power levels (based on character level) and react appropriately to threats.","_title":"Power Awareness System"},
   "CLEAN_CONTEXT_FOCUS_CHAT_HISTORY": {"userlvl":"basic","type": "integer","description": "Context history length with only conversations. Ideally set it to 20-30.","scope":"global"},
   "BGL_TRIGGER_HOURS": {"userlvl":"basic","type": "number","default": 24,"description": "Number of in-game hours between Background Life events. NPCs will generate thoughts and take actions based on this interval. Default: 24 hours. Range: 1-720 hours.","scope":"global"},
+  "VISUAL_CONTEXT_ENABLED": {"userlvl":"basic","type":"boolean","default":false,"description":"Inject recent saved image descriptions for the current location into roleplay prompts. Capture storage remains available while this is disabled.","scope":"global"},
+  "VISUAL_CONTEXT_SCENE_TTL_MINUTES": {"userlvl":"basic","type":"integer","default":10,"description":"Minutes before an unlocked visual scene description expires from prompt context. Locked records do not expire.","scope":"global"},
+  "VISUAL_CONTEXT_PROMPT_MAX_CHARS": {"userlvl":"pro","type":"integer","default":1800,"description":"Maximum number of visual context characters included in each roleplay prompt.","scope":"global"},
   "CONNECTOR": {
     "_title":"AI/LLM Connectors",
     "openrouterjson": {

--- a/conf/conf_schema.json
+++ b/conf/conf_schema.json
@@ -107,7 +107,6 @@
   "POWER_AWARENESS_ENABLED": {"userlvl":"basic","type":"boolean","scope":"global","description":"NPCs will be aware of relative power levels (based on character level) and react appropriately to threats.","_title":"Power Awareness System"},
   "CLEAN_CONTEXT_FOCUS_CHAT_HISTORY": {"userlvl":"basic","type": "integer","description": "Context history length with only conversations. Ideally set it to 20-30.","scope":"global"},
   "BGL_TRIGGER_HOURS": {"userlvl":"basic","type": "number","default": 24,"description": "Number of in-game hours between Background Life events. NPCs will generate thoughts and take actions based on this interval. Default: 24 hours. Range: 1-720 hours.","scope":"global"},
-  "VISUAL_CONTEXT_ENABLED": {"userlvl":"basic","type":"boolean","default":false,"description":"Inject recent saved image descriptions for the current location into roleplay prompts. Capture storage remains available while this is disabled.","scope":"global"},
   "VISUAL_CONTEXT_SCENE_TTL_MINUTES": {"userlvl":"basic","type":"integer","default":10,"description":"Minutes before an unlocked visual scene description expires from prompt context. Locked records do not expire.","scope":"global"},
   "VISUAL_CONTEXT_PROMPT_MAX_CHARS": {"userlvl":"pro","type":"integer","default":1800,"description":"Maximum number of visual context characters included in each roleplay prompt.","scope":"global"},
   "CONNECTOR": {

--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -7225,6 +7225,27 @@ if ($checkVersion("master_packages")<20260716002) {
 
 }
 
+//----------------------------------------------------
+// VISUAL CONTEXT - Persistent image descriptions
+// Version 20260718001
+//----------------------------------------------------
+
+if ($checkVersion("visual_context") < 20260718001) {
+    Logger::debug("Applying visual_context 20260718001 - add persistent visual descriptions");
+    require_once(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'visual_context.php');
+
+    $b_ok = chimEnsureVisualContextTable();
+    if ($b_ok) {
+        chimSetGeneralSetting('VISUAL_CONTEXT_ENABLED', false, chimGetSchemaDescription('VISUAL_CONTEXT_ENABLED'));
+        chimSetGeneralSetting('VISUAL_CONTEXT_SCENE_TTL_MINUTES', 10, chimGetSchemaDescription('VISUAL_CONTEXT_SCENE_TTL_MINUTES'));
+        chimSetGeneralSetting('VISUAL_CONTEXT_PROMPT_MAX_CHARS', 1800, chimGetSchemaDescription('VISUAL_CONTEXT_PROMPT_MAX_CHARS'));
+        $updateVersion("visual_context", 20260718001);
+        Logger::info("Applied patch visual_context 20260718001");
+    } else {
+        Logger::error("Failed to apply patch visual_context 20260718001");
+    }
+}
+
 Logger::info(__FILE__." update file processed");
 
 //----------------------------------------------------

--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -7236,7 +7236,6 @@ if ($checkVersion("visual_context") < 20260718001) {
 
     $b_ok = chimEnsureVisualContextTable();
     if ($b_ok) {
-        chimSetGeneralSetting('VISUAL_CONTEXT_ENABLED', false, chimGetSchemaDescription('VISUAL_CONTEXT_ENABLED'));
         chimSetGeneralSetting('VISUAL_CONTEXT_SCENE_TTL_MINUTES', 10, chimGetSchemaDescription('VISUAL_CONTEXT_SCENE_TTL_MINUTES'));
         chimSetGeneralSetting('VISUAL_CONTEXT_PROMPT_MAX_CHARS', 1800, chimGetSchemaDescription('VISUAL_CONTEXT_PROMPT_MAX_CHARS'));
         $updateVersion("visual_context", 20260718001);

--- a/itt.php
+++ b/itt.php
@@ -15,6 +15,7 @@ require_once($path . "lib" .DIRECTORY_SEPARATOR."model_dynmodel.php");
 require_once($path . "lib" .DIRECTORY_SEPARATOR."data_functions.php");
 require_once($path . "lib" .DIRECTORY_SEPARATOR."chat_helper_functions.php");
 require_once($path . "lib" .DIRECTORY_SEPARATOR."logger.php");
+require_once($path . "lib" .DIRECTORY_SEPARATOR."visual_context.php");
 
 if (isset($_GET["format"]) && $_GET["format"]=="png")
     $finalName=__DIR__.DIRECTORY_SEPARATOR."soundcache/_img_".md5($_FILES["file"]["tmp_name"]).".png";
@@ -96,10 +97,37 @@ $hints.="Location: $location";
 
 require_once($path."itt/itt-{$GLOBALS["ITTFUNCTION"]}.php");
 
-echo itt($finalNameJpeg,$hints);
+$description = trim(strval(itt($finalNameJpeg, $hints)));
+$galleryDirectory = __DIR__.DIRECTORY_SEPARATOR."data/pictures/gallery/";
+$galleryPath = $galleryDirectory.basename($finalNameJpeg);
+@mkdir($galleryDirectory, 0777, true);
+if (@rename($finalNameJpeg, $galleryPath)) {
+    $visualType = chimVisualContextSubjectType($_GET['visual_type'] ?? 'scene');
+    $subjectName = chimVisualContextText($_GET['visual_name'] ?? ($_GET['fg'] ?? ''), 300);
+    $subjectKey = chimVisualContextText($_GET['visual_key'] ?? '', 500);
+    chimVisualContextStore([
+        'subject_type' => $visualType,
+        'subject_key' => $subjectKey,
+        'subject_name' => $subjectName,
+        'plugin' => $_GET['visual_plugin'] ?? '',
+        'baseid' => $_GET['visual_baseid'] ?? '',
+        'refid' => $_GET['visual_refid'] ?? '',
+        'cell_id' => $_GET['visual_cell'] ?? '',
+        'location_name' => $_GET['visual_location'] ?? $location,
+        'image_path' => 'data/pictures/gallery/' . basename($galleryPath),
+        'image_sha256' => hash_file('sha256', $galleryPath) ?: '',
+        'description' => $description,
+        'perspective' => $_GET['visual_perspective'] ?? 'first_person',
+        'provider' => $GLOBALS['ITTFUNCTION'] ?? '',
+        'model' => $GLOBALS['ITT']['model'] ?? '',
+        'metadata' => [
+            'visible_characters' => $vc ?? [],
+            'foreground' => chimVisualContextText($_GET['fg'] ?? '', 300),
+        ],
+    ]);
+}
 
-@mkdir(__DIR__.DIRECTORY_SEPARATOR."data/pictures/gallery/",0777);
-@rename($finalNameJpeg,__DIR__.DIRECTORY_SEPARATOR."data/pictures/gallery/".basename($finalNameJpeg));
+echo $description;
 
 
 ?>

--- a/itt.php
+++ b/itt.php
@@ -99,8 +99,20 @@ require_once($path."itt/itt-{$GLOBALS["ITTFUNCTION"]}.php");
 
 $description = trim(strval(itt($finalNameJpeg, $hints)));
 $galleryDirectory = __DIR__.DIRECTORY_SEPARATOR."data/pictures/gallery/";
-$galleryPath = $galleryDirectory.basename($finalNameJpeg);
+$visualLocation = $_GET['visual_location'] ?? $location;
+$gameTs = DataLastKnownGameTS();
+$gameDate = $gameTs > 0 ? convert_gamets2skyrim_long_date($gameTs) : '';
 @mkdir($galleryDirectory, 0777, true);
+$galleryFilename = chimVisualContextGalleryFilename($visualLocation, $gameDate, 'jpg');
+$galleryPath = $galleryDirectory.$galleryFilename;
+$filenameStem = pathinfo($galleryFilename, PATHINFO_FILENAME);
+$filenameExtension = pathinfo($galleryFilename, PATHINFO_EXTENSION);
+$filenameCounter = 2;
+while (file_exists($galleryPath)) {
+    $galleryFilename = $filenameStem . '__' . $filenameCounter . '.' . $filenameExtension;
+    $galleryPath = $galleryDirectory.$galleryFilename;
+    $filenameCounter++;
+}
 if (@rename($finalNameJpeg, $galleryPath)) {
     $visualType = chimVisualContextSubjectType($_GET['visual_type'] ?? 'scene');
     $subjectName = chimVisualContextText($_GET['visual_name'] ?? ($_GET['fg'] ?? ''), 300);
@@ -113,7 +125,7 @@ if (@rename($finalNameJpeg, $galleryPath)) {
         'baseid' => $_GET['visual_baseid'] ?? '',
         'refid' => $_GET['visual_refid'] ?? '',
         'cell_id' => $_GET['visual_cell'] ?? '',
-        'location_name' => $_GET['visual_location'] ?? $location,
+        'location_name' => $visualLocation,
         'image_path' => 'data/pictures/gallery/' . basename($galleryPath),
         'image_sha256' => hash_file('sha256', $galleryPath) ?: '',
         'description' => $description,

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -14,6 +14,7 @@ require_once(__DIR__."/core/npc_master.class.php");
 require_once(__DIR__."/core/core_profiles.class.php");
 require_once(__DIR__."/prompt_injections.php");
 require_once(__DIR__."/vr_items.php");
+require_once(__DIR__."/visual_context.php");
 
 
 function ChangeHerikaName($new_name="") {
@@ -1549,6 +1550,14 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
                 $nearbyActorsList[]=$nearbyActor;
         }
         $GLOBALS["PROMPT_NEARBY_SECTIONS"] .= "\n<actors_nearby>\n" . implode(", ", $nearbyActorsList) . "\n</actors_nearby>";
+    }
+
+    $visualContext = chimBuildVisualContextPrompt(DataLastKnownLocation());
+    if ($visualContext !== '') {
+        if (!isset($GLOBALS["PROMPT_NEARBY_SECTIONS"])) {
+            $GLOBALS["PROMPT_NEARBY_SECTIONS"] = "";
+        }
+        $GLOBALS["PROMPT_NEARBY_SECTIONS"] .= "\n" . $visualContext;
     }
     
 

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -187,6 +187,9 @@ if (!function_exists('chimGetManagedGeneralSettingIds')) {
             'AUTOFILL_CUSTOM_PROFILES',
             'AUTOFILL_CUSTOM_PROFILES_TRIGGER',
             'BGL_TRIGGER_HOURS',
+            'VISUAL_CONTEXT_ENABLED',
+            'VISUAL_CONTEXT_SCENE_TTL_MINUTES',
+            'VISUAL_CONTEXT_PROMPT_MAX_CHARS',
             'END_CONVERSATION_COOLDOWN',
             'CLEAN_CONTEXT_FOCUS_CHAT_HISTORY',
             'FEATURES@MEMORY_EMBEDDING@ENABLED',
@@ -312,6 +315,9 @@ if (!function_exists('chimPrettySettingLabel')) {
             'CHIM_AI_QUEST_PROGRESSION' => 'AI Quest Progression (Beta)',
             'CHIM_PLAYER_ONLY_QUEST_ADVANCEMENT' => 'Player Only Quest Advancement',
             'CHIM_ITEM_PICKUP_EVENTLOG_MIN_VALUE' => 'Item Pickup Detection Value',
+            'VISUAL_CONTEXT_ENABLED' => 'Use Visual Context',
+            'VISUAL_CONTEXT_SCENE_TTL_MINUTES' => 'Visual Scene Lifetime',
+            'VISUAL_CONTEXT_PROMPT_MAX_CHARS' => 'Visual Prompt Limit',
         ];
         if (isset($customLabels[$flatName])) {
             return $customLabels[$flatName];
@@ -338,6 +344,10 @@ if (!function_exists('chimGetOverrideableGeneralSettingCategory')) {
 
         if (strpos($flatId, 'RECHAT') === 0) {
             return 'Rechat';
+        }
+
+        if (strpos($flatId, 'VISUAL_CONTEXT_') === 0) {
+            return 'Visual Context';
         }
 
         if (in_array($flatId, ['CHIM_AI_QUEST_PROGRESSION', 'CHIM_PLAYER_ONLY_QUEST_ADVANCEMENT'], true)) {

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -187,7 +187,6 @@ if (!function_exists('chimGetManagedGeneralSettingIds')) {
             'AUTOFILL_CUSTOM_PROFILES',
             'AUTOFILL_CUSTOM_PROFILES_TRIGGER',
             'BGL_TRIGGER_HOURS',
-            'VISUAL_CONTEXT_ENABLED',
             'VISUAL_CONTEXT_SCENE_TTL_MINUTES',
             'VISUAL_CONTEXT_PROMPT_MAX_CHARS',
             'END_CONVERSATION_COOLDOWN',
@@ -315,7 +314,6 @@ if (!function_exists('chimPrettySettingLabel')) {
             'CHIM_AI_QUEST_PROGRESSION' => 'AI Quest Progression (Beta)',
             'CHIM_PLAYER_ONLY_QUEST_ADVANCEMENT' => 'Player Only Quest Advancement',
             'CHIM_ITEM_PICKUP_EVENTLOG_MIN_VALUE' => 'Item Pickup Detection Value',
-            'VISUAL_CONTEXT_ENABLED' => 'Use Visual Context',
             'VISUAL_CONTEXT_SCENE_TTL_MINUTES' => 'Visual Scene Lifetime',
             'VISUAL_CONTEXT_PROMPT_MAX_CHARS' => 'Visual Prompt Limit',
         ];

--- a/lib/visual_context.php
+++ b/lib/visual_context.php
@@ -1,0 +1,225 @@
+<?php
+
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'settings.php');
+
+if (!function_exists('chimEnsureVisualContextTable')) {
+    function chimEnsureVisualContextTable(): bool
+    {
+        static $ready = false;
+        if ($ready) {
+            return true;
+        }
+
+        $db = $GLOBALS['db'] ?? null;
+        if (!$db) {
+            return false;
+        }
+
+        $ready = $db->execQuery(<<<'SQL'
+CREATE TABLE IF NOT EXISTS public.visual_context (
+    id BIGSERIAL PRIMARY KEY,
+    subject_type TEXT NOT NULL DEFAULT 'scene',
+    subject_key TEXT NOT NULL,
+    subject_name TEXT NOT NULL DEFAULT '',
+    plugin TEXT NOT NULL DEFAULT '',
+    baseid TEXT NOT NULL DEFAULT '',
+    refid TEXT NOT NULL DEFAULT '',
+    cell_id TEXT NOT NULL DEFAULT '',
+    location_name TEXT NOT NULL DEFAULT '',
+    image_path TEXT NOT NULL DEFAULT '',
+    image_sha256 TEXT NOT NULL DEFAULT '',
+    description TEXT NOT NULL DEFAULT '',
+    perspective TEXT NOT NULL DEFAULT 'first_person',
+    provider TEXT NOT NULL DEFAULT '',
+    model TEXT NOT NULL DEFAULT '',
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    locked BOOLEAN NOT NULL DEFAULT FALSE,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    user_edited BOOLEAN NOT NULL DEFAULT FALSE,
+    captured_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS visual_context_location_idx
+    ON public.visual_context (LOWER(location_name), active, captured_at DESC);
+CREATE INDEX IF NOT EXISTS visual_context_subject_idx
+    ON public.visual_context (subject_type, subject_key, active, captured_at DESC);
+CREATE INDEX IF NOT EXISTS visual_context_image_idx
+    ON public.visual_context (image_sha256);
+SQL) !== false;
+
+        return $ready;
+    }
+}
+
+if (!function_exists('chimVisualContextSubjectType')) {
+    function chimVisualContextSubjectType($value): string
+    {
+        $value = strtolower(trim(strval($value)));
+        $allowed = ['scene', 'location', 'actor', 'player', 'item', 'furniture', 'object'];
+        return in_array($value, $allowed, true) ? $value : 'scene';
+    }
+}
+
+if (!function_exists('chimVisualContextText')) {
+    function chimVisualContextText($value, int $maxLength = 500): string
+    {
+        if (is_array($value) || is_object($value)) {
+            $value = json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        }
+        $value = trim(preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u', '', strval($value)) ?? '');
+        if (function_exists('mb_substr')) {
+            return mb_substr($value, 0, $maxLength);
+        }
+        return substr($value, 0, $maxLength);
+    }
+}
+
+if (!function_exists('chimVisualContextStore')) {
+    function chimVisualContextStore(array $record): bool
+    {
+        $db = $GLOBALS['db'] ?? null;
+        if (!$db || !chimEnsureVisualContextTable()) {
+            return false;
+        }
+
+        $subjectType = chimVisualContextSubjectType($record['subject_type'] ?? 'scene');
+        $location = chimVisualContextText($record['location_name'] ?? '', 300);
+        $subjectName = chimVisualContextText($record['subject_name'] ?? '', 300);
+        $subjectKey = chimVisualContextText($record['subject_key'] ?? '', 500);
+        if ($subjectKey === '') {
+            $subjectKey = $subjectType . ':' . strtolower($subjectName !== '' ? $subjectName : $location);
+        }
+
+        $metadata = $record['metadata'] ?? [];
+        if (!is_array($metadata)) {
+            $metadata = [];
+        }
+        $metadataJson = json_encode($metadata, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($metadataJson === false) {
+            $metadataJson = '{}';
+        }
+
+        $query = "INSERT INTO public.visual_context (
+                subject_type, subject_key, subject_name, plugin, baseid, refid, cell_id,
+                location_name, image_path, image_sha256, description, perspective,
+                provider, model, metadata, locked, active, user_edited
+            ) VALUES (" . implode(', ', [
+                $db->escapeLiteral($subjectType),
+                $db->escapeLiteral($subjectKey),
+                $db->escapeLiteral($subjectName),
+                $db->escapeLiteral(chimVisualContextText($record['plugin'] ?? '', 255)),
+                $db->escapeLiteral(chimVisualContextText($record['baseid'] ?? '', 32)),
+                $db->escapeLiteral(chimVisualContextText($record['refid'] ?? '', 32)),
+                $db->escapeLiteral(chimVisualContextText($record['cell_id'] ?? '', 32)),
+                $db->escapeLiteral($location),
+                $db->escapeLiteral(chimVisualContextText($record['image_path'] ?? '', 1000)),
+                $db->escapeLiteral(chimVisualContextText($record['image_sha256'] ?? '', 64)),
+                $db->escapeLiteral(chimVisualContextText($record['description'] ?? '', 12000)),
+                $db->escapeLiteral(chimVisualContextText($record['perspective'] ?? 'first_person', 50)),
+                $db->escapeLiteral(chimVisualContextText($record['provider'] ?? '', 100)),
+                $db->escapeLiteral(chimVisualContextText($record['model'] ?? '', 255)),
+                $db->escapeLiteral($metadataJson) . '::jsonb',
+                !empty($record['locked']) ? 'TRUE' : 'FALSE',
+                array_key_exists('active', $record) && empty($record['active']) ? 'FALSE' : 'TRUE',
+                !empty($record['user_edited']) ? 'TRUE' : 'FALSE',
+            ]) . ')';
+
+        return $db->execQuery($query) !== false;
+    }
+}
+
+if (!function_exists('chimVisualContextList')) {
+    function chimVisualContextList(int $limit = 250): array
+    {
+        $db = $GLOBALS['db'] ?? null;
+        if (!$db || !chimEnsureVisualContextTable()) {
+            return [];
+        }
+        $limit = max(1, min($limit, 1000));
+        $rows = $db->fetchAll("SELECT * FROM public.visual_context ORDER BY locked DESC, captured_at DESC LIMIT {$limit}");
+        return is_array($rows) ? $rows : [];
+    }
+}
+
+if (!function_exists('chimVisualContextUpdate')) {
+    function chimVisualContextUpdate(int $id, array $values): bool
+    {
+        $db = $GLOBALS['db'] ?? null;
+        if ($id < 1 || !$db || !chimEnsureVisualContextTable()) {
+            return false;
+        }
+
+        $assignments = [];
+        if (array_key_exists('description', $values)) {
+            $assignments[] = 'description=' . $db->escapeLiteral(chimVisualContextText($values['description'], 12000));
+            $assignments[] = 'user_edited=TRUE';
+        }
+        foreach (['locked', 'active'] as $booleanKey) {
+            if (array_key_exists($booleanKey, $values)) {
+                $assignments[] = $booleanKey . '=' . (!empty($values[$booleanKey]) ? 'TRUE' : 'FALSE');
+            }
+        }
+        if (!$assignments) {
+            return false;
+        }
+        $assignments[] = 'updated_at=CURRENT_TIMESTAMP';
+        return $db->execQuery('UPDATE public.visual_context SET ' . implode(', ', $assignments) . ' WHERE id=' . intval($id)) !== false;
+    }
+}
+
+if (!function_exists('chimVisualContextDelete')) {
+    function chimVisualContextDelete(int $id): bool
+    {
+        $db = $GLOBALS['db'] ?? null;
+        return $id > 0 && $db && chimEnsureVisualContextTable()
+            ? $db->delete('public.visual_context', 'id=' . intval($id)) !== false
+            : false;
+    }
+}
+
+if (!function_exists('chimBuildVisualContextPrompt')) {
+    function chimBuildVisualContextPrompt(string $location): string
+    {
+        if (!chimGetGeneralSettingBool('VISUAL_CONTEXT_ENABLED', false)) {
+            return '';
+        }
+
+        $db = $GLOBALS['db'] ?? null;
+        $location = trim($location);
+        if (!$db || $location === '' || !chimEnsureVisualContextTable()) {
+            return '';
+        }
+
+        $ttlMinutes = max(1, min(chimGetGeneralSettingInt('VISUAL_CONTEXT_SCENE_TTL_MINUTES', 10), 1440));
+        $maxChars = max(200, min(chimGetGeneralSettingInt('VISUAL_CONTEXT_PROMPT_MAX_CHARS', 1800), 12000));
+        $locationLiteral = $db->escapeLiteral($location);
+        $rows = $db->fetchAll("SELECT subject_type, subject_name, description, captured_at
+            FROM public.visual_context
+            WHERE active = TRUE
+              AND description <> ''
+              AND LOWER(location_name) = LOWER({$locationLiteral})
+              AND (locked = TRUE OR captured_at >= CURRENT_TIMESTAMP - INTERVAL '{$ttlMinutes} minutes')
+            ORDER BY locked DESC, user_edited DESC, captured_at DESC
+            LIMIT 3");
+        if (!is_array($rows) || !$rows) {
+            return '';
+        }
+
+        $entries = [];
+        foreach ($rows as $row) {
+            $label = chimVisualContextText($row['subject_name'] ?? '', 120);
+            $description = chimVisualContextText($row['description'] ?? '', $maxChars);
+            if ($description === '') {
+                continue;
+            }
+            $entries[] = ($label !== '' ? $label . ': ' : '') . $description;
+        }
+        if (!$entries) {
+            return '';
+        }
+
+        $body = chimVisualContextText(implode("\n", $entries), $maxChars);
+        $body = htmlspecialchars($body, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        return "<visual_context>\n# RECENT VISUAL CONTEXT FOR THE CURRENT LOCATION\n{$body}\n</visual_context>";
+    }
+}

--- a/lib/visual_context.php
+++ b/lib/visual_context.php
@@ -74,6 +74,26 @@ if (!function_exists('chimVisualContextText')) {
     }
 }
 
+if (!function_exists('chimVisualContextLocationBase')) {
+    function chimVisualContextLocationBase($value): string
+    {
+        $value = html_entity_decode(chimVisualContextText($value, 1000), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        if ($value === '') {
+            return '';
+        }
+
+        if (preg_match('/Context\s*(?:new\s*)?location:\s*([^,\)]+)/iu', $value, $matches)) {
+            $value = $matches[1];
+        } else {
+            $value = preg_split('/,\s*Hold\s*:/iu', $value, 2)[0] ?? $value;
+            $value = preg_replace('/^(?:Location|Context\s*(?:new\s*)?location):\s*/iu', '', $value) ?? $value;
+        }
+
+        $value = preg_replace('/\s+/u', ' ', $value) ?? $value;
+        return chimVisualContextText(trim($value, " \t\n\r\0\x0B,()"), 300);
+    }
+}
+
 if (!function_exists('chimVisualContextStore')) {
     function chimVisualContextStore(array $record): bool
     {
@@ -182,18 +202,24 @@ if (!function_exists('chimBuildVisualContextPrompt')) {
     {
         $db = $GLOBALS['db'] ?? null;
         $location = trim($location);
-        if (!$db || $location === '' || !chimEnsureVisualContextTable()) {
+        $locationBase = chimVisualContextLocationBase($location);
+        if (!$db || $locationBase === '' || !chimEnsureVisualContextTable()) {
             return '';
         }
 
         $ttlMinutes = max(1, min(chimGetGeneralSettingInt('VISUAL_CONTEXT_SCENE_TTL_MINUTES', 10), 1440));
         $maxChars = max(200, min(chimGetGeneralSettingInt('VISUAL_CONTEXT_PROMPT_MAX_CHARS', 1800), 12000));
-        $locationLiteral = $db->escapeLiteral($location);
+        $locationLiteral = $db->escapeLiteral($locationBase);
         $rows = $db->fetchAll("SELECT subject_type, subject_name, description, captured_at
             FROM public.visual_context
             WHERE active = TRUE
               AND description <> ''
-              AND LOWER(location_name) = LOWER({$locationLiteral})
+              AND LOWER(BTRIM(REGEXP_REPLACE(
+                    SPLIT_PART(location_name, ',', 1),
+                    '^\\(?context[[:space:]]+(new[[:space:]]+)?location:[[:space:]]*',
+                    '',
+                    'i'
+                  ), ' ()')) = LOWER({$locationLiteral})
               AND (locked = TRUE OR captured_at >= CURRENT_TIMESTAMP - INTERVAL '{$ttlMinutes} minutes')
             ORDER BY locked DESC, user_edited DESC, captured_at DESC
             LIMIT 3");

--- a/lib/visual_context.php
+++ b/lib/visual_context.php
@@ -180,10 +180,6 @@ if (!function_exists('chimVisualContextDelete')) {
 if (!function_exists('chimBuildVisualContextPrompt')) {
     function chimBuildVisualContextPrompt(string $location): string
     {
-        if (!chimGetGeneralSettingBool('VISUAL_CONTEXT_ENABLED', false)) {
-            return '';
-        }
-
         $db = $GLOBALS['db'] ?? null;
         $location = trim($location);
         if (!$db || $location === '' || !chimEnsureVisualContextTable()) {

--- a/lib/visual_context.php
+++ b/lib/visual_context.php
@@ -94,6 +94,41 @@ if (!function_exists('chimVisualContextLocationBase')) {
     }
 }
 
+if (!function_exists('chimVisualContextFilenamePart')) {
+    function chimVisualContextFilenamePart($value, string $fallback, int $maxLength = 120): string
+    {
+        $value = html_entity_decode(chimVisualContextText($value, 500), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        if (function_exists('iconv')) {
+            $transliterated = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $value);
+            if ($transliterated !== false) {
+                $value = $transliterated;
+            }
+        }
+
+        $value = preg_replace('/[^A-Za-z0-9]+/', '_', $value) ?? '';
+        $value = trim($value, '_');
+        if ($value === '') {
+            $value = $fallback;
+        }
+
+        return substr($value, 0, max(1, $maxLength));
+    }
+}
+
+if (!function_exists('chimVisualContextGalleryFilename')) {
+    function chimVisualContextGalleryFilename($location, $gameDate, string $extension = 'jpg'): string
+    {
+        $locationPart = chimVisualContextFilenamePart(chimVisualContextLocationBase($location), 'Unknown_Location', 100);
+        $datePart = chimVisualContextFilenamePart($gameDate, 'Unknown_Skyrim_Time', 140);
+        $extension = strtolower(preg_replace('/[^A-Za-z0-9]/', '', $extension) ?? 'jpg');
+        if ($extension === '') {
+            $extension = 'jpg';
+        }
+
+        return $locationPart . '__' . $datePart . '.' . $extension;
+    }
+}
+
 if (!function_exists('chimVisualContextStore')) {
     function chimVisualContextStore(array $record): bool
     {

--- a/ui/cmd/gallery_delete.php
+++ b/ui/cmd/gallery_delete.php
@@ -23,10 +23,12 @@ if ($method === 'POST') {
     require_once $enginePath . "lib" . DIRECTORY_SEPARATOR . "chat_helper_functions.php";
     require_once $enginePath . "lib" . DIRECTORY_SEPARATOR . "data_functions.php";
     require_once $enginePath . "lib" . DIRECTORY_SEPARATOR . "logger.php";
+    require_once $enginePath . "lib" . DIRECTORY_SEPARATOR . "visual_context.php";
 
     $GLOBALS["ENGINE_PATH"] = $enginePath;
 
-    $source = $jsonDataInput["source"];
+    $source = $jsonDataInput["source"] ?? '';
+    $filename = '';
     $parsedUrl = parse_url($source);
     $path = $parsedUrl['path'];
     $pathParts = explode('/', trim($path, '/'));
@@ -38,11 +40,18 @@ if ($method === 'POST') {
         $filename  = "$enginePath/data/pictures/gallery/uploads/" .basename($source);
 
     error_log("Will delete $filename");
-    if ($filename)
+    if ($filename) {
         unlink($filename);
+        $relativeImagePath = 'data/pictures/gallery/' . (($lastFolder === 'uploads') ? 'uploads/' : '') . basename($source);
+        $db = $GLOBALS['db'] ?? null;
+        if ($db && chimEnsureVisualContextTable()) {
+            $db->delete('public.visual_context', 'image_path=' . $db->escapeLiteral($relativeImagePath));
+        }
+    }
     
 
-    $source = $jsonDataInput["sourceVid"];
+    $source = $jsonDataInput["sourceVid"] ?? '';
+    $filename = '';
     $parsedUrl = parse_url($source);
     $path = $parsedUrl['path'];
     $pathParts = explode('/', trim($path, '/'));

--- a/ui/soulgaze_gallery.php
+++ b/ui/soulgaze_gallery.php
@@ -229,7 +229,7 @@ foreach (chimVisualContextList(1000) as $record) {
                         </div>
                         <div class="visual-editor-options">
                             <input type="hidden" name="active" value="0">
-                            <label><input type="checkbox" name="active" value="1" <?= !empty($visualRecord['active']) && $visualRecord['active'] !== 'f' ? 'checked' : '' ?>> Active</label>
+                            <label><input type="checkbox" name="active" value="1" <?= !empty($visualRecord['active']) && $visualRecord['active'] !== 'f' ? 'checked' : '' ?>> Eligible for prompt use</label>
                             <input type="hidden" name="locked" value="0">
                             <label><input type="checkbox" name="locked" value="1" <?= !empty($visualRecord['locked']) && $visualRecord['locked'] !== 'f' ? 'checked' : '' ?>> Locked</label>
                             <button class="btn" type="submit" name="visual_context_action" value="save">Save</button>

--- a/ui/soulgaze_gallery.php
+++ b/ui/soulgaze_gallery.php
@@ -78,7 +78,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['visual_context_action
         chimVisualContextUpdate($recordId, [
             'description' => $_POST['description'] ?? '',
             'locked' => !empty($_POST['locked']),
-            'active' => !empty($_POST['active']),
         ]);
     } elseif ($action === 'delete') {
         chimVisualContextDelete($recordId);
@@ -228,10 +227,8 @@ foreach (chimVisualContextList(1000) as $record) {
                             <span><?= htmlspecialchars(strval($visualRecord['location_name'] ?? '')) ?></span>
                         </div>
                         <div class="visual-editor-options">
-                            <input type="hidden" name="active" value="0">
-                            <label><input type="checkbox" name="active" value="1" <?= !empty($visualRecord['active']) && $visualRecord['active'] !== 'f' ? 'checked' : '' ?>> Eligible for prompt use</label>
                             <input type="hidden" name="locked" value="0">
-                            <label><input type="checkbox" name="locked" value="1" <?= !empty($visualRecord['locked']) && $visualRecord['locked'] !== 'f' ? 'checked' : '' ?>> Locked</label>
+                            <label><input type="checkbox" name="locked" value="1" <?= !empty($visualRecord['locked']) && $visualRecord['locked'] !== 'f' ? 'checked' : '' ?>> Lock as Location Description</label>
                             <button class="btn" type="submit" name="visual_context_action" value="save">Save</button>
                             <button class="btn" type="submit" name="visual_context_action" value="delete" onclick="return confirm('Remove this visual context record? The image will remain in the gallery.');">Remove Record</button>
                         </div>

--- a/ui/soulgaze_gallery.php
+++ b/ui/soulgaze_gallery.php
@@ -13,6 +13,7 @@ if ($webRoot == '/') $webRoot = '';
 $webRoot = rtrim($webRoot, '/');
 
 require_once(__DIR__.DIRECTORY_SEPARATOR."profile_loader.php");
+require_once(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."lib".DIRECTORY_SEPARATOR."visual_context.php");
 
 $TITLE = "🖼️ Soulgaze Gallery - CHIM";
 
@@ -36,6 +37,11 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     .card { background:#2a2a2a; border:1px solid #4a4a4a; border-radius:8px; overflow:hidden; display:flex; flex-direction:column; }
     .thumb { width:100%; aspect-ratio:1/1; object-fit:cover; display:block; cursor:pointer; background:#1a1a1a; }
     .info { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:6px 8px; }
+    .visual-editor { border-top:1px solid #4a4a4a; padding:8px; display:grid; gap:7px; }
+    .visual-editor textarea { width:100%; min-height:76px; resize:vertical; box-sizing:border-box; border:1px solid #4a4a4a; border-radius:5px; background:#171717; color:#e9efff; padding:7px; font:inherit; font-size:12px; }
+    .visual-editor-meta { display:flex; align-items:center; justify-content:space-between; gap:8px; color:#9fb1c9; font-size:11px; }
+    .visual-editor-options { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
+    .visual-editor-options label { display:flex; gap:5px; align-items:center; color:#cfd9ea; font-size:11px; }
     .name { color:#e9efff; font-size:12px; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; }
     .actions { display:flex; gap:6px; }
     .btn { padding:4px 8px; border-radius:6px; border:1px solid #4a4a4a; background:#2a2a2a; color:#e9efff; text-decoration:none; cursor:pointer; font-size:12px; }
@@ -64,6 +70,26 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 
 $isEmbed = isset($_GET['embed']) && $_GET['embed'] == '1';
 $isPicker = isset($_GET['picker']) && $_GET['picker'] == '1';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['visual_context_action'])) {
+    $recordId = intval($_POST['visual_context_id'] ?? 0);
+    $action = strval($_POST['visual_context_action']);
+    if ($action === 'save') {
+        chimVisualContextUpdate($recordId, [
+            'description' => $_POST['description'] ?? '',
+            'locked' => !empty($_POST['locked']),
+            'active' => !empty($_POST['active']),
+        ]);
+    } elseif ($action === 'delete') {
+        chimVisualContextDelete($recordId);
+    }
+
+    $qs = [];
+    if ($isEmbed) $qs['embed'] = '1';
+    if ($isPicker) $qs['picker'] = '1';
+    header('Location: soulgaze_gallery.php' . (count($qs) ? ('?' . http_build_query($qs)) : ''));
+    exit;
+}
 
 // Handle direct uploads into the gallery
 $uploadError = '';
@@ -146,6 +172,18 @@ if ($rootFs && is_dir($rootFs)) {
 }
 // Sort newest first
 usort($images, function($a, $b){ return $b['mtime'] <=> $a['mtime']; });
+$visualByRel = [];
+foreach (chimVisualContextList(1000) as $record) {
+    $relativePath = str_replace('\\', '/', strval($record['image_path'] ?? ''));
+    $marker = 'data/pictures/gallery/';
+    $markerPosition = strpos($relativePath, $marker);
+    if ($markerPosition !== false) {
+        $relativePath = substr($relativePath, $markerPosition + strlen($marker));
+    }
+    if ($relativePath !== '') {
+        $visualByRel[$relativePath] = $record;
+    }
+}
 ?>
 
 <div class="container-fluid">
@@ -164,7 +202,7 @@ usort($images, function($a, $b){ return $b['mtime'] <=> $a['mtime']; });
         <div class="empty">No images found. Make sure to use the Soulgaze hotkey ingame to take pictures!</div>
     <?php else: ?>
         <div class="grid">
-            <?php foreach ($images as $img): $n = $img['name']; $u = $img['url']; ?>
+            <?php foreach ($images as $img): $n = $img['name']; $u = $img['url']; $visualRecord = $visualByRel[$img['rel']] ?? null; ?>
                 <div class="card" data-url="<?php echo htmlspecialchars($u); ?>">
                     <?php if ($img['type']=="mp4") {?>
                     <video class="vthumb thumb" controls src="<?php echo htmlspecialchars($u); ?>" alt="<?php echo htmlspecialchars($n); ?>" loading="lazy" ></video>
@@ -181,6 +219,24 @@ usort($images, function($a, $b){ return $b['mtime'] <=> $a['mtime']; });
                             <?php endif; ?>
                         </div>
                     </div>
+                    <?php if ($visualRecord): ?>
+                    <form method="post" class="visual-editor">
+                        <input type="hidden" name="visual_context_id" value="<?= intval($visualRecord['id']) ?>">
+                        <textarea name="description" aria-label="Visual description"><?= htmlspecialchars(strval($visualRecord['description'] ?? ''), ENT_QUOTES) ?></textarea>
+                        <div class="visual-editor-meta">
+                            <span><?= htmlspecialchars(ucfirst(strval($visualRecord['subject_type'] ?? 'scene'))) ?><?= !empty($visualRecord['subject_name']) ? ': ' . htmlspecialchars(strval($visualRecord['subject_name'])) : '' ?></span>
+                            <span><?= htmlspecialchars(strval($visualRecord['location_name'] ?? '')) ?></span>
+                        </div>
+                        <div class="visual-editor-options">
+                            <input type="hidden" name="active" value="0">
+                            <label><input type="checkbox" name="active" value="1" <?= !empty($visualRecord['active']) && $visualRecord['active'] !== 'f' ? 'checked' : '' ?>> Active</label>
+                            <input type="hidden" name="locked" value="0">
+                            <label><input type="checkbox" name="locked" value="1" <?= !empty($visualRecord['locked']) && $visualRecord['locked'] !== 'f' ? 'checked' : '' ?>> Locked</label>
+                            <button class="btn" type="submit" name="visual_context_action" value="save">Save</button>
+                            <button class="btn" type="submit" name="visual_context_action" value="delete" onclick="return confirm('Remove this visual context record? The image will remain in the gallery.');">Remove Record</button>
+                        </div>
+                    </form>
+                    <?php endif; ?>
                 </div>
             <?php endforeach; ?>
         </div>
@@ -293,6 +349,7 @@ function close(){ if (!lb) return; lb.style.display='none'; lbImg.removeAttribut
   document.addEventListener('click', function(e){
     const card = e.target && e.target.closest && e.target.closest('.card');
     if (!card) return;
+    if (e.target && e.target.closest && e.target.closest('.visual-editor')) return;
     const useBtn = e.target && e.target.classList && e.target.classList.contains('pick');
     const img = card.querySelector('.thumb');
     if (!img) return;

--- a/unittests/tests/VisualContextTest.php
+++ b/unittests/tests/VisualContextTest.php
@@ -22,4 +22,46 @@ final class VisualContextTest extends TestCase
     {
         $this->assertSame('{"model":"vision"}', chimVisualContextText(['model' => 'vision'], 100));
     }
+
+    public function testCurrentLocationContextIsAlwaysAvailableWithoutAnEnableSetting(): void
+    {
+        $GLOBALS['db'] = new class {
+            public function execQuery(string $query): bool
+            {
+                return true;
+            }
+
+            public function escapeLiteral($value): string
+            {
+                return "'" . str_replace("'", "''", strval($value)) . "'";
+            }
+
+            public function fetchOne(string $query): array
+            {
+                return [];
+            }
+
+            public function fetchAll(string $query): array
+            {
+                if (strpos($query, 'FROM public.visual_context') === false) {
+                    return [];
+                }
+
+                return [[
+                    'subject_type' => 'scene',
+                    'subject_name' => 'Riverwood square',
+                    'description' => 'Lantern light falls across the wet road.',
+                    'captured_at' => '2026-07-19 12:00:00+00',
+                ]];
+            }
+        };
+
+        try {
+            $prompt = chimBuildVisualContextPrompt('Riverwood');
+            $this->assertStringContainsString('<visual_context>', $prompt);
+            $this->assertStringContainsString('Lantern light falls across the wet road.', $prompt);
+        } finally {
+            unset($GLOBALS['db']);
+        }
+    }
 }

--- a/unittests/tests/VisualContextTest.php
+++ b/unittests/tests/VisualContextTest.php
@@ -23,9 +23,23 @@ final class VisualContextTest extends TestCase
         $this->assertSame('{"model":"vision"}', chimVisualContextText(['model' => 'vision'], 100));
     }
 
+    public function testLocationBaseNormalizesEventAndStoredFormats(): void
+    {
+        $this->assertSame(
+            'Riverwood outdoors',
+            chimVisualContextLocationBase("(Context location: Riverwood outdoors ,Hold: Whiterun, Buildings to go:Riverwood Trader)")
+        );
+        $this->assertSame(
+            'Riverwood outdoors',
+            chimVisualContextLocationBase('Riverwood outdoors ,Hold: Whiterun')
+        );
+    }
+
     public function testCurrentLocationContextIsAlwaysAvailableWithoutAnEnableSetting(): void
     {
-        $GLOBALS['db'] = new class {
+        $db = new class {
+            public string $lastQuery = '';
+
             public function execQuery(string $query): bool
             {
                 return true;
@@ -43,6 +57,7 @@ final class VisualContextTest extends TestCase
 
             public function fetchAll(string $query): array
             {
+                $this->lastQuery = $query;
                 if (strpos($query, 'FROM public.visual_context') === false) {
                     return [];
                 }
@@ -55,11 +70,13 @@ final class VisualContextTest extends TestCase
                 ]];
             }
         };
+        $GLOBALS['db'] = $db;
 
         try {
-            $prompt = chimBuildVisualContextPrompt('Riverwood');
+            $prompt = chimBuildVisualContextPrompt('(Context location: Riverwood, Hold: Whiterun)');
             $this->assertStringContainsString('<visual_context>', $prompt);
             $this->assertStringContainsString('Lantern light falls across the wet road.', $prompt);
+            $this->assertStringContainsString("LOWER('Riverwood')", $db->lastQuery);
         } finally {
             unset($GLOBALS['db']);
         }

--- a/unittests/tests/VisualContextTest.php
+++ b/unittests/tests/VisualContextTest.php
@@ -23,4 +23,3 @@ final class VisualContextTest extends TestCase
         $this->assertSame('{"model":"vision"}', chimVisualContextText(['model' => 'vision'], 100));
     }
 }
-

--- a/unittests/tests/VisualContextTest.php
+++ b/unittests/tests/VisualContextTest.php
@@ -35,6 +35,17 @@ final class VisualContextTest extends TestCase
         );
     }
 
+    public function testGalleryFilenameUsesLocationAndSkyrimTime(): void
+    {
+        $this->assertSame(
+            'Riverwood_outdoors__Tirdas_7_19_AM_19th_of_Last_Seed_4E_201.jpg',
+            chimVisualContextGalleryFilename(
+                'Riverwood outdoors ,Hold: Whiterun',
+                'Tirdas, 7:19 AM, 19th of Last Seed, 4E 201'
+            )
+        );
+    }
+
     public function testCurrentLocationContextIsAlwaysAvailableWithoutAnEnableSetting(): void
     {
         $db = new class {

--- a/unittests/tests/VisualContextTest.php
+++ b/unittests/tests/VisualContextTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'visual_context.php');
+
+final class VisualContextTest extends TestCase
+{
+    public function testSubjectTypeFallsBackToScene(): void
+    {
+        $this->assertSame('actor', chimVisualContextSubjectType('Actor'));
+        $this->assertSame('scene', chimVisualContextSubjectType('unsupported'));
+    }
+
+    public function testTextNormalizationRemovesControlCharactersAndLimitsLength(): void
+    {
+        $this->assertSame('abcdef', chimVisualContextText("abc\x00def", 20));
+        $this->assertSame('abcd', chimVisualContextText('abcdef', 4));
+    }
+
+    public function testStructuredValuesAreSerializedWithoutArrayWarnings(): void
+    {
+        $this->assertSame('{"model":"vision"}', chimVisualContextText(['model' => 'vision'], 100));
+    }
+}
+


### PR DESCRIPTION
## Summary
- persist successful image descriptions with location and stable subject metadata
- always include eligible current-location visual context with lifetime and size limits
- normalize event and stored location formats so fresh captures are actually injected
- add gallery controls to edit, lock as a location description, and remove visual records
- name new gallery captures from their location and Skyrim in-game date/time

## Behavior
- visual context is always enabled and has no separate enable toggle
- new captures are automatically eligible for prompt use
- unlocked records expire after the configured lifetime; records locked as location descriptions persist
- saving a gallery record changes only its description and location lock state
- location matching supports full context events and compact `location, Hold:` capture metadata
- new captures use readable names such as `Riverwood_outdoors__Tirdas_7_19_AM_19th_of_Last_Seed_4E_201.jpg`
- same-minute filename collisions receive a numeric suffix instead of overwriting an image
- existing hashed gallery images and database references remain valid
- no automatic background captures or additional image-model requests are introduced

## Validation
- PHP syntax and diff checks passed
- focused PHPUnit suite passed: 6 tests, 11 assertions
- database migration and record storage verified locally
- deployed runtime query retrieved the newest Riverwood capture in `<visual_context>`
- deployed source and runtime SHA-256 matched; Apache reloaded successfully
- Soulgaze gallery returned HTTP 200, displayed `Lock as Location Description`, and no longer exposed the eligibility control
