### PR TITLE
Fix snapshots with identity columns

### DIFF
--- a/lib/playthrough_schema.php
+++ b/lib/playthrough_schema.php
@@ -10,16 +10,29 @@
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'logger.php');
 
 /**
+ * Check whether the installed clone function includes identity-column support.
+ */
+function pts_clone_function_is_current($definition): bool {
+    return is_string($definition)
+        && stripos($definition, 'OVERRIDING SYSTEM VALUE') !== false;
+}
+
+/**
  * Ensure the clone_schema SQL functions exist in the database.
  * Safe to call multiple times (idempotent).
  */
 function pts_ensure_functions($conn): bool {
-    // Check if functions already exist in chim_meta schema
-    $checkQuery = "SELECT 1 FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE p.proname = 'clone_schema' AND n.nspname = 'chim_meta' LIMIT 1";
+    // Existing installations may have an older function definition that cannot
+    // copy explicit values into GENERATED ALWAYS identity columns.
+    $checkQuery = "SELECT pg_get_functiondef(p.oid) AS function_definition FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE p.proname = 'clone_schema' AND n.nspname = 'chim_meta' LIMIT 1";
     $checkResult = @pg_query($conn, $checkQuery);
     if ($checkResult && pg_num_rows($checkResult) > 0) {
-        // Functions already exist
-        return true;
+        $row = pg_fetch_assoc($checkResult);
+        if (pts_clone_function_is_current($row['function_definition'] ?? null)) {
+            return true;
+        }
+
+        Logger::info("Schema clone functions are outdated; refreshing definitions");
     }
     
     $sqlFile = __DIR__ . DIRECTORY_SEPARATOR . 'schema_clone_function.sql';
@@ -42,10 +55,11 @@ function pts_ensure_functions($conn): bool {
         return false;
     }
     
-    // Verify functions were created
+    // Verify the current function definition was installed
     $verifyResult = @pg_query($conn, $checkQuery);
-    if (!$verifyResult || pg_num_rows($verifyResult) === 0) {
-        Logger::error("Schema clone functions were not created successfully");
+    $verifyRow = $verifyResult ? pg_fetch_assoc($verifyResult) : false;
+    if (!$verifyRow || !pts_clone_function_is_current($verifyRow['function_definition'] ?? null)) {
+        Logger::error("Schema clone functions were not installed successfully");
         return false;
     }
     

--- a/lib/schema_clone_function.sql
+++ b/lib/schema_clone_function.sql
@@ -21,8 +21,8 @@ BEGIN
         EXECUTE format('CREATE TABLE IF NOT EXISTS %I.%I (LIKE %I.%I INCLUDING ALL)',
                        dest_schema, obj.tablename, source_schema, obj.tablename);
         
-        -- Copy all data
-        EXECUTE format('INSERT INTO %I.%I SELECT * FROM %I.%I ON CONFLICT DO NOTHING',
+        -- Copy all data, preserving values from GENERATED ALWAYS identity columns.
+        EXECUTE format('INSERT INTO %I.%I OVERRIDING SYSTEM VALUE SELECT * FROM %I.%I ON CONFLICT DO NOTHING',
                        dest_schema, obj.tablename, source_schema, obj.tablename);
     END LOOP;
 

--- a/unittests/tests/SchemaCloneIdentityTest.php
+++ b/unittests/tests/SchemaCloneIdentityTest.php
@@ -2,8 +2,27 @@
 
 use PHPUnit\Framework\TestCase;
 
+require_once(
+    __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..'
+    . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'playthrough_schema.php'
+);
+
 final class SchemaCloneIdentityTest extends TestCase
 {
+    public function testLegacyCloneFunctionNeedsRefresh(): void
+    {
+        $legacyDefinition = 'INSERT INTO destination SELECT * FROM source';
+
+        $this->assertFalse(pts_clone_function_is_current($legacyDefinition));
+    }
+
+    public function testIdentityAwareCloneFunctionIsCurrent(): void
+    {
+        $currentDefinition = 'INSERT INTO destination OVERRIDING SYSTEM VALUE SELECT * FROM source';
+
+        $this->assertTrue(pts_clone_function_is_current($currentDefinition));
+    }
+
     public function testSchemaClonePreservesGeneratedIdentityValues(): void
     {
         $sql = file_get_contents(

--- a/unittests/tests/SchemaCloneIdentityTest.php
+++ b/unittests/tests/SchemaCloneIdentityTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class SchemaCloneIdentityTest extends TestCase
+{
+    public function testSchemaClonePreservesGeneratedIdentityValues(): void
+    {
+        $sql = file_get_contents(
+            __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..'
+            . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'schema_clone_function.sql'
+        );
+
+        $this->assertIsString($sql);
+        $this->assertStringContainsString(
+            'INSERT INTO %I.%I OVERRIDING SYSTEM VALUE SELECT * FROM %I.%I ON CONFLICT DO NOTHING',
+            $sql
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Preserve values from PostgreSQL `GENERATED ALWAYS` identity columns while cloning playthrough snapshot schemas.
- Detect and refresh outdated `chim_meta.clone_schema` definitions on existing installations.
- Add focused regression coverage for identity-aware clone detection and SQL generation.

## Root cause

The clone function recreates tables with `LIKE ... INCLUDING ALL`, which preserves identity-column definitions, then copies explicit values with `INSERT ... SELECT *`. PostgreSQL rejects those identity values unless the insert uses `OVERRIDING SYSTEM VALUE`.

Existing installations already had `chim_meta.clone_schema`, and `pts_ensure_functions()` previously returned as soon as any clone function existed. Updating only the SQL file therefore fixed fresh installs but did not replace the legacy function for affected users.

## Fix

- Clone data with `OVERRIDING SYSTEM VALUE`.
- Read the installed function definition with `pg_get_functiondef()`.
- Return immediately when identity support is already installed.
- Re-run the existing idempotent `CREATE OR REPLACE` SQL only when the function is missing or outdated.
- Verify the refreshed definition before reporting success.

No schemas, snapshots, tables, or user data are dropped by the upgrade.

## Discord report

- https://discord.com/channels/1109612896482246826/1529732091137495131/1529732091137495131
- Thread ID: `1529732091137495131`

## Validation

- PHP syntax checks passed for both changed PHP files.
- Focused PHPUnit: 3 tests, 4 assertions.
- Existing-installation probe changed an installed legacy function from `legacy` to `current` through `pts_ensure_functions()`.
- Transactional PostgreSQL snapshot probe preserved `rowid=42` from a `GENERATED ALWAYS AS IDENTITY` table.
- A subsequent insert into the cloned table succeeded with `rowid=44`, confirming the cloned identity sequence remained usable.
- The live function was restored and verified current after the probe.
- Repository-wide PHPUnit was attempted but exceeded the two-minute local test window; no focused test failure occurred.
- CHIM unstable guard requires this draft PR because the change affects runtime database behavior.

## Related parity work

- HerikaServer: https://github.com/abeiro/HerikaServer/pull/608
- DialecticServer: https://github.com/Dwemer-Dynamics/DialecticServer/pull/14
- StobeServer: https://github.com/Dwemer-Dynamics/StobeServer/pull/34

## Remaining validation

No in-game testing was performed.