### PR TITLE
Allow narrator recall of diary memories

### DIFF
--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -7487,6 +7487,25 @@ if ($checkVersion("prompts") < 20260719001) {
     Logger::info("Applied patch prompts 20260719001 - improved book reading prompt");
 }
 
+if ($checkVersion("memory_summary") < 20260721001) {
+    Logger::debug("Applying memory_summary 20260721001 - normalize diary memory owners");
+
+    $migrationOk = $db->execQuery("
+        UPDATE public.memory_summary
+        SET companions = '|' || trim(both '|' from trim(companions)) || '|'
+        WHERE classifier = 'diary'
+          AND nullif(trim(companions), '') IS NOT NULL
+          AND companions NOT LIKE '|%|'
+    ") !== false;
+
+    if ($migrationOk) {
+        $updateVersion("memory_summary", 20260721001);
+        Logger::info("Applied patch memory_summary 20260721001");
+    } else {
+        Logger::error("Failed to apply patch memory_summary 20260721001");
+    }
+}
+
 
 // master Packages update 
 if ($checkVersion("master_packages")<20260716002) {

--- a/lib/core/narrator.class.php
+++ b/lib/core/narrator.class.php
@@ -365,6 +365,7 @@ class Narrator
             ],
             'diary_enabled' => ['NARRATOR_DIARY_ENABLED', 'bool', false],
             'auto_diary_enabled' => ['NARRATOR_AUTO_DIARY_ENABLED', 'bool', false],
+            'only_diary_access' => ['NARRATOR_ONLY_DIARY_ACCESS', 'bool', false],
             'connector_id' => ['NARRATOR_CONNECTOR_ID', 'int', null],
             'diary_connector_id' => ['NARRATOR_DIARY_CONNECTOR_ID', 'int', null],
         ];

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -4815,12 +4815,26 @@ function dataGetMemoryScopeConditionSql($npcName)
     return "(scope IS NULL OR scope='global')";
 }
 
-function dataGetMemoryCompanionConditionSql($npcName, string $column = 'companions'): string
+function dataGetMemoryCompanionConditionSql(
+    $npcName,
+    string $column = 'companions',
+    string $classifierColumn = 'classifier'
+): string
 {
     $npcName = trim((string)$npcName);
     if ($npcName === '') {
-        // The narrator intentionally searches the global memory bank.
-        return 'TRUE';
+        $narratorOnlyDiaryAccess = filter_var(
+            $GLOBALS['NARRATOR_ONLY_DIARY_ACCESS'] ?? false,
+            FILTER_VALIDATE_BOOLEAN
+        );
+        if (!$narratorOnlyDiaryAccess) {
+            // By default, the narrator searches every NPC diary in the global memory bank.
+            return 'TRUE';
+        }
+
+        $narratorName = $GLOBALS['db']->escape('The Narrator');
+        return "(COALESCE($classifierColumn, '') NOT IN ('diary','auto_diary','backgroundlife_diary')"
+            . " OR $column LIKE '%|$narratorName|%' OR $column='$narratorName')";
     }
 
     $npcEsc = $GLOBALS['db']->escape($npcName);
@@ -4944,7 +4958,7 @@ function DataSearchMemory($rawstring,$npcfilter) {
     
     
     $scopeConditionSql = dataGetMemoryScopeConditionSql($npcfilter);
-    $companionConditionSql = dataGetMemoryCompanionConditionSql($npcfilter, 'A.companions');
+    $companionConditionSql = dataGetMemoryCompanionConditionSql($npcfilter, 'A.companions', 'A.classifier');
 
     $memory=$GLOBALS["db"]->fetchAll("
         SELECT summary,gamets_truncated,

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -4092,7 +4092,12 @@ function PackIntoSummary($onlyMissingDiary=false)
     
     if ($onlyMissingDiary) {
         $results = $db->query("insert into memory_summary (gamets_truncated,n,packed_message,summary,classifier,uid,companions,scope)
-        select gamets,1,message,message,'diary',uid,speaker,'global'
+        select gamets,1,message,message,'diary',uid,
+            case
+                when nullif(trim(speaker), '') is null then ''
+                else '|' || trim(both '|' from trim(speaker)) || '|'
+            end,
+            'global'
         from memory
         where event in ('diary','auto_diary','backgroundlife_diary')
         and uid not in (select uid from memory_summary where classifier in  ('diary','auto_diary','backgroundlife_diary'))");
@@ -4204,7 +4209,12 @@ function PackIntoSummary($onlyMissingDiary=false)
         $results = $db->query($query);
         
         $results = $db->query("insert into memory_summary (gamets_truncated,n,packed_message,summary,classifier,uid,companions,scope)
-                                    select gamets,1,message,message,'diary',uid,speaker,'global'
+                                    select gamets,1,message,message,'diary',uid,
+                                        case
+                                            when nullif(trim(speaker), '') is null then ''
+                                            else '|' || trim(both '|' from trim(speaker)) || '|'
+                                        end,
+                                        'global'
                                     from memory
                                     where event='diary'
                                     and gamets>$maxRow
@@ -4805,6 +4815,18 @@ function dataGetMemoryScopeConditionSql($npcName)
     return "(scope IS NULL OR scope='global')";
 }
 
+function dataGetMemoryCompanionConditionSql($npcName, string $column = 'companions'): string
+{
+    $npcName = trim((string)$npcName);
+    if ($npcName === '') {
+        // The narrator intentionally searches the global memory bank.
+        return 'TRUE';
+    }
+
+    $npcEsc = $GLOBALS['db']->escape($npcName);
+    return "($column LIKE '%|$npcEsc|%' OR $column='$npcEsc')";
+}
+
 function DataSearchMemory($rawstring,$npcfilter) {
     
     //$kw=explode(" ",($rawstring));
@@ -4922,6 +4944,7 @@ function DataSearchMemory($rawstring,$npcfilter) {
     
     
     $scopeConditionSql = dataGetMemoryScopeConditionSql($npcfilter);
+    $companionConditionSql = dataGetMemoryCompanionConditionSql($npcfilter, 'A.companions');
 
     $memory=$GLOBALS["db"]->fetchAll("
         SELECT summary,gamets_truncated,
@@ -4931,7 +4954,7 @@ function DataSearchMemory($rawstring,$npcfilter) {
         where native_vec @@to_tsquery('$kwStringAny')
         and not (native_vec @@to_tsquery('#Reminiscence'))
         and $scopeConditionSql
-        and companions like '|%{$GLOBALS["db"]->escape($npcfilter)}|%'
+        and $companionConditionSql
 
         ORDER BY rank_all DESC, rank_any DESC;
         ",true);
@@ -5120,14 +5143,12 @@ function DataSearchMemoryByVector($rawstring,$npcfilter,$useContextKw=false,$tim
         }
 
        
-        if (empty($npcfilter)) {
-            $npcfilter=$GLOBALS["HERIKA_NAME"];
-        } else {
-            if ($useContextKw)
-                $result=array_merge($result,lastKeyWordsContext(5,$npcfilter));
+        if (!empty($npcfilter) && $useContextKw) {
+            $result=array_merge($result,lastKeyWordsContext(5,$npcfilter));
         }
 
         $scopeConditionSql = dataGetMemoryScopeConditionSql($npcfilter);
+        $companionConditionSql = dataGetMemoryCompanionConditionSql($npcfilter);
 
         $contextKeywords  = implode(" ", $result);
         $contextKeywords=strtr(internalDumbTranslator($contextKeywords),["remember"=>"","Remember"=>"","do you remember"=>""]);
@@ -5194,7 +5215,7 @@ function DataSearchMemoryByVector($rawstring,$npcfilter,$useContextKw=false,$tim
                     FROM public.memory_summary 
                     WHERE embedding IS NOT NULL
                     and $scopeConditionSql
-                    and companions like '|%{$GLOBALS["db"]->escape($npcfilter)}|%'
+                    and $companionConditionSql
                     and (gamets_truncated<$timeThreshold or $timeThreshold=0)
                     
                     ORDER BY 

--- a/ui/core/narrator_management.php
+++ b/ui/core/narrator_management.php
@@ -219,6 +219,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_narrator'])) {
         $narrator->set('remove_player_autochat_asterisks', isset($_POST['remove_player_autochat_asterisks']) && $_POST['remove_player_autochat_asterisks'] === '1' ? '1' : '0');
         $narrator->set('diary_enabled', isset($_POST['diary_enabled']) && $_POST['diary_enabled'] === '1' ? '1' : '0');
         $narrator->set('auto_diary_enabled', isset($_POST['auto_diary_enabled']) && $_POST['auto_diary_enabled'] === '1' ? '1' : '0');
+        $narrator->set('only_diary_access', isset($_POST['only_diary_access']) && $_POST['only_diary_access'] === '1' ? '1' : '0');
         
         // Save integer settings
         if (isset($_POST['random_chance'])) {
@@ -350,6 +351,7 @@ $removeAsterisksFromNpcOutput = $narrator->getBool(
 );
 $diaryEnabled = $narrator->getBool('diary_enabled', false);
 $autoDiaryEnabled = $narrator->getBool('auto_diary_enabled', false);
+$onlyDiaryAccess = $narrator->getBool('only_diary_access', false);
 $dynamicProfileEnabled = $narrator->getBool('dynamic_profile', false);
 $dynamicProfileFields = $narrator->getDynamicProfileFields();
 
@@ -1398,6 +1400,15 @@ if (!$isEmbed) {
                         <span class="toggle-label">Narrator Auto Diary</span>
                     </label>
                     <span class="hint">Allow The Narrator to join sleep and wait auto-diary generation. This does not affect manual narrator diary actions.</span>
+
+                    <label class="toggle-row">
+                        <div class="toggle-switch">
+                            <input type="checkbox" id="only_diary_access" name="only_diary_access" value="1" <?php echo $onlyDiaryAccess ? 'checked' : ''; ?>>
+                            <span class="toggle-slider"></span>
+                        </div>
+                        <span class="toggle-label">Narrator only diary access</span>
+                    </label>
+                    <span class="hint">Restrict the Narrator to diary entries written by The Narrator. When disabled, the Narrator may recall relevant diary entries from all NPCs.</span>
                 </div>
 
                 <!-- Narration Section -->

--- a/unittests/tests/DiaryMemoryRecallTest.php
+++ b/unittests/tests/DiaryMemoryRecallTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/data_functions.php';
+
+final class DiaryMemoryRecallTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['db'] = new class {
+            public array $queries = [];
+
+            public function escape($value): string
+            {
+                return str_replace("'", "''", (string)$value);
+            }
+
+            public function query(string $query): bool
+            {
+                $this->queries[] = $query;
+                return true;
+            }
+        };
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['db']);
+    }
+
+    public function testNarratorSearchesTheGlobalMemoryBank(): void
+    {
+        $this->assertSame('TRUE', dataGetMemoryCompanionConditionSql(''));
+    }
+
+    public function testDiaryPackingWritesCanonicalOwnerFormat(): void
+    {
+        PackIntoSummary(true);
+
+        $this->assertCount(1, $GLOBALS['db']->queries);
+        $this->assertStringContainsString("'|' || trim(both '|' from trim(speaker)) || '|'", $GLOBALS['db']->queries[0]);
+        $this->assertStringContainsString("event in ('diary','auto_diary','backgroundlife_diary')", $GLOBALS['db']->queries[0]);
+    }
+
+    public function testNpcRecallMatchesCanonicalAndLegacyDiaryOwners(): void
+    {
+        $this->assertSame(
+            "(memory_summary.companions LIKE '%|Embry|%' OR memory_summary.companions='Embry')",
+            dataGetMemoryCompanionConditionSql('Embry', 'memory_summary.companions')
+        );
+    }
+
+    public function testNpcNameIsEscapedInRecallCondition(): void
+    {
+        $this->assertSame(
+            "(companions LIKE '%|M''aiq''s Friend|%' OR companions='M''aiq''s Friend')",
+            dataGetMemoryCompanionConditionSql("M'aiq's Friend")
+        );
+    }
+}

--- a/unittests/tests/DiaryMemoryRecallTest.php
+++ b/unittests/tests/DiaryMemoryRecallTest.php
@@ -26,12 +26,28 @@ final class DiaryMemoryRecallTest extends TestCase
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['db']);
+        unset($GLOBALS['db'], $GLOBALS['NARRATOR_ONLY_DIARY_ACCESS']);
     }
 
-    public function testNarratorSearchesTheGlobalMemoryBank(): void
+    public function testNarratorSearchesTheGlobalMemoryBankByDefault(): void
     {
         $this->assertSame('TRUE', dataGetMemoryCompanionConditionSql(''));
+    }
+
+    public function testNarratorCanBeRestrictedToItsOwnDiary(): void
+    {
+        $GLOBALS['NARRATOR_ONLY_DIARY_ACCESS'] = true;
+
+        $this->assertSame(
+            "(COALESCE(memory_summary.classifier, '') NOT IN ('diary','auto_diary','backgroundlife_diary')"
+                . " OR memory_summary.companions LIKE '%|The Narrator|%'"
+                . " OR memory_summary.companions='The Narrator')",
+            dataGetMemoryCompanionConditionSql(
+                '',
+                'memory_summary.companions',
+                'memory_summary.classifier'
+            )
+        );
     }
 
     public function testDiaryPackingWritesCanonicalOwnerFormat(): void


### PR DESCRIPTION
## Summary
- store newly compacted diary memories with canonical pipe-delimited owners
- migrate existing diary memory owners so normal NPC recall can select them
- keep NPC diary recall owner-scoped while allowing the Narrator to search all NPC diaries by default
- add the off-by-default `Narrator only diary access` setting to restrict diary recall to the Narrator's own entries
- preserve the Narrator's access to ordinary global dialogue memories when that restriction is enabled

## Root cause
Diary summaries stored `companions` as plain names such as `The Narrator`, while memory retrieval expected pipe-delimited values such as `|The Narrator|`. Vector recall also replaced the Narrator's intentional global scope with a Narrator-only filter.

## Migration
`memory_summary` migration `20260721001` normalizes existing diary-owner values. It is idempotent and preserves empty rows. The new Narrator setting requires no schema migration; an absent value defaults to off.

## Validation
- `php -l` passed for all five changed PHP files in source and deployed runtime
- `DiaryMemoryRecallTest`: 5 tests, 7 assertions passed in source and deployed runtime
- PostgreSQL migration verified against the local database and confirmed idempotent on a second pass
- existing legacy diary owner `Embry` normalized to `|Embry|`
- live Narration page returns HTTP 200, renders the new toggle unchecked by default, and the control switches cleanly
- Apache restarted successfully with no new warnings from this change

## Scope
HerikaServer only. No CHIM plugin protocol or binary changes are required.