### PR TITLE
Add configurable remote MiniMe service URL

### DIFF
--- a/conf/conf_schema.json
+++ b/conf/conf_schema.json
@@ -549,7 +549,7 @@
     "MEMORY_EMBEDDING": {
       "_title":"Memory Settings",
       "ENABLED": {"type":"boolean","description":"Enable long-term memory recall. The system injects relevant memory summaries into AI context for responses."},
-      "TXTAI_URL": {"type":"url","description":"TXT2VEC from DwemerDistro. Make sure its set to http://127.0.0.1:8082"},
+      "TXTAI_URL": {"type":"url","description":"MiniMe/TXT2VEC service base URL. Use http://127.0.0.1:8082 for the local DwemerDistro service, or set the reachable URL of a remote service."},
       "USE_TEXT2VEC": {"type":"boolean","description":"Use TXT2VEC to create embeddings for memories. These are more accurate than keywords."},
       "MEMORY_TIME_DELAY": {"type":"integer","description":"Time in minutes to delay before using a memory in a prompt. Used to avoid pushing recent dialogues as memories."},
       "MEMORY_CONTEXT_SIZE": {"type":"integer","description":"The amount of the most relevant memory records that will be injected into the prompt."},

--- a/lib/minimet5_service.php
+++ b/lib/minimet5_service.php
@@ -2,13 +2,40 @@
 /**
  * MiniMeT5 Service Functions
  *
- * These functions interface with the MiniMeT5 local service (port 8082).
+ * These functions interface with the MiniMeT5/TXT2VEC service configured by
+ * FEATURES.MEMORY_EMBEDDING.TXTAI_URL (local port 8082 by default).
  * If the service is not running or not configured, they fail gracefully
  * by returning null/empty instead of blocking on connection timeouts.
  *
  * The service availability is cached per-request to avoid repeated
  * connection attempts when the service is down.
  */
+
+function _minimeServiceBaseUrl() {
+    $defaultUrl = 'http://127.0.0.1:8082';
+    $configuredUrl = $GLOBALS['FEATURES']['MEMORY_EMBEDDING']['TXTAI_URL'] ?? $defaultUrl;
+    $configuredUrl = rtrim(trim((string)$configuredUrl), '/');
+
+    if ($configuredUrl === '' || filter_var($configuredUrl, FILTER_VALIDATE_URL) === false) {
+        return $defaultUrl;
+    }
+
+    $parts = parse_url($configuredUrl);
+    $scheme = strtolower((string)($parts['scheme'] ?? ''));
+    if (!in_array($scheme, ['http', 'https'], true) || empty($parts['host'])) {
+        return $defaultUrl;
+    }
+
+    return $configuredUrl;
+}
+
+function _minimeServiceEndpoint($path, $query = []) {
+    $url = _minimeServiceBaseUrl() . '/' . ltrim((string)$path, '/');
+    if (!empty($query)) {
+        $url .= '?' . http_build_query($query, '', '&', PHP_QUERY_RFC3986);
+    }
+    return $url;
+}
 
 /**
  * Check if MiniMeT5 service is available (cached per request)
@@ -21,15 +48,21 @@ function _minimeServiceAvailable() {
         return $available;
     }
 
+    $parts = parse_url(_minimeServiceBaseUrl());
+    $scheme = strtolower((string)($parts['scheme'] ?? 'http'));
+    $host = (string)($parts['host'] ?? '127.0.0.1');
+    $port = (int)($parts['port'] ?? ($scheme === 'https' ? 443 : 80));
+    $socketHost = ($scheme === 'https' ? 'ssl://' : '') . $host;
+
     // Quick socket check - 100ms timeout
-    $socket = @fsockopen('127.0.0.1', 8082, $errno, $errstr, 0.1);
+    $socket = @fsockopen($socketHost, $port, $errno, $errstr, 0.1);
     if ($socket) {
         fclose($socket);
         $available = true;
     } else {
         $available = false;
         // Only log once per request
-        error_log("[MiniMeT5] Service not available on port 8082 - skipping MiniMe calls this request");
+        error_log("[MiniMeT5] Service not available at {$host}:{$port} - skipping MiniMe calls this request");
     }
 
     return $available;
@@ -66,7 +99,7 @@ function minimeCommand($text) {
         return null;
     }
 
-    $url = "http://127.0.0.1:8082/command?text=" . urlencode($text);
+    $url = _minimeServiceEndpoint('command', ['text' => $text]);
     $result = @file_get_contents($url);
     return $result !== false ? $result : null;
 }
@@ -85,9 +118,9 @@ function minimeExtract($text,$useOnlyDetector=false) {
         return $GLOBALS["MINIME_CACHE"][md5($text)];
 
     if ($useOnlyDetector)
-        $url = "http://127.0.0.1:8082/detectMemory?text=" . urlencode($text);
+        $url = _minimeServiceEndpoint('detectMemory', ['text' => $text]);
     else
-        $url = "http://127.0.0.1:8082/extract?text=" . urlencode($text);
+        $url = _minimeServiceEndpoint('extract', ['text' => $text]);
 
     $result = @file_get_contents($url);
     $GLOBALS["MINIME_CACHE"][md5($text)] = $result !== false ? $result : null;
@@ -104,7 +137,7 @@ function minimePostTopic($text) {
         return null;
     }
 
-    $url = "http://127.0.0.1:8082/posttopic?text=" . urlencode($text);
+    $url = _minimeServiceEndpoint('posttopic', ['text' => $text]);
     $result = @file_get_contents($url);
     return $result !== false ? $result : null;
 }
@@ -119,7 +152,7 @@ function minimeTask($text) {
         return null;
     }
 
-    $url = "http://127.0.0.1:8082/task?text=" . urlencode($text);
+    $url = _minimeServiceEndpoint('task', ['text' => $text]);
     $result = @file_get_contents($url);
     return $result !== false ? $result : null;
 }
@@ -134,7 +167,7 @@ function minimeTopic($text) {
         return null;
     }
 
-    $url = "http://127.0.0.1:8082/topic?text=" . urlencode($text);
+    $url = _minimeServiceEndpoint('topic', ['text' => $text]);
     $result = @file_get_contents($url);
     return $result !== false ? $result : null;
 }
@@ -149,7 +182,7 @@ function minimePostScene($text) {
         return null;
     }
 
-    $url = "http://127.0.0.1:8082/ambient?text=" . urlencode($text);
+    $url = _minimeServiceEndpoint('ambient', ['text' => $text]);
     $result = @file_get_contents($url);
     return $result !== false ? $result : null;
 }

--- a/ui/global_settings.php
+++ b/ui/global_settings.php
@@ -73,6 +73,7 @@ $gsSections = [
     ],
     'Memory' => [
         [ 'name' => 'FEATURES@MEMORY_EMBEDDING@ENABLED', 'type' => 'boolean' ],
+        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@TXTAI_URL', 'type' => 'url' ],
         [ 'name' => 'FEATURES@MEMORY_EMBEDDING@USE_TEXT2VEC', 'type' => 'boolean' ],
         [ 'name' => 'FEATURES@MEMORY_EMBEDDING@AUTO_CREATE_SUMMARY_INTERVAL', 'type' => 'integer' ],
     ],
@@ -118,6 +119,9 @@ function pretty_label(string $flatName): string
     if (strpos($flatName, 'FEATURES@MEMORY_EMBEDDING@') === 0) {
         $parts = explode('@', $flatName);
         $last = end($parts) ?: $flatName;
+        if (strtoupper(trim($last)) === 'TXTAI_URL') {
+            return 'MiniMe / TXT2VEC URL';
+        }
         return ucwords(str_replace('_', ' ', strtolower(trim($last))));
     }
     if (strpos($flatName, 'TRANSLATION@settings@') === 0) {

--- a/unittests/tests/MiniMeServiceUrlTest.php
+++ b/unittests/tests/MiniMeServiceUrlTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."lib".DIRECTORY_SEPARATOR."minimet5_service.php");
+
+final class MiniMeServiceUrlTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['FEATURES']);
+    }
+
+    public function testUsesConfiguredRemoteServiceUrl(): void
+    {
+        $GLOBALS['FEATURES']['MEMORY_EMBEDDING']['TXTAI_URL'] = 'http://192.168.1.40:8082/';
+
+        $this->assertSame('http://192.168.1.40:8082', _minimeServiceBaseUrl());
+        $this->assertSame(
+            'http://192.168.1.40:8082/extract?text=hello%20world',
+            _minimeServiceEndpoint('extract', ['text' => 'hello world'])
+        );
+    }
+
+    public function testPreservesHttpsAndPathPrefixes(): void
+    {
+        $GLOBALS['FEATURES']['MEMORY_EMBEDDING']['TXTAI_URL'] = 'https://ai.example.test/services/minime/';
+
+        $this->assertSame(
+            'https://ai.example.test/services/minime/topic?text=Whiterun',
+            _minimeServiceEndpoint('/topic', ['text' => 'Whiterun'])
+        );
+    }
+
+    public function testFallsBackToLocalDefaultForInvalidUrl(): void
+    {
+        $GLOBALS['FEATURES']['MEMORY_EMBEDDING']['TXTAI_URL'] = 'not a URL';
+
+        $this->assertSame('http://127.0.0.1:8082', _minimeServiceBaseUrl());
+    }
+}


### PR DESCRIPTION
﻿## Summary

- adds a managed **MiniMe / TXT2VEC URL** field under Global Settings > Memory
- routes MiniMe availability checks and all MiniMe requests through the existing `FEATURES.MEMORY_EMBEDDING.TXTAI_URL` setting
- supports remote HTTP/HTTPS services and optional path prefixes
- retains `http://127.0.0.1:8082` as the fallback for missing or invalid settings

## Why

Discord thread `1529439517117907044` reports running MiniMeT5/TXT2VEC on another machine. MiniMe was hard-coded to `127.0.0.1:8082`, so the existing configurable TXT2VEC URL did not affect MiniMe detection or requests.

## Validation

- PHP lint passed for all changed PHP files
- `conf/conf_schema.json` parsed successfully
- focused PHPUnit: **3 tests, 4 assertions passed**
- deployed runtime hashes matched the feature worktree
- deployed helper produced the expected remote URL with encoded query text
- local Global Settings page returned HTTP 200 and visually rendered the new field and help text

## Deployment

Server-only deployment to local WSL HerikaServer. No CHIM DLL or game-plugin files changed.

## Coordination

The unstable push guard requires this PR due to recent Augusto ownership and file overlap with open PRs #606 and #593. The functional scope is independent, but `conf/conf_schema.json` and `ui/global_settings.php` may need a conflict refresh if those PRs merge first.

## Testing boundary

No external remote MiniMe host was available for a live network request. URL construction, HTTP/HTTPS handling, path-prefix behavior, fallback behavior, and the local default endpoint were validated.
