### PR TITLE
Add Background Life narrative pacing

### DIFF
--- a/debug/simple_llm_request_with_context_life_v2.php
+++ b/debug/simple_llm_request_with_context_life_v2.php
@@ -53,6 +53,7 @@ require_once $enginePath . 'lib/core/api_badge.class.php';
 require_once $enginePath . 'lib/core/core_profiles.class.php';
 require_once $enginePath . 'lib/core/llm_connector.class.php';
 require_once $enginePath . 'lib/core/tts_connector.class.php';
+require_once $enginePath . 'lib/core/bgl_narrative_pacing.php';
 require_once $enginePath . 'lib/lazy_xml.php';
 require_once $enginePath . 'debug/background_action_handler.php';
 
@@ -1000,6 +1001,10 @@ if ($isFullMode) {
 
 $step2Content .= "<text>\n$innerThoughtBuffer\n</text>\n\n";
 $step2Content .= $innerThoughtStyle . "\n\n";
+$pacingState = is_array($extdata['background_life_pacing'] ?? null)
+    ? $extdata['background_life_pacing']
+    : [];
+$step2Content .= chimBglPacingPromptBlock($pacingState) . "\n\n";
 
 
 $step2Content .= <<<PROMPT
@@ -1166,7 +1171,9 @@ $metadata = $npcMaster->getMetadata($currentNpcData);
 // ─── Update Background-Life Timestamp ────────────────────────────────────────
 
 $extdata['background_life_last_updated'] = $last_gamets;
-$npcMaster->updateExtendedKeysByName($npcName, $extdata);
+$npcMaster->updateExtendedKeysByName($npcName, [
+    'background_life_last_updated' => $last_gamets,
+]);
 
 
 // ─── Parse LLM Decision Response ─────────────────────────────────────────────
@@ -1188,37 +1195,49 @@ if ($isDryRun && $forceAction) {   // In dry-run mode (forceAction was enabled),
     die();
 }
 
+$pacingReview = chimBglPacingReviewAction(
+    (string) $parsed['action'],
+    $pacingState,
+    $LAST_REPORTED_LOCATION ?: (string) ($lastLocRow['location'] ?? ''),
+    $npcIsTravelling
+);
+if ($pacingReview['adjusted']) {
+    error_log("[BGL PACING] Replaced '{$parsed['action']}' with '{$pacingReview['action']}': {$pacingReview['reason']}");
+    $parsed['action'] = $pacingReview['action'];
+}
+
 $refHexString = convertSignedToUnsignedHex(hexdec($currentNpcData['refid']));
 
 // ─── Dispatch: Movement / Stay Action ────────────────────────────────────────
 $recordDiaryEntry = true;
+$actionHandled = false;
 if (!empty($parsed['action'])) {
     [$actionCmd, $actionArg] = array_pad(explode(':', $parsed['action'], 2), 2, null);
     error_log("[BGL RUN] Chosen action: $actionCmd, argument: $actionArg, reason: {$parsed['reason']}");
     $GLOBALS["LAST_REASON"] = $parsed['reason'];
     switch ($actionCmd) {
         case 'TravelTo':
-            handleTravelToAction($actionArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $lastEventParsed, $db);
+            $actionHandled = handleTravelToAction($actionArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $lastEventParsed, $db);
             unset($parsed['rumor']);   // Prevent rumor dispatch if MoveTo action is chosen
             break;
         case 'StayAtPlace':
             [$stayLocation, $stayIntent] = array_pad(explode(':', (string) $actionArg, 2), 2, '');
             $stayLocation = trim($stayLocation);
             $stayIntent = trim($stayIntent);
-            handleStayAtPlaceAction($stayLocation, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db, $stayIntent);
+            $actionHandled = handleStayAtPlaceAction($stayLocation, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db, $stayIntent);
             break;
         case 'ReturnHome':
-            handleReturnHome($actionArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db);
+            $actionHandled = handleReturnHome($actionArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db);
             unset($parsed['notification']);   // Prevent letter dispatch if ReturnHome action is chosen
             break;
         case 'FindNPC':
-            handleFindNPCAction($actionArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db, $LAST_REPORTED_LOCATION);
+            $actionHandled = handleFindNPCAction($actionArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db, $LAST_REPORTED_LOCATION);
             unset($parsed['notification']);   // Prevent letter dispatch if FindNPC action is chosen
             unset($parsed['rumor']);   // Prevent rumor dispatch if FindNPC action is chosen
             $recordDiaryEntry = false;
             break;
         case 'MoveTo':
-            handleMoveToAction($actionArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db);
+            $actionHandled = handleMoveToAction($actionArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db);
             unset($parsed['notification']);   // Prevent letter dispatch if MoveTo action is chosen
             unset($parsed['rumor']);   // Prevent rumor dispatch if MoveTo action is chosen
             $recordDiaryEntry = false;
@@ -1226,7 +1245,7 @@ if (!empty($parsed['action'])) {
         case 'SpeakTo':
             $historyWithInnerThought = $history
                 . "\n\n<inner_thought>\n{$innerThoughtBuffer}\n</inner_thought>\n";
-            handleSpeakToAction($actionArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db, $connectionHandler, $dynamicBiography, $historyWithInnerThought, $lastEventParsed['location']);
+            $actionHandled = handleSpeakToAction($actionArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db, $connectionHandler, $dynamicBiography, $historyWithInnerThought, $lastEventParsed['location'] ?? null);
             unset($parsed['notification']);   // Prevent letter dispatch if SpeakTo action is chosen
             //unset($parsed['rumor']);   // Prevent rumor dispatch if SpeakTo action is chosen
             $recordDiaryEntry = false;
@@ -1244,7 +1263,9 @@ if (!empty($parsed['action'])) {
                 $tradeCmd = trim($tradeCmd);
                 if ($tradeCmd !== 'BuyItem' && $tradeCmd !== 'SellItem')
                     continue;
-                handleTradeItemsAction($tradeCmd, $tradeArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db);
+                if (handleTradeItemsAction($tradeCmd, $tradeArg, $currentNpcData, $GLOBALS['HERIKA_NAME'], $last_ts, $last_gamets, $momentum, $db)) {
+                    $actionHandled = true;
+                }
             }
             unset($parsed['notification']);
             unset($parsed['rumor']);
@@ -1252,6 +1273,7 @@ if (!empty($parsed['action'])) {
             break;
         case 'Continue':
             error_log("[BGL RUN] Chosen action: Continue. No new action will be issued. Reason: {$parsed['reason']}");
+            $actionHandled = true;
             unset($parsed['notification']);
             unset($parsed['rumor']);
             $recordDiaryEntry = false;
@@ -1264,6 +1286,23 @@ if (!empty($parsed['action'])) {
             triggerNpcUpdate($GLOBALS['HERIKA_NAME'], ($extdata['background_life_last_updated_ec'] ?? 0) + 1);
             break;
     }
+}
+
+if ($actionHandled) {
+    $pacingState = chimBglPacingRecordAction(
+        $pacingState,
+        (string) $parsed['action'],
+        $last_gamets,
+        $bglTriggerHours,
+        (bool) $pacingReview['adjusted'],
+        (string) $pacingReview['reason']
+    );
+    $npcMaster->updateExtendedKeysByName($npcName, [
+        'background_life_last_updated' => $last_gamets,
+        'background_life_last_updated_ec' => 0,
+        'background_life_pacing' => $pacingState,
+    ]);
+    error_log("[BGL PACING] {$GLOBALS['HERIKA_NAME']} entered phase {$pacingState['phase']}; next cycle in {$pacingState['cadence_hours']} in-game hours.");
 }
 
 // ─── Dispatch: Letter / Notification (disabled) ─────────────────────────────

--- a/lib/core/bgl_narrative_pacing.php
+++ b/lib/core/bgl_narrative_pacing.php
@@ -1,0 +1,251 @@
+<?php
+
+const CHIM_BGL_GAMETS_TO_HOURS = 0.0000024;
+const CHIM_BGL_PACING_HISTORY_LIMIT = 6;
+const CHIM_BGL_PACING_REPEAT_LIMIT = 2;
+
+function chimBglPacingGametsForHours(float $hours): int
+{
+    return (int) round(max(0.0, $hours) / CHIM_BGL_GAMETS_TO_HOURS);
+}
+
+function chimBglPacingParseAction(string $action): array
+{
+    $action = trim($action);
+    [$rawCommand, $argument] = array_pad(explode(':', $action, 2), 2, '');
+    $commandLookup = [
+        'travelto' => 'TravelTo',
+        'stayatplace' => 'StayAtPlace',
+        'returnhome' => 'ReturnHome',
+        'findnpc' => 'FindNPC',
+        'moveto' => 'MoveTo',
+        'speakto' => 'SpeakTo',
+        'buyitem' => 'BuyItem',
+        'sellitem' => 'SellItem',
+        'continue' => 'Continue',
+    ];
+
+    $commandKey = strtolower(trim($rawCommand));
+    $command = $commandLookup[$commandKey] ?? trim($rawCommand);
+    $argument = trim(preg_replace('/\s+/', ' ', $argument) ?? $argument);
+
+    return [
+        'command' => $command,
+        'argument' => $argument,
+    ];
+}
+
+function chimBglPacingActionSignature(string $action): string
+{
+    $parts = chimBglPacingParseAction($action);
+    $command = strtolower($parts['command']);
+    $argument = $parts['argument'];
+
+    if (in_array($parts['command'], ['SpeakTo', 'MoveTo', 'FindNPC'], true)) {
+        $argument = explode(':', $argument, 2)[0] ?? '';
+    } elseif (in_array($parts['command'], ['BuyItem', 'SellItem'], true)) {
+        $firstTransaction = explode(',', $argument, 2)[0] ?? '';
+        $argument = explode(':', $firstTransaction, 2)[0] ?? '';
+    }
+
+    $argument = strtolower(trim(preg_replace('/\s+/', ' ', $argument) ?? $argument));
+    return $argument === '' ? $command : "$command:$argument";
+}
+
+function chimBglPacingPhaseForAction(string $action): string
+{
+    $command = chimBglPacingParseAction($action)['command'];
+
+    if (in_array($command, ['TravelTo', 'MoveTo', 'FindNPC', 'Continue'], true)) {
+        return 'transition';
+    }
+    if (in_array($command, ['SpeakTo', 'BuyItem', 'SellItem'], true)) {
+        return 'engagement';
+    }
+    if ($command === 'ReturnHome') {
+        return 'resolution';
+    }
+
+    return 'quiet';
+}
+
+function chimBglPacingCadenceHours(string $phase, float $baseHours, int $repeatCount = 1): float
+{
+    $baseHours = max(1.0, $baseHours);
+    $factor = [
+        'transition' => 0.25,
+        'engagement' => 0.5,
+        'resolution' => 0.75,
+        'quiet' => 1.0,
+    ][$phase] ?? 1.0;
+
+    $hours = max(1.0, $baseHours * $factor);
+    if ($repeatCount > 1) {
+        $hours *= 1.0 + (0.5 * min(2, $repeatCount - 1));
+    }
+
+    return min($baseHours, round($hours, 2));
+}
+
+function chimBglPacingReviewAction(
+    string $action,
+    array $state,
+    string $currentLocation = '',
+    bool $isTravelling = false
+): array {
+    $parts = chimBglPacingParseAction($action);
+    $signature = chimBglPacingActionSignature($action);
+    $lastSignature = (string) ($state['last_signature'] ?? '');
+    $repeatCount = (int) ($state['repeat_count'] ?? 0);
+    $reason = '';
+
+    if ($parts['command'] === 'Continue' && !$isTravelling) {
+        $reason = 'Continue was selected without an active journey.';
+    } elseif ($signature !== '' && $signature === $lastSignature && $repeatCount >= CHIM_BGL_PACING_REPEAT_LIMIT) {
+        $reason = 'The same background action was selected too many times in succession.';
+    }
+
+    if ($reason === '') {
+        return [
+            'action' => trim($action),
+            'adjusted' => false,
+            'reason' => '',
+        ];
+    }
+
+    $location = trim(str_replace(':', ' ', $currentLocation));
+    if ($location === '') {
+        $location = 'Current Location';
+    }
+
+    return [
+        'action' => "StayAtPlace:$location:Relax",
+        'adjusted' => true,
+        'reason' => $reason,
+    ];
+}
+
+function chimBglPacingRecordAction(
+    array $state,
+    string $action,
+    int $currentGamets,
+    float $baseHours,
+    bool $adjusted = false,
+    string $adjustmentReason = ''
+): array {
+    $signature = chimBglPacingActionSignature($action);
+    $lastSignature = (string) ($state['last_signature'] ?? '');
+    $repeatCount = $signature !== '' && $signature === $lastSignature
+        ? ((int) ($state['repeat_count'] ?? 0)) + 1
+        : 1;
+    $phase = chimBglPacingPhaseForAction($action);
+    $cadenceHours = chimBglPacingCadenceHours($phase, $baseHours, $repeatCount);
+    $recentActions = is_array($state['recent_actions'] ?? null) ? $state['recent_actions'] : [];
+
+    $recentActions[] = [
+        'action' => trim($action),
+        'signature' => $signature,
+        'phase' => $phase,
+        'gamets' => $currentGamets,
+        'adjusted' => $adjusted,
+    ];
+    $recentActions = array_slice($recentActions, -CHIM_BGL_PACING_HISTORY_LIMIT);
+
+    return [
+        'version' => 1,
+        'phase' => $phase,
+        'last_action' => trim($action),
+        'last_signature' => $signature,
+        'repeat_count' => $repeatCount,
+        'recent_actions' => array_values($recentActions),
+        'last_cycle_gamets' => $currentGamets,
+        'next_cycle_gamets' => $currentGamets + chimBglPacingGametsForHours($cadenceHours),
+        'cadence_hours' => $cadenceHours,
+        'last_adjustment_reason' => $adjusted ? trim($adjustmentReason) : '',
+    ];
+}
+
+function chimBglPacingIsDue(array $extendedData, int $currentGamets, float $baseHours): bool
+{
+    $state = is_array($extendedData['background_life_pacing'] ?? null)
+        ? $extendedData['background_life_pacing']
+        : [];
+    $nextCycle = (int) ($state['next_cycle_gamets'] ?? 0);
+    if ($nextCycle > 0) {
+        return $currentGamets >= $nextCycle;
+    }
+
+    $lastUpdated = (int) ($extendedData['background_life_last_updated'] ?? 0);
+    if ($lastUpdated <= 0) {
+        return true;
+    }
+
+    return $currentGamets >= ($lastUpdated + chimBglPacingGametsForHours($baseHours));
+}
+
+function chimBglPacingNextDueGamets(array $npcRow, float $baseHours): int
+{
+    $extendedData = json_decode((string) ($npcRow['extended_data'] ?? '{}'), true) ?: [];
+    $state = is_array($extendedData['background_life_pacing'] ?? null)
+        ? $extendedData['background_life_pacing']
+        : [];
+    $nextCycle = (int) ($state['next_cycle_gamets'] ?? 0);
+    if ($nextCycle > 0) {
+        return $nextCycle;
+    }
+
+    $lastUpdated = (int) ($extendedData['background_life_last_updated'] ?? 0);
+    return $lastUpdated > 0
+        ? $lastUpdated + chimBglPacingGametsForHours($baseHours)
+        : 0;
+}
+
+function chimBglPacingSortCandidates(array $npcRows, float $baseHours): array
+{
+    usort($npcRows, static function (array $left, array $right) use ($baseHours): int {
+        $dueComparison = chimBglPacingNextDueGamets($left, $baseHours)
+            <=> chimBglPacingNextDueGamets($right, $baseHours);
+        if ($dueComparison !== 0) {
+            return $dueComparison;
+        }
+
+        return strcasecmp((string) ($left['npc_name'] ?? ''), (string) ($right['npc_name'] ?? ''));
+    });
+
+    return $npcRows;
+}
+
+function chimBglPacingDefer(array $state, int $currentGamets, float $hours): array
+{
+    $state['version'] = 1;
+    $state['next_cycle_gamets'] = $currentGamets + chimBglPacingGametsForHours($hours);
+    $state['cadence_hours'] = max(1.0, $hours);
+    return $state;
+}
+
+function chimBglPacingPromptBlock(array $state): string
+{
+    $phase = (string) ($state['phase'] ?? 'unstarted');
+    $guidance = [
+        'transition' => 'Complete or meaningfully advance the current journey before starting an unrelated thread.',
+        'engagement' => 'Respond to the outcome of the interaction and avoid repeating the same conversation or exchange.',
+        'resolution' => 'Let consequences settle and prefer a believable return to routine over immediate new drama.',
+        'quiet' => 'A quiet routine is valid. Only begin a new objective when the context provides a concrete reason.',
+        'unstarted' => 'Choose a grounded first beat based on established goals and current circumstances.',
+    ][$phase] ?? 'Choose a grounded next beat that advances or settles the current thread.';
+
+    $recent = [];
+    foreach (array_slice((array) ($state['recent_actions'] ?? []), -4) as $entry) {
+        if (is_array($entry) && trim((string) ($entry['action'] ?? '')) !== '') {
+            $recent[] = trim((string) $entry['action']);
+        }
+    }
+    $recentText = empty($recent) ? 'None recorded.' : implode(' -> ', $recent);
+
+    return "<narrative_pacing>\n"
+        . "Current phase: $phase\n"
+        . "Recent background actions: $recentText\n"
+        . "Guidance: $guidance\n"
+        . "Do not repeat an identical action and target unless it is required to complete an unfinished journey.\n"
+        . "</narrative_pacing>";
+}

--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -21,6 +21,7 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
     require_once $enginePath . "lib/core/api_badge.class.php";
     require_once $enginePath . "lib/core/core_profiles.class.php";
     require_once $enginePath . "lib/core/llm_connector.class.php";
+    require_once $enginePath . "lib/core/bgl_narrative_pacing.php";
 
     /**
      * Process delayed events waiting for TTS to finish
@@ -111,10 +112,6 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
     $bglTriggerHours = chimGetBackgroundLifeTriggerHours();
     $bglTriggerHoursAgoGamets = $maxRow - ($bglTriggerHours / 0.0000024);
 
-    $bglTriggerHours = chimGetBackgroundLifeTriggerHours();
-    $bglTriggerDays = $bglTriggerHours/24;
-    $bglTriggerDaysAgoGamets=$maxRow - ( (24 * $bglTriggerDays) / 0.0000024);
-
 
     // BgL tracking coords, in-game daily
 
@@ -180,7 +177,7 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         $mwdata = json_decode($npc["extended_data"], true);
         // Trigger if never updated, or if last update is older than configured threshold
         $mustInstructBypassBgl=false;
-        if (!isset($mwdata["background_life_last_updated"]) || $mwdata["background_life_last_updated"] < ($bglTriggerDaysAgoGamets)) {
+        if (!isset($mwdata["background_life_last_updated"]) || $mwdata["background_life_last_updated"] < $bglTriggerHoursAgoGamets) {
             logger::info("[BGL] Passive event for {$npc["npc_name"]}");
 
 
@@ -210,6 +207,7 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
     
     // BgL commands
     $allEnabledBgLNpc = $GLOBALS["db"]->fetchAll("SELECT * FROM core_npc_master WHERE extended_data->>'background_life_enabled' = 'true' AND extended_data->>'background_life_commands' = 'true' ");
+    $allEnabledBgLNpc = chimBglPacingSortCandidates($allEnabledBgLNpc, $bglTriggerHours);
     foreach ($allEnabledBgLNpc as $npc) {
         $mwdata = json_decode($npc["extended_data"], true);
         $mustInstructBypassBgl=false;
@@ -247,9 +245,12 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         }
 
         // Trigger if never updated, or if last update is older than configured threshold
-        if (!isset($mwdata["background_life_last_updated"]) || $mwdata["background_life_last_updated"] < ($bglTriggerDaysAgoGamets)) {
-            $delta = ($mwdata["background_life_last_updated"] - $bglTriggerDaysAgoGamets) * 0.0000024;
-            error_log("[BGL] Event for {$npc["npc_name"]}, last updated: {$mwdata["background_life_last_updated"]}, threshold: {$bglTriggerDaysAgoGamets}, BGL_TRIGGER_DAYS: {$GLOBALS['BGL_TRIGGER_DAYS']}, delta: {$delta}, presence delta: {$mwdata["background_life_last_updated_presence_delta"]}");
+        if (chimBglPacingIsDue($mwdata, $maxRow, $bglTriggerHours)) {
+            $lastUpdated = (int) ($mwdata["background_life_last_updated"] ?? 0);
+            $presenceDelta = (int) ($mwdata["background_life_last_updated_presence_delta"] ?? 0);
+            $nextDue = chimBglPacingNextDueGamets($npc, $bglTriggerHours);
+            $delta = ($maxRow - $nextDue) * 0.0000024;
+            error_log("[BGL] Event for {$npc["npc_name"]}, last updated: {$lastUpdated}, next due: {$nextDue}, BGL_TRIGGER_HOURS: {$bglTriggerHours}, overdue hours: {$delta}, presence delta: {$presenceDelta}");
 
             if ($mustInstructBypassBgl){
                 error_log("[BGL] {$npc["npc_name"]} has been near a player for more than 10 checks. Issuing INSTRUCTION");
@@ -271,6 +272,10 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
                 $extended = json_decode($npcData["extended_data"], true);
                 $extended["background_life_last_updated"] = $maxRow;
                 $extended["background_life_last_updated_presence_delta"] = 0;
+                $pacingState = is_array($extended['background_life_pacing'] ?? null)
+                    ? $extended['background_life_pacing']
+                    : [];
+                $extended['background_life_pacing'] = chimBglPacingDefer($pacingState, $maxRow, $bglTriggerHours);
                 $npcData = $npcManager->setExtendedData($npcData, $extended);
                 $npcManager->updateByArray($npcData);
                 
@@ -283,8 +288,10 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
             }
             break;  // One per iteration - break after processing
         } else {
-            $delta = ($mwdata["background_life_last_updated"] - $bglTriggerHoursAgoGamets) * 0.0000024;
-            error_log("[BGL] Skipping {$npc["npc_name"]}, last updated: {$mwdata["background_life_last_updated"]}, threshold: {$bglTriggerHoursAgoGamets}, BGL_TRIGGER_HOURS: {$bglTriggerHours}, delta: {$delta}");
+            $lastUpdated = (int) ($mwdata["background_life_last_updated"] ?? 0);
+            $nextDue = chimBglPacingNextDueGamets($npc, $bglTriggerHours);
+            $hoursRemaining = max(0, ($nextDue - $maxRow) * 0.0000024);
+            error_log("[BGL] Skipping {$npc["npc_name"]}, last updated: {$lastUpdated}, next due: {$nextDue}, BGL_TRIGGER_HOURS: {$bglTriggerHours}, hours remaining: {$hoursRemaining}");
         }
     }
 

--- a/unittests/tests/BackgroundLifeNarrativePacingTest.php
+++ b/unittests/tests/BackgroundLifeNarrativePacingTest.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR
+    . 'lib' . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bgl_narrative_pacing.php');
+
+final class BackgroundLifeNarrativePacingTest extends TestCase
+{
+    public function testActionSignatureUsesMeaningfulTarget(): void
+    {
+        $this->assertSame('speakto:adrianne avenicci', chimBglPacingActionSignature('SpeakTo:Adrianne Avenicci:0001A67C'));
+        $this->assertSame('buyitem:belethor', chimBglPacingActionSignature('BuyItem:Belethor:00012EB7:1:10'));
+    }
+
+    public function testActionPhasesRepresentNarrativeBeatTypes(): void
+    {
+        $this->assertSame('transition', chimBglPacingPhaseForAction('TravelTo:Whiterun'));
+        $this->assertSame('engagement', chimBglPacingPhaseForAction('SpeakTo:Lydia:000A2C8E'));
+        $this->assertSame('resolution', chimBglPacingPhaseForAction('ReturnHome'));
+        $this->assertSame('quiet', chimBglPacingPhaseForAction('StayAtPlace:Bannered Mare:Relax'));
+    }
+
+    public function testCadenceKeepsActiveThreadsMovingWithoutExceedingBaseCooldown(): void
+    {
+        $this->assertSame(6.0, chimBglPacingCadenceHours('transition', 24.0));
+        $this->assertSame(12.0, chimBglPacingCadenceHours('engagement', 24.0));
+        $this->assertSame(18.0, chimBglPacingCadenceHours('resolution', 24.0));
+        $this->assertSame(24.0, chimBglPacingCadenceHours('quiet', 24.0));
+        $this->assertSame(12.0, chimBglPacingCadenceHours('transition', 24.0, 3));
+    }
+
+    public function testThirdIdenticalActionIsRedirectedToQuietBeat(): void
+    {
+        $state = [
+            'last_signature' => 'speakto:lydia',
+            'repeat_count' => 2,
+        ];
+
+        $review = chimBglPacingReviewAction('SpeakTo:Lydia:000A2C8E', $state, 'Dragonsreach (Interior)', false);
+
+        $this->assertTrue($review['adjusted']);
+        $this->assertSame('StayAtPlace:Dragonsreach (Interior):Relax', $review['action']);
+        $this->assertStringContainsString('too many times', $review['reason']);
+    }
+
+    public function testContinueIsOnlyAllowedDuringActiveJourney(): void
+    {
+        $blocked = chimBglPacingReviewAction('Continue', [], 'Whiterun', false);
+        $allowed = chimBglPacingReviewAction('Continue', [], 'Whiterun', true);
+
+        $this->assertTrue($blocked['adjusted']);
+        $this->assertFalse($allowed['adjusted']);
+        $this->assertSame('Continue', $allowed['action']);
+    }
+
+    public function testRecordingActionPersistsRecentBeatAndNextDueTime(): void
+    {
+        $state = chimBglPacingRecordAction([], 'TravelTo:Whiterun', 1000, 24.0);
+
+        $this->assertSame('transition', $state['phase']);
+        $this->assertSame(1, $state['repeat_count']);
+        $this->assertSame(6.0, $state['cadence_hours']);
+        $this->assertSame(1000 + chimBglPacingGametsForHours(6.0), $state['next_cycle_gamets']);
+        $this->assertCount(1, $state['recent_actions']);
+    }
+
+    public function testDueCheckUsesPacingStateAndLegacyTimestampFallback(): void
+    {
+        $this->assertFalse(chimBglPacingIsDue([
+            'background_life_pacing' => ['next_cycle_gamets' => 2000],
+        ], 1999, 24.0));
+        $this->assertTrue(chimBglPacingIsDue([
+            'background_life_pacing' => ['next_cycle_gamets' => 2000],
+        ], 2000, 24.0));
+
+        $baseGamets = chimBglPacingGametsForHours(24.0);
+        $this->assertFalse(chimBglPacingIsDue([
+            'background_life_last_updated' => 1000,
+        ], 999 + $baseGamets, 24.0));
+        $this->assertTrue(chimBglPacingIsDue([
+            'background_life_last_updated' => 1000,
+        ], 1000 + $baseGamets, 24.0));
+    }
+
+    public function testCandidateSortPrioritizesOldestDueNpc(): void
+    {
+        $rows = [
+            ['npc_name' => 'Later', 'extended_data' => json_encode(['background_life_pacing' => ['next_cycle_gamets' => 3000]])],
+            ['npc_name' => 'Never Run', 'extended_data' => '{}'],
+            ['npc_name' => 'Sooner', 'extended_data' => json_encode(['background_life_pacing' => ['next_cycle_gamets' => 2000]])],
+        ];
+
+        $sorted = chimBglPacingSortCandidates($rows, 24.0);
+
+        $this->assertSame(['Never Run', 'Sooner', 'Later'], array_column($sorted, 'npc_name'));
+    }
+
+    public function testPromptBlockExplainsCurrentPhaseAndRecentActions(): void
+    {
+        $prompt = chimBglPacingPromptBlock([
+            'phase' => 'engagement',
+            'recent_actions' => [
+                ['action' => 'MoveTo:Lydia'],
+                ['action' => 'SpeakTo:Lydia:000A2C8E'],
+            ],
+        ]);
+
+        $this->assertStringContainsString('<narrative_pacing>', $prompt);
+        $this->assertStringContainsString('Current phase: engagement', $prompt);
+        $this->assertStringContainsString('MoveTo:Lydia -> SpeakTo:Lydia:000A2C8E', $prompt);
+    }
+}


### PR DESCRIPTION
## Summary
- persist a compact narrative pacing state for each active Background Life NPC
- schedule journeys, interactions, resolutions, and quiet routines at phase-appropriate intervals derived from the existing trigger setting
- prioritize never-run and oldest-due NPCs to prevent scheduler starvation
- provide recent narrative beats to the action decision and redirect a third identical action loop to a quiet local activity
- preserve legacy timing for NPCs that do not yet have pacing state

## Validation
- PHP syntax checks for all changed files
- `BackgroundLife` tests: 14 passed, 36 assertions
- `CoreRequestStabilityTest`: 7 passed, 13 assertions
- `ActionCatalogTest`: 10 passed, 139 assertions
- full suite reaches database-backed tests but cannot complete in the isolated Windows worktree because PostgreSQL is unavailable