### PR TITLE
Add persistent faction politics context

### DIFF
--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -7225,6 +7225,17 @@ if ($checkVersion("master_packages")<20260716002) {
 
 }
 
+if ($checkVersion("faction_politics") < 20260719001) {
+    Logger::debug("Applying faction_politics 20260719001 - create persistent faction world-state tables");
+    $schemaFile = __DIR__ . "/../lib/core/database_schema/faction_politics.sql";
+    if (is_file($schemaFile) && $db->execQuery(file_get_contents($schemaFile))) {
+        $updateVersion("faction_politics", 20260719001);
+        Logger::info("Applied patch faction_politics 20260719001");
+    } else {
+        Logger::error("Failed to apply patch faction_politics 20260719001");
+    }
+}
+
 Logger::info(__FILE__." update file processed");
 
 //----------------------------------------------------

--- a/lib/core/database_schema/faction_politics.sql
+++ b/lib/core/database_schema/faction_politics.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS public.core_faction_politics_state (
+    faction_key text PRIMARY KEY,
+    faction_name text NOT NULL,
+    status text NOT NULL DEFAULT 'stable',
+    influence smallint NOT NULL DEFAULT 0 CHECK (influence BETWEEN -100 AND 100),
+    agenda text NOT NULL DEFAULT '',
+    summary text NOT NULL DEFAULT '',
+    gamets bigint NOT NULL DEFAULT 0,
+    created_at bigint NOT NULL DEFAULT 0,
+    updated_at bigint NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS public.core_faction_politics_relation (
+    faction_a_key text NOT NULL,
+    faction_a_name text NOT NULL,
+    faction_b_key text NOT NULL,
+    faction_b_name text NOT NULL,
+    stance text NOT NULL DEFAULT 'neutral',
+    score smallint NOT NULL DEFAULT 0 CHECK (score BETWEEN -100 AND 100),
+    summary text NOT NULL DEFAULT '',
+    gamets bigint NOT NULL DEFAULT 0,
+    created_at bigint NOT NULL DEFAULT 0,
+    updated_at bigint NOT NULL DEFAULT 0,
+    PRIMARY KEY (faction_a_key, faction_b_key),
+    CHECK (faction_a_key <> faction_b_key)
+);
+
+CREATE TABLE IF NOT EXISTS public.core_faction_politics_development (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    title text NOT NULL,
+    summary text NOT NULL,
+    faction_keys jsonb NOT NULL DEFAULT '[]'::jsonb,
+    status text NOT NULL DEFAULT 'active',
+    gamets bigint NOT NULL DEFAULT 0,
+    created_at bigint NOT NULL DEFAULT 0,
+    updated_at bigint NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS faction_politics_development_active_idx
+    ON public.core_faction_politics_development (status, gamets DESC, id DESC);

--- a/lib/core/faction_politics.php
+++ b/lib/core/faction_politics.php
@@ -1,0 +1,266 @@
+<?php
+
+function chimFactionPoliticsText($value): string
+{
+    return trim((string)$value);
+}
+
+function chimFactionPoliticsKey(array $faction): string
+{
+    $stableKey = chimFactionPoliticsText($faction['stable_key'] ?? '');
+    if ($stableKey !== '' && strpos($stableKey, '|') !== false) {
+        [$stablePlugin, $stableLocalFormId] = explode('|', $stableKey, 2);
+        $stableLocalFormId = preg_replace('/[^0-9a-f]/i', '', $stableLocalFormId);
+        if (trim($stablePlugin) !== '' && $stableLocalFormId !== '') {
+            return strtoupper(trim($stablePlugin)) . '|'
+                . strtoupper(str_pad($stableLocalFormId, 8, '0', STR_PAD_LEFT));
+        }
+    }
+
+    $plugin = chimFactionPoliticsText($faction['plugin'] ?? '');
+    $localFormId = preg_replace('/^0x/i', '', chimFactionPoliticsText($faction['local_formid'] ?? ''));
+    if ($plugin !== '' && $localFormId !== '' && ctype_xdigit($localFormId)) {
+        return strtoupper($plugin) . '|' . strtoupper(str_pad($localFormId, 8, '0', STR_PAD_LEFT));
+    }
+
+    $formId = preg_replace('/^0x/i', '', chimFactionPoliticsText($faction['formid'] ?? ''));
+    if ($formId !== '' && ctype_xdigit($formId)) {
+        return 'FORMID|' . strtoupper(str_pad($formId, 8, '0', STR_PAD_LEFT));
+    }
+
+    $name = strtolower(chimFactionPoliticsText($faction['name'] ?? ''));
+    $name = preg_replace('/[^a-z0-9]+/', '-', $name);
+    return $name === '' ? '' : 'NAME|' . trim($name, '-');
+}
+
+function chimFactionPoliticsName(array $faction, string $fallback = ''): string
+{
+    $name = chimFactionPoliticsText($faction['name'] ?? '');
+    return $name !== '' ? $name : chimFactionPoliticsText($fallback);
+}
+
+function chimFactionPoliticsCanonicalPair(string $keyA, string $nameA, string $keyB, string $nameB): array
+{
+    $left = [chimFactionPoliticsText($keyA), chimFactionPoliticsText($nameA)];
+    $right = [chimFactionPoliticsText($keyB), chimFactionPoliticsText($nameB)];
+    if (strcmp($left[0], $right[0]) > 0) {
+        [$left, $right] = [$right, $left];
+    }
+    return [$left[0], $left[1], $right[0], $right[1]];
+}
+
+function chimFactionPoliticsClamp($value): int
+{
+    return max(-100, min(100, (int)$value));
+}
+
+function chimFactionPoliticsEnum($value, array $allowed, string $fallback): string
+{
+    $value = strtolower(chimFactionPoliticsText($value));
+    return in_array($value, $allowed, true) ? $value : $fallback;
+}
+
+function chimFactionPoliticsDecodeExtendedData($value): array
+{
+    if (is_array($value)) {
+        return $value;
+    }
+    $decoded = json_decode((string)$value, true);
+    return is_array($decoded) ? $decoded : [];
+}
+
+function chimFactionPoliticsMembershipsFromNpcRows(array $npcRows): array
+{
+    $memberships = [];
+    foreach ($npcRows as $npcRow) {
+        $extendedData = chimFactionPoliticsDecodeExtendedData($npcRow['extended_data'] ?? []);
+        $factions = isset($extendedData['factions']) && is_array($extendedData['factions'])
+            ? $extendedData['factions']
+            : [];
+        foreach ($factions as $faction) {
+            if (!is_array($faction) || (isset($faction['rank']) && (int)$faction['rank'] < 0)) {
+                continue;
+            }
+            $key = chimFactionPoliticsKey($faction);
+            if ($key === '') {
+                continue;
+            }
+            $memberships[$key] = chimFactionPoliticsName($faction, $key);
+        }
+    }
+    ksort($memberships, SORT_NATURAL | SORT_FLAG_CASE);
+    return $memberships;
+}
+
+function chimFactionPoliticsSceneNames($currentNpcData, $cachePeople): array
+{
+    $names = [];
+    if (is_array($currentNpcData)) {
+        $currentName = chimFactionPoliticsText($currentNpcData['npc_name'] ?? '');
+        if ($currentName !== '') {
+            $names[strtolower($currentName)] = $currentName;
+        }
+    }
+    foreach (explode('|', (string)$cachePeople) as $name) {
+        $name = chimFactionPoliticsText($name);
+        if ($name !== '') {
+            $names[strtolower($name)] = $name;
+        }
+    }
+    return array_values($names);
+}
+
+function chimFactionPoliticsXml($value): string
+{
+    return htmlspecialchars(chimFactionPoliticsText($value), ENT_QUOTES | ENT_XML1, 'UTF-8');
+}
+
+function chimFactionPoliticsBuildContext(
+    array $memberships,
+    array $states,
+    array $relations,
+    array $developments,
+    int $developmentLimit = 5
+): string {
+    if (empty($memberships)) {
+        return '';
+    }
+
+    $relevantKeys = array_fill_keys(array_keys($memberships), true);
+    $lines = [];
+    foreach ($states as $state) {
+        $key = chimFactionPoliticsText($state['faction_key'] ?? '');
+        if (!isset($relevantKeys[$key])) {
+            continue;
+        }
+        $line = '- ' . chimFactionPoliticsXml($state['faction_name'] ?? $memberships[$key]);
+        $line .= ': ' . chimFactionPoliticsXml($state['status'] ?? 'stable');
+        $line .= ', influence ' . chimFactionPoliticsClamp($state['influence'] ?? 0);
+        if (chimFactionPoliticsText($state['agenda'] ?? '') !== '') {
+            $line .= '. Agenda: ' . chimFactionPoliticsXml($state['agenda']);
+        }
+        if (chimFactionPoliticsText($state['summary'] ?? '') !== '') {
+            $line .= '. ' . chimFactionPoliticsXml($state['summary']);
+        }
+        $lines[] = $line;
+    }
+
+    foreach ($relations as $relation) {
+        $keyA = chimFactionPoliticsText($relation['faction_a_key'] ?? '');
+        $keyB = chimFactionPoliticsText($relation['faction_b_key'] ?? '');
+        if (!isset($relevantKeys[$keyA]) && !isset($relevantKeys[$keyB])) {
+            continue;
+        }
+        $line = '- ' . chimFactionPoliticsXml($relation['faction_a_name'] ?? $keyA);
+        $line .= ' and ' . chimFactionPoliticsXml($relation['faction_b_name'] ?? $keyB);
+        $line .= ': ' . chimFactionPoliticsXml($relation['stance'] ?? 'neutral');
+        $line .= ' (' . chimFactionPoliticsClamp($relation['score'] ?? 0) . ')';
+        if (chimFactionPoliticsText($relation['summary'] ?? '') !== '') {
+            $line .= '. ' . chimFactionPoliticsXml($relation['summary']);
+        }
+        $lines[] = $line;
+    }
+
+    $developmentLimit = max(0, min(10, $developmentLimit));
+    $developmentCount = 0;
+    foreach ($developments as $development) {
+        if ($developmentCount >= $developmentLimit) {
+            break;
+        }
+        $keys = $development['faction_keys'] ?? [];
+        if (is_string($keys)) {
+            $keys = json_decode($keys, true);
+        }
+        if (!is_array($keys) || empty(array_intersect(array_keys($relevantKeys), $keys))) {
+            continue;
+        }
+        $line = '- Development: ' . chimFactionPoliticsXml($development['title'] ?? 'Political development');
+        if (chimFactionPoliticsText($development['summary'] ?? '') !== '') {
+            $line .= '. ' . chimFactionPoliticsXml($development['summary']);
+        }
+        $lines[] = $line;
+        $developmentCount++;
+    }
+
+    if (empty($lines)) {
+        return '';
+    }
+
+    return "\n<faction_politics>\n# CURRENT FACTION POLITICS\n"
+        . implode("\n", $lines)
+        . "\nUse this as current world state. Do not invent political changes that are not supported by events.\n</faction_politics>";
+}
+
+function chimFactionPoliticsTablesExist($db): bool
+{
+    try {
+        $row = $db->fetchOne("SELECT to_regclass('public.core_faction_politics_state') AS state_table");
+        return !empty($row['state_table']);
+    } catch (Throwable $e) {
+        return false;
+    }
+}
+
+function chimFactionPoliticsBuildSceneContext($db, $currentNpcData, $cachePeople, int $developmentLimit = 5): string
+{
+    if (!chimFactionPoliticsTablesExist($db)) {
+        return '';
+    }
+
+    $names = chimFactionPoliticsSceneNames($currentNpcData, $cachePeople);
+    if (empty($names)) {
+        return '';
+    }
+
+    $escapedNames = array_map(static fn($name) => "lower('" . $db->escape($name) . "')", $names);
+    try {
+        $npcRows = $db->fetchAll(
+            'SELECT npc_name, extended_data FROM core_npc_master WHERE lower(npc_name) IN ('
+            . implode(',', $escapedNames) . ')'
+        );
+        if (is_array($currentNpcData)) {
+            $npcRows[] = $currentNpcData;
+        }
+        $memberships = chimFactionPoliticsMembershipsFromNpcRows($npcRows);
+        if (empty($memberships)) {
+            return '';
+        }
+
+        $states = $db->fetchAll('SELECT * FROM core_faction_politics_state ORDER BY faction_name');
+        $relations = $db->fetchAll('SELECT * FROM core_faction_politics_relation ORDER BY faction_a_name, faction_b_name');
+        $developments = $db->fetchAll(
+            "SELECT * FROM core_faction_politics_development WHERE status = 'active' ORDER BY gamets DESC, id DESC LIMIT 50"
+        );
+        return chimFactionPoliticsBuildContext(
+            $memberships,
+            is_array($states) ? $states : [],
+            is_array($relations) ? $relations : [],
+            is_array($developments) ? $developments : [],
+            $developmentLimit
+        );
+    } catch (Throwable $e) {
+        return '';
+    }
+}
+
+function chimFactionPoliticsDetectedCatalog($db): array
+{
+    $catalog = [];
+    try {
+        $rows = $db->fetchAll('SELECT extended_data FROM core_npc_master WHERE extended_data IS NOT NULL');
+        foreach (chimFactionPoliticsMembershipsFromNpcRows(is_array($rows) ? $rows : []) as $key => $name) {
+            $catalog[$key] = $name;
+        }
+        $factions = $db->fetchAll("SELECT formid, name FROM factions WHERE name IS NOT NULL AND btrim(name) <> ''");
+        foreach (is_array($factions) ? $factions : [] as $faction) {
+            $key = chimFactionPoliticsKey($faction);
+            if ($key !== '' && !isset($catalog[$key])) {
+                $catalog[$key] = chimFactionPoliticsName($faction, $key);
+            }
+        }
+    } catch (Throwable $e) {
+        return $catalog;
+    }
+    natcasesort($catalog);
+    return $catalog;
+}

--- a/main.php
+++ b/main.php
@@ -2395,6 +2395,16 @@ if (isset($GLOBALS["PROMPT_NEARBY_SECTIONS"])) {
     $nearbySections = $GLOBALS["PROMPT_NEARBY_SECTIONS"];
 }
 
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'faction_politics.php';
+$factionPoliticsContext = chimFactionPoliticsBuildSceneContext(
+    $GLOBALS['db'],
+    $GLOBALS['CHIM_CORE_CURRENT_NPC_DATA'] ?? null,
+    $GLOBALS['CACHE_PEOPLE'] ?? ''
+);
+if ($factionPoliticsContext !== '') {
+    $nearbySections .= $factionPoliticsContext;
+}
+
 $promptInjectionContext = [
     "game_request" => $gameRequest,
     "herika_name" => function_exists('chimGetPromptCharacterName') ? chimGetPromptCharacterName() : ($GLOBALS["HERIKA_NAME"] ?? ""),

--- a/ui/events-memories.php
+++ b/ui/events-memories.php
@@ -511,7 +511,7 @@ if (isset($_GET['delete_memory']) && !empty($_GET['delete_memory'])) {
 
 // Get active tab from URL parameter, default to 'eventlog'
 $activeTab = isset($_GET['tab']) ? $_GET['tab'] : 'eventlog';
-$validTabs = ['eventlog', 'responselog', 'adventure', 'memory', 'diaries', 'books', 'soulgaze', 'quests', 'questgen', 'backgroundlife'];
+$validTabs = ['eventlog', 'responselog', 'adventure', 'memory', 'diaries', 'books', 'soulgaze', 'quests', 'questgen', 'backgroundlife', 'factionpolitics'];
 if (!in_array($activeTab, $validTabs, true)) {
     $activeTab = 'eventlog';
 }
@@ -1890,6 +1890,10 @@ function getTimeColor($time) {
 
         <div id="backgroundlife-tab" class="tab-content embed-tab <?php echo $activeTab === 'backgroundlife' ? 'active' : ''; ?>">
             <iframe class="embed-frame" title="Background Life" <?php echo $activeTab === 'backgroundlife' ? 'src' : 'data-src'; ?>="<?php echo $webRoot; ?>/ui/mapview.php"></iframe>
+        </div>
+
+        <div id="factionpolitics-tab" class="tab-content embed-tab <?php echo $activeTab === 'factionpolitics' ? 'active' : ''; ?>">
+            <iframe class="embed-frame" title="Faction Politics" <?php echo $activeTab === 'factionpolitics' ? 'src' : 'data-src'; ?>="<?php echo $webRoot; ?>/ui/faction_politics.php?embed=1"></iframe>
         </div>
     </div>
 </div>

--- a/ui/faction_politics.php
+++ b/ui/faction_politics.php
@@ -1,0 +1,321 @@
+<?php
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'profile_loader.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'faction_politics.php';
+
+$isEmbed = isset($_GET['embed']) && (string)$_GET['embed'] === '1';
+$scriptPath = $_SERVER['SCRIPT_NAME'] ?? '';
+$webRoot = rtrim(dirname(dirname($scriptPath)), '/');
+if ($webRoot === '/' || $webRoot === '.') {
+    $webRoot = '';
+}
+$db = $GLOBALS['db'];
+$TITLE = 'Faction Politics';
+
+if (empty($_SESSION['faction_politics_csrf'])) {
+    $_SESSION['faction_politics_csrf'] = bin2hex(random_bytes(24));
+}
+
+function factionPoliticsUiH($value): string
+{
+    return htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+}
+
+function factionPoliticsUiRedirect(bool $isEmbed, string $notice, string $type = 'ok'): void
+{
+    $query = ['notice' => $notice, 'notice_type' => $type];
+    if ($isEmbed) {
+        $query['embed'] = '1';
+    }
+    header('Location: faction_politics.php?' . http_build_query($query));
+    exit;
+}
+
+function factionPoliticsUiEscape($db, $value): string
+{
+    return $db->escape(chimFactionPoliticsText($value));
+}
+
+$tablesReady = chimFactionPoliticsTablesExist($db);
+$catalog = $tablesReady ? chimFactionPoliticsDetectedCatalog($db) : [];
+$states = $tablesReady ? $db->fetchAll('SELECT * FROM core_faction_politics_state ORDER BY lower(faction_name)') : [];
+$relations = $tablesReady ? $db->fetchAll('SELECT * FROM core_faction_politics_relation ORDER BY lower(faction_a_name), lower(faction_b_name)') : [];
+$developments = $tablesReady ? $db->fetchAll('SELECT * FROM core_faction_politics_development ORDER BY status, gamets DESC, id DESC') : [];
+foreach ($states as $state) {
+    $catalog[$state['faction_key']] = $state['faction_name'];
+}
+foreach ($relations as $relation) {
+    $catalog[$relation['faction_a_key']] = $relation['faction_a_name'];
+    $catalog[$relation['faction_b_key']] = $relation['faction_b_name'];
+}
+natcasesort($catalog);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!$tablesReady) {
+        factionPoliticsUiRedirect($isEmbed, 'Database update is not installed yet.', 'error');
+    }
+    $token = (string)($_POST['csrf_token'] ?? '');
+    if (!hash_equals((string)$_SESSION['faction_politics_csrf'], $token)) {
+        factionPoliticsUiRedirect($isEmbed, 'The form expired. Reload and try again.', 'error');
+    }
+
+    $action = (string)($_POST['action'] ?? '');
+    $now = time();
+    try {
+        if ($action === 'save_state') {
+            $key = substr(chimFactionPoliticsText($_POST['faction_key'] ?? ''), 0, 180);
+            $name = substr(chimFactionPoliticsText($catalog[$key] ?? ''), 0, 180);
+            if ($key === '' || $name === '') {
+                throw new RuntimeException('Choose a faction.');
+            }
+            $status = chimFactionPoliticsEnum(
+                $_POST['status'] ?? '',
+                ['stable', 'rising', 'declining', 'fractured', 'dominant', 'disbanded'],
+                'stable'
+            );
+            $influence = chimFactionPoliticsClamp($_POST['influence'] ?? 0);
+            $agenda = substr(chimFactionPoliticsText($_POST['agenda'] ?? ''), 0, 2000);
+            $summary = substr(chimFactionPoliticsText($_POST['summary'] ?? ''), 0, 4000);
+            $gamets = max(0, (int)($_POST['gamets'] ?? 0));
+            $db->execQuery(
+                "INSERT INTO core_faction_politics_state
+                    (faction_key, faction_name, status, influence, agenda, summary, gamets, created_at, updated_at)
+                 VALUES ('" . factionPoliticsUiEscape($db, $key) . "', '" . factionPoliticsUiEscape($db, $name) . "', '"
+                    . factionPoliticsUiEscape($db, $status) . "', {$influence}, '" . factionPoliticsUiEscape($db, $agenda) . "', '"
+                    . factionPoliticsUiEscape($db, $summary) . "', {$gamets}, {$now}, {$now})
+                 ON CONFLICT (faction_key) DO UPDATE SET
+                    faction_name = EXCLUDED.faction_name,
+                    status = EXCLUDED.status,
+                    influence = EXCLUDED.influence,
+                    agenda = EXCLUDED.agenda,
+                    summary = EXCLUDED.summary,
+                    gamets = EXCLUDED.gamets,
+                    updated_at = EXCLUDED.updated_at"
+            );
+            factionPoliticsUiRedirect($isEmbed, 'Faction state saved.');
+        }
+
+        if ($action === 'delete_state') {
+            $key = factionPoliticsUiEscape($db, $_POST['faction_key'] ?? '');
+            $db->execQuery("DELETE FROM core_faction_politics_state WHERE faction_key = '{$key}'");
+            factionPoliticsUiRedirect($isEmbed, 'Faction state deleted.');
+        }
+
+        if ($action === 'save_relation') {
+            [$keyA, $nameA, $keyB, $nameB] = chimFactionPoliticsCanonicalPair(
+                substr(chimFactionPoliticsText($_POST['faction_a_key'] ?? ''), 0, 180),
+                substr(chimFactionPoliticsText($catalog[$_POST['faction_a_key'] ?? ''] ?? ''), 0, 180),
+                substr(chimFactionPoliticsText($_POST['faction_b_key'] ?? ''), 0, 180),
+                substr(chimFactionPoliticsText($catalog[$_POST['faction_b_key'] ?? ''] ?? ''), 0, 180)
+            );
+            if ($keyA === '' || $keyB === '' || $keyA === $keyB) {
+                throw new RuntimeException('Choose two different factions.');
+            }
+            $stance = chimFactionPoliticsEnum(
+                $_POST['stance'] ?? '',
+                ['allied', 'friendly', 'neutral', 'tense', 'hostile', 'war'],
+                'neutral'
+            );
+            $score = chimFactionPoliticsClamp($_POST['score'] ?? 0);
+            $summary = substr(chimFactionPoliticsText($_POST['summary'] ?? ''), 0, 4000);
+            $gamets = max(0, (int)($_POST['gamets'] ?? 0));
+            $db->execQuery(
+                "INSERT INTO core_faction_politics_relation
+                    (faction_a_key, faction_a_name, faction_b_key, faction_b_name, stance, score, summary, gamets, created_at, updated_at)
+                 VALUES ('" . factionPoliticsUiEscape($db, $keyA) . "', '" . factionPoliticsUiEscape($db, $nameA) . "', '"
+                    . factionPoliticsUiEscape($db, $keyB) . "', '" . factionPoliticsUiEscape($db, $nameB) . "', '"
+                    . factionPoliticsUiEscape($db, $stance) . "', {$score}, '" . factionPoliticsUiEscape($db, $summary)
+                    . "', {$gamets}, {$now}, {$now})
+                 ON CONFLICT (faction_a_key, faction_b_key) DO UPDATE SET
+                    faction_a_name = EXCLUDED.faction_a_name,
+                    faction_b_name = EXCLUDED.faction_b_name,
+                    stance = EXCLUDED.stance,
+                    score = EXCLUDED.score,
+                    summary = EXCLUDED.summary,
+                    gamets = EXCLUDED.gamets,
+                    updated_at = EXCLUDED.updated_at"
+            );
+            factionPoliticsUiRedirect($isEmbed, 'Faction relation saved.');
+        }
+
+        if ($action === 'delete_relation') {
+            [$keyA, , $keyB] = chimFactionPoliticsCanonicalPair(
+                $_POST['faction_a_key'] ?? '',
+                '',
+                $_POST['faction_b_key'] ?? '',
+                ''
+            );
+            $db->execQuery(
+                "DELETE FROM core_faction_politics_relation WHERE faction_a_key = '"
+                . factionPoliticsUiEscape($db, $keyA) . "' AND faction_b_key = '"
+                . factionPoliticsUiEscape($db, $keyB) . "'"
+            );
+            factionPoliticsUiRedirect($isEmbed, 'Faction relation deleted.');
+        }
+
+        if ($action === 'save_development') {
+            $title = substr(chimFactionPoliticsText($_POST['title'] ?? ''), 0, 240);
+            $summary = substr(chimFactionPoliticsText($_POST['summary'] ?? ''), 0, 5000);
+            $keys = array_values(array_unique(array_filter(array_map(
+                static fn($key) => substr(chimFactionPoliticsText($key), 0, 180),
+                is_array($_POST['faction_keys'] ?? null) ? $_POST['faction_keys'] : []
+            ))));
+            if ($title === '' || $summary === '' || empty($keys)) {
+                throw new RuntimeException('A title, summary, and at least one faction are required.');
+            }
+            $status = chimFactionPoliticsEnum($_POST['status'] ?? '', ['active', 'resolved'], 'active');
+            $gamets = max(0, (int)($_POST['gamets'] ?? 0));
+            $json = factionPoliticsUiEscape($db, json_encode($keys, JSON_UNESCAPED_SLASHES));
+            $db->execQuery(
+                "INSERT INTO core_faction_politics_development
+                    (title, summary, faction_keys, status, gamets, created_at, updated_at)
+                 VALUES ('" . factionPoliticsUiEscape($db, $title) . "', '" . factionPoliticsUiEscape($db, $summary)
+                    . "', '{$json}'::jsonb, '" . factionPoliticsUiEscape($db, $status) . "', {$gamets}, {$now}, {$now})"
+            );
+            factionPoliticsUiRedirect($isEmbed, 'Political development added.');
+        }
+
+        if ($action === 'delete_development') {
+            $id = max(0, (int)($_POST['id'] ?? 0));
+            $db->execQuery("DELETE FROM core_faction_politics_development WHERE id = {$id}");
+            factionPoliticsUiRedirect($isEmbed, 'Political development deleted.');
+        }
+
+        if ($action === 'resolve_development') {
+            $id = max(0, (int)($_POST['id'] ?? 0));
+            $db->execQuery("UPDATE core_faction_politics_development SET status = 'resolved', updated_at = {$now} WHERE id = {$id}");
+            factionPoliticsUiRedirect($isEmbed, 'Political development resolved.');
+        }
+    } catch (Throwable $e) {
+        factionPoliticsUiRedirect($isEmbed, $e->getMessage(), 'error');
+    }
+}
+
+ob_start();
+include __DIR__ . DIRECTORY_SEPARATOR . 'tmpl' . DIRECTORY_SEPARATOR . 'head.html';
+if (!$isEmbed) {
+    include __DIR__ . DIRECTORY_SEPARATOR . 'tmpl' . DIRECTORY_SEPARATOR . 'navbar.php';
+}
+?>
+<link rel="stylesheet" href="<?php echo factionPoliticsUiH($webRoot); ?>/ui/css/main.css">
+<style>
+main { padding: <?php echo $isEmbed ? '18px 10px 36px' : '100px 10px 36px'; ?>; max-width: 1500px; margin: 0 auto; }
+.politics-header { text-align:center; margin-bottom:18px; }
+.politics-header h1 { margin:0 0 6px; color:#e6b76c; }
+.politics-grid { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:14px; align-items:start; }
+.politics-card { background:#222; border:1px solid #444; border-radius:8px; padding:16px; }
+.politics-card h2 { margin:0 0 12px; color:#e6b76c; font-size:1.2rem; }
+.politics-card label { display:block; margin:9px 0 4px; color:#ddd; font-weight:600; }
+.politics-card input,.politics-card select,.politics-card textarea { width:100%; box-sizing:border-box; background:#171717; color:#eee; border:1px solid #555; border-radius:5px; padding:8px; }
+.politics-card textarea { min-height:76px; resize:vertical; }
+.politics-card select[multiple] { min-height:125px; }
+.politics-actions { display:flex; gap:8px; margin-top:12px; flex-wrap:wrap; }
+.politics-list { margin-top:14px; display:grid; gap:8px; }
+.politics-row { border:1px solid #3e3e3e; border-radius:6px; padding:10px; background:#1b1b1b; }
+.politics-row strong { color:#fff; }
+.politics-meta { color:#aaa; font-size:.86rem; margin-top:4px; }
+.politics-row form { margin-top:8px; }
+.politics-notice { padding:10px 12px; margin-bottom:14px; border-radius:5px; background:#173f28; border:1px solid #2d8a50; }
+.politics-notice.error { background:#4b2020; border-color:#a94442; }
+.politics-empty { color:#999; padding:8px 0; }
+@media (max-width:1000px) { .politics-grid { grid-template-columns:1fr; } }
+</style>
+<main>
+    <div class="politics-header">
+        <h1>Faction Politics</h1>
+        <p>Track faction influence, relationships, and current political developments. Only politics relevant to NPCs in the current scene enters AI context.</p>
+    </div>
+    <?php if (isset($_GET['notice'])): ?>
+        <div class="politics-notice <?php echo ($_GET['notice_type'] ?? '') === 'error' ? 'error' : ''; ?>"><?php echo factionPoliticsUiH($_GET['notice']); ?></div>
+    <?php endif; ?>
+    <?php if (!$tablesReady): ?>
+        <div class="politics-notice error">Faction politics tables are unavailable. Run the database updater, then reload this page.</div>
+    <?php else: ?>
+    <div class="politics-grid">
+        <section class="politics-card">
+            <h2>Faction State</h2>
+            <form method="post">
+                <input type="hidden" name="csrf_token" value="<?php echo factionPoliticsUiH($_SESSION['faction_politics_csrf']); ?>">
+                <input type="hidden" name="action" value="save_state">
+                <label for="state-faction">Faction</label>
+                <select id="state-faction" name="faction_key" required data-faction-select>
+                    <option value="">Choose detected faction...</option>
+                    <?php foreach ($catalog as $key => $name): ?><option value="<?php echo factionPoliticsUiH($key); ?>" data-name="<?php echo factionPoliticsUiH($name); ?>"><?php echo factionPoliticsUiH($name); ?></option><?php endforeach; ?>
+                </select>
+                <label>Status</label>
+                <select name="status"><option>stable</option><option>rising</option><option>declining</option><option>fractured</option><option>dominant</option><option>disbanded</option></select>
+                <label>Influence (-100 to 100)</label><input type="number" name="influence" min="-100" max="100" value="0">
+                <label>Current agenda</label><input name="agenda" maxlength="2000">
+                <label>Summary</label><textarea name="summary" maxlength="4000"></textarea>
+                <label>Game timestamp</label><input type="number" name="gamets" min="0" value="0">
+                <div class="politics-actions"><button class="btn-base btn-primary" type="submit">Save State</button></div>
+            </form>
+            <div class="politics-list">
+                <?php foreach ($states as $state): ?><div class="politics-row">
+                    <strong><?php echo factionPoliticsUiH($state['faction_name']); ?></strong>
+                    <div><?php echo factionPoliticsUiH($state['status']); ?>, influence <?php echo (int)$state['influence']; ?></div>
+                    <?php if ($state['agenda'] !== ''): ?><div class="politics-meta">Agenda: <?php echo factionPoliticsUiH($state['agenda']); ?></div><?php endif; ?>
+                    <?php if ($state['summary'] !== ''): ?><div class="politics-meta"><?php echo factionPoliticsUiH($state['summary']); ?></div><?php endif; ?>
+                    <form method="post" onsubmit="return confirm('Delete this faction state?');"><input type="hidden" name="csrf_token" value="<?php echo factionPoliticsUiH($_SESSION['faction_politics_csrf']); ?>"><input type="hidden" name="action" value="delete_state"><input type="hidden" name="faction_key" value="<?php echo factionPoliticsUiH($state['faction_key']); ?>"><button class="btn-base btn-danger" type="submit">Delete</button></form>
+                </div><?php endforeach; ?>
+                <?php if (empty($states)): ?><div class="politics-empty">No faction states configured.</div><?php endif; ?>
+            </div>
+        </section>
+
+        <section class="politics-card">
+            <h2>Faction Relations</h2>
+            <form method="post">
+                <input type="hidden" name="csrf_token" value="<?php echo factionPoliticsUiH($_SESSION['faction_politics_csrf']); ?>"><input type="hidden" name="action" value="save_relation">
+                <label>First faction</label><select id="relation-a" name="faction_a_key" required data-faction-select><option value="">Choose faction...</option><?php foreach ($catalog as $key => $name): ?><option value="<?php echo factionPoliticsUiH($key); ?>" data-name="<?php echo factionPoliticsUiH($name); ?>"><?php echo factionPoliticsUiH($name); ?></option><?php endforeach; ?></select>
+                <label>Second faction</label><select id="relation-b" name="faction_b_key" required data-faction-select><option value="">Choose faction...</option><?php foreach ($catalog as $key => $name): ?><option value="<?php echo factionPoliticsUiH($key); ?>" data-name="<?php echo factionPoliticsUiH($name); ?>"><?php echo factionPoliticsUiH($name); ?></option><?php endforeach; ?></select>
+                <label>Stance</label><select name="stance"><option>allied</option><option>friendly</option><option selected>neutral</option><option>tense</option><option>hostile</option><option>war</option></select>
+                <label>Score (-100 to 100)</label><input type="number" name="score" min="-100" max="100" value="0">
+                <label>Summary</label><textarea name="summary" maxlength="4000"></textarea>
+                <label>Game timestamp</label><input type="number" name="gamets" min="0" value="0">
+                <div class="politics-actions"><button class="btn-base btn-primary" type="submit">Save Relation</button></div>
+            </form>
+            <div class="politics-list">
+                <?php foreach ($relations as $relation): ?><div class="politics-row">
+                    <strong><?php echo factionPoliticsUiH($relation['faction_a_name']); ?> / <?php echo factionPoliticsUiH($relation['faction_b_name']); ?></strong>
+                    <div><?php echo factionPoliticsUiH($relation['stance']); ?> (<?php echo (int)$relation['score']; ?>)</div>
+                    <?php if ($relation['summary'] !== ''): ?><div class="politics-meta"><?php echo factionPoliticsUiH($relation['summary']); ?></div><?php endif; ?>
+                    <form method="post" onsubmit="return confirm('Delete this faction relation?');"><input type="hidden" name="csrf_token" value="<?php echo factionPoliticsUiH($_SESSION['faction_politics_csrf']); ?>"><input type="hidden" name="action" value="delete_relation"><input type="hidden" name="faction_a_key" value="<?php echo factionPoliticsUiH($relation['faction_a_key']); ?>"><input type="hidden" name="faction_b_key" value="<?php echo factionPoliticsUiH($relation['faction_b_key']); ?>"><button class="btn-base btn-danger" type="submit">Delete</button></form>
+                </div><?php endforeach; ?>
+                <?php if (empty($relations)): ?><div class="politics-empty">No faction relations configured.</div><?php endif; ?>
+            </div>
+        </section>
+
+        <section class="politics-card">
+            <h2>Political Developments</h2>
+            <form method="post">
+                <input type="hidden" name="csrf_token" value="<?php echo factionPoliticsUiH($_SESSION['faction_politics_csrf']); ?>"><input type="hidden" name="action" value="save_development">
+                <label>Title</label><input name="title" maxlength="240" required>
+                <label>Involved factions</label><select name="faction_keys[]" multiple required><?php foreach ($catalog as $key => $name): ?><option value="<?php echo factionPoliticsUiH($key); ?>"><?php echo factionPoliticsUiH($name); ?></option><?php endforeach; ?></select>
+                <label>Status</label><select name="status"><option>active</option><option>resolved</option></select>
+                <label>Summary</label><textarea name="summary" maxlength="5000" required></textarea>
+                <label>Game timestamp</label><input type="number" name="gamets" min="0" value="0">
+                <div class="politics-actions"><button class="btn-base btn-primary" type="submit">Add Development</button></div>
+            </form>
+            <div class="politics-list">
+                <?php foreach ($developments as $development): ?><div class="politics-row">
+                    <strong><?php echo factionPoliticsUiH($development['title']); ?></strong> <span class="politics-meta"><?php echo factionPoliticsUiH($development['status']); ?></span>
+                    <div class="politics-meta"><?php echo factionPoliticsUiH($development['summary']); ?></div>
+                    <div class="politics-actions">
+                        <?php if ($development['status'] === 'active'): ?><form method="post"><input type="hidden" name="csrf_token" value="<?php echo factionPoliticsUiH($_SESSION['faction_politics_csrf']); ?>"><input type="hidden" name="action" value="resolve_development"><input type="hidden" name="id" value="<?php echo (int)$development['id']; ?>"><button class="btn-base btn-secondary" type="submit">Resolve</button></form><?php endif; ?>
+                        <form method="post" onsubmit="return confirm('Delete this political development?');"><input type="hidden" name="csrf_token" value="<?php echo factionPoliticsUiH($_SESSION['faction_politics_csrf']); ?>"><input type="hidden" name="action" value="delete_development"><input type="hidden" name="id" value="<?php echo (int)$development['id']; ?>"><button class="btn-base btn-danger" type="submit">Delete</button></form>
+                    </div>
+                </div><?php endforeach; ?>
+                <?php if (empty($developments)): ?><div class="politics-empty">No political developments configured.</div><?php endif; ?>
+            </div>
+        </section>
+    </div>
+    <?php endif; ?>
+</main>
+<?php
+if (!$isEmbed) {
+    include __DIR__ . DIRECTORY_SEPARATOR . 'tmpl' . DIRECTORY_SEPARATOR . 'footer.html';
+}
+$buffer = ob_get_contents();
+ob_end_clean();
+$buffer = preg_replace('/(<title>)(.*?)(<\/title>)/i', '$1' . $TITLE . '$3', $buffer);
+echo $buffer;
+?>

--- a/ui/tmpl/events_memories_navigation.php
+++ b/ui/tmpl/events_memories_navigation.php
@@ -33,6 +33,7 @@ $eventsMemoriesGroups = [
             ['key' => 'quests', 'label' => 'Active Quests', 'icon' => '&#x1F3AF;', 'href' => $eventsMemoriesUiRoot . '/events-memories.php?tab=quests'],
             ['key' => 'questgen', 'label' => 'AI Quest Manager', 'icon' => '&#x1F9ED;', 'href' => $eventsMemoriesUiRoot . '/events-memories.php?tab=questgen'],
             ['key' => 'backgroundlife', 'label' => 'Background Life', 'icon' => '&#x1F5FA;&#xFE0F;', 'href' => $eventsMemoriesUiRoot . '/events-memories.php?tab=backgroundlife'],
+            ['key' => 'factionpolitics', 'label' => 'Faction Politics', 'icon' => '&#x2696;&#xFE0F;', 'href' => $eventsMemoriesUiRoot . '/events-memories.php?tab=factionpolitics'],
         ],
     ],
 ];

--- a/unittests/tests/FactionPoliticsTest.php
+++ b/unittests/tests/FactionPoliticsTest.php
@@ -1,0 +1,145 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/core/faction_politics.php';
+
+final class FactionPoliticsTest extends TestCase
+{
+    public function testFactionKeyPrefersStablePluginReference(): void
+    {
+        $this->assertSame(
+            'MYSOCIETY.ESP|00001234',
+            chimFactionPoliticsKey([
+                'stable_key' => 'MySociety.esp|001234',
+                'formid' => 'FE012345',
+                'name' => 'My Society',
+            ])
+        );
+        $this->assertSame('FORMID|0005C84D', chimFactionPoliticsKey(['formid' => '5c84d']));
+        $this->assertSame('NAME|unnamed-circle', chimFactionPoliticsKey(['name' => 'Unnamed Circle']));
+    }
+
+    public function testCanonicalPairIsIndependentOfInputOrder(): void
+    {
+        $this->assertSame(
+            ['A', 'Faction A', 'B', 'Faction B'],
+            chimFactionPoliticsCanonicalPair('B', 'Faction B', 'A', 'Faction A')
+        );
+    }
+
+    public function testMembershipsIgnoreInactiveFactionRanks(): void
+    {
+        $memberships = chimFactionPoliticsMembershipsFromNpcRows([[
+            'extended_data' => json_encode(['factions' => [
+                ['stable_key' => 'Guards.esp|00000001', 'name' => 'City Guard', 'rank' => 0],
+                ['stable_key' => 'Guild.esp|00000002', 'name' => 'Former Guild', 'rank' => -1],
+            ]]),
+        ]]);
+
+        $this->assertSame(['GUARDS.ESP|00000001' => 'City Guard'], $memberships);
+    }
+
+    public function testContextIncludesOnlyPoliticsConnectedToSceneFactions(): void
+    {
+        $context = chimFactionPoliticsBuildContext(
+            ['GUARDS' => 'City Guard'],
+            [
+                ['faction_key' => 'GUARDS', 'faction_name' => 'City Guard', 'status' => 'rising', 'influence' => 25, 'agenda' => 'Secure the roads', 'summary' => 'Recruiting patrols'],
+                ['faction_key' => 'MAGES', 'faction_name' => 'Mage Circle', 'status' => 'stable', 'influence' => 10],
+            ],
+            [
+                ['faction_a_key' => 'GUARDS', 'faction_a_name' => 'City Guard', 'faction_b_key' => 'MERCHANTS', 'faction_b_name' => 'Merchants', 'stance' => 'friendly', 'score' => 30, 'summary' => 'Shared road patrols'],
+                ['faction_a_key' => 'MAGES', 'faction_a_name' => 'Mage Circle', 'faction_b_key' => 'THIEVES', 'faction_b_name' => 'Thieves', 'stance' => 'hostile', 'score' => -80],
+            ],
+            [
+                ['title' => 'Caravan protected', 'summary' => 'A caravan arrived safely.', 'faction_keys' => json_encode(['GUARDS'])],
+                ['title' => 'Secret duel', 'summary' => 'Unrelated.', 'faction_keys' => json_encode(['MAGES'])],
+            ]
+        );
+
+        $this->assertStringContainsString('City Guard: rising, influence 25', $context);
+        $this->assertStringContainsString('City Guard and Merchants: friendly (30)', $context);
+        $this->assertStringContainsString('Caravan protected', $context);
+        $this->assertStringNotContainsString('Mage Circle', $context);
+        $this->assertStringNotContainsString('Secret duel', $context);
+    }
+
+    public function testContextEscapesMarkupAndHonorsDevelopmentLimit(): void
+    {
+        $context = chimFactionPoliticsBuildContext(
+            ['A' => 'A'],
+            [],
+            [],
+            [
+                ['title' => '<first>', 'summary' => 'One & two', 'faction_keys' => ['A']],
+                ['title' => 'second', 'summary' => 'Hidden', 'faction_keys' => ['A']],
+            ],
+            1
+        );
+
+        $this->assertStringContainsString('&lt;first&gt;', $context);
+        $this->assertStringContainsString('One &amp; two', $context);
+        $this->assertStringNotContainsString('second', $context);
+    }
+
+    public function testNoMembershipOrNoRelevantRecordsAddsNoPromptText(): void
+    {
+        $this->assertSame('', chimFactionPoliticsBuildContext([], [], [], []));
+        $this->assertSame('', chimFactionPoliticsBuildContext(['A' => 'A'], [], [], []));
+    }
+
+    public function testSceneLoaderUsesCurrentAndNearbyNpcMemberships(): void
+    {
+        $db = new class {
+            public array $queries = [];
+
+            public function escape(string $value): string
+            {
+                return str_replace("'", "''", $value);
+            }
+
+            public function fetchOne(string $query): array
+            {
+                return ['state_table' => 'core_faction_politics_state'];
+            }
+
+            public function fetchAll(string $query): array
+            {
+                $this->queries[] = $query;
+                if (str_contains($query, 'FROM core_npc_master')) {
+                    return [[
+                        'npc_name' => 'Nearby NPC',
+                        'extended_data' => json_encode(['factions' => [[
+                            'stable_key' => 'Nearby.esp|00000010',
+                            'name' => 'Nearby Faction',
+                            'rank' => 0,
+                        ]]]),
+                    ]];
+                }
+                if (str_contains($query, 'FROM core_faction_politics_state')) {
+                    return [[
+                        'faction_key' => 'CURRENT.ESP|00000001',
+                        'faction_name' => 'Current Faction',
+                        'status' => 'dominant',
+                        'influence' => 80,
+                    ]];
+                }
+                return [];
+            }
+        };
+
+        $context = chimFactionPoliticsBuildSceneContext($db, [
+            'npc_name' => 'Current NPC',
+            'extended_data' => json_encode(['factions' => [[
+                'stable_key' => 'Current.esp|00000001',
+                'name' => 'Current Faction',
+                'rank' => 0,
+            ]]]),
+        ], '|Nearby NPC|');
+
+        $this->assertStringContainsString('Current Faction: dominant', $context);
+        $this->assertStringContainsString("lower('Nearby NPC')", $db->queries[0]);
+        $this->assertStringContainsString("lower('Current NPC')", $db->queries[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- add persistent faction state, inter-faction relations, and political developments
- expose a Faction Politics editor in the Roleplay hub using detected plugin-aware faction identities
- inject only political records relevant to the speaking NPC and factions represented in the current scene
- keep unconfigured installs prompt-neutral

## Validation
- `php -l` passed for every changed PHP file
- `php unittests/vendor/bin/phpunit unittests/tests/FactionPoliticsTest.php --colors=never` (7 tests, 18 assertions)
- `git diff --check`
- outgoing diff contains no compiled game artifacts

## Full suite note
The full suite reaches 123 tests before failing in existing database integration setup: PostgreSQL connectivity is lost on the Windows harness and several tests call the pre-existing missing `sql::escapeLiteral()` method. The focused faction-politics tests pass independently.