### PR TITLE
Fix profile imports and stale database sequences

### DIFF
--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -7527,6 +7527,27 @@ if ($checkVersion("physical_npc_diaries") < 20260719002) {
     Logger::info("Applied patch physical_npc_diaries 20260719002");
 }
 
+if ($checkVersion("playthrough_schema") < 20260723001) {
+    Logger::debug("Applying playthrough_schema 20260723001 - repair stale database sequences");
+
+    $schemaFunctionsPath = __DIR__ . "/../lib/schema_clone_function.sql";
+    $migrationOk = is_readable($schemaFunctionsPath)
+        && $db->execQuery(file_get_contents($schemaFunctionsPath)) !== false;
+
+    if ($migrationOk) {
+        $migrationOk = $db->execQuery(
+            "SELECT chim_meta.sync_schema_sequences('public')"
+        ) !== false;
+    }
+
+    if ($migrationOk) {
+        $updateVersion("playthrough_schema", 20260723001);
+        Logger::info("Applied patch playthrough_schema 20260723001");
+    } else {
+        Logger::error("Failed to apply patch playthrough_schema 20260723001");
+    }
+}
+
 // master Packages update 
 if ($checkVersion("master_packages")<20260716002) {
     if ($db->execQuery(file_get_contents(__DIR__."/../data/master_packages_202607.sql"))) {

--- a/lib/core/api_badge.class.php
+++ b/lib/core/api_badge.class.php
@@ -23,7 +23,7 @@ class ApiBadge {
 			$filtered['id'] = (int)$filtered['id'];
 		}
         
-        return $this->db->insert($this->table, $filtered);
+        return $this->db->insertReturningId($this->table, $filtered);
     }
 
     // Read by ID
@@ -69,6 +69,10 @@ class ApiBadge {
     // Truncate the table
     public function truncate($restart = false, $cascade = false) {
         return $this->db->truncate($this->table, $restart, $cascade);
+    }
+
+    public function getLastError() {
+        return $this->db->GetLastError();
     }
 
     // Upsert using ON CONFLICT (requires UNIQUE or PRIMARY constraint)

--- a/lib/core/core_profiles.class.php
+++ b/lib/core/core_profiles.class.php
@@ -66,7 +66,7 @@ class CoreProfile
         }
 
         $filtered = array_intersect_key($data, array_flip($fields));
-        return $GLOBALS["db"]->insert($this->table, $filtered);
+        return $GLOBALS["db"]->insertReturningId($this->table, $filtered);
     }
 
     public function readAll()

--- a/lib/core/llm_connector.class.php
+++ b/lib/core/llm_connector.class.php
@@ -135,7 +135,7 @@ class LLMConnector
         }
 
         $filtered = array_intersect_key($data, array_flip($fields));
-        return $GLOBALS["db"]->insert($this->table, $filtered);
+        return $GLOBALS["db"]->insertReturningId($this->table, $filtered);
     }
 
     public function readAll()

--- a/lib/playthrough_schema.php
+++ b/lib/playthrough_schema.php
@@ -10,11 +10,13 @@
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'logger.php');
 
 /**
- * Check whether the installed clone function includes identity-column support.
+ * Check whether the installed clone function includes identity-column and
+ * ownership-based sequence synchronization support.
  */
 function pts_clone_function_is_current($definition): bool {
     return is_string($definition)
-        && stripos($definition, 'OVERRIDING SYSTEM VALUE') !== false;
+        && stripos($definition, 'OVERRIDING SYSTEM VALUE') !== false
+        && stripos($definition, 'sync_schema_sequences(dest_schema)') !== false;
 }
 
 /**

--- a/lib/postgresql.class.php
+++ b/lib/postgresql.class.php
@@ -157,6 +157,45 @@ class sql
         }
     }
 
+    public function insertReturningId($table, $data, $idColumn = 'id')
+    {
+        $startTime = microtime(true);
+        $this->re_connect();
+
+        foreach (array_merge([$table, $idColumn], array_keys($data)) as $identifier) {
+            if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', (string)$identifier)) {
+                Logger::error("SQL: Invalid identifier for insertReturningId");
+                return 0;
+            }
+        }
+
+        $values = [];
+        foreach (array_keys($data) as $index => $column) {
+            $values[] = '$' . ($index + 1);
+        }
+
+        $columns = implode(', ', array_keys($data));
+        $query = "INSERT INTO {$table} ({$columns}) VALUES (" . implode(', ', $values) . ") RETURNING {$idColumn}";
+        $result = pg_query_params(self::$link, $query, array_values($data));
+
+        $elapsedTime = microtime(true) - $startTime;
+        if (!isset($GLOBALS["DB_EXECUTION_TIME"])) {
+            $GLOBALS["DB_EXECUTION_TIME"] = 0;
+        }
+        $GLOBALS["DB_EXECUTION_TIME"] += $elapsedTime;
+
+        if ($this->debug_level > 2 && $elapsedTime > $this->queryTimeThreshold) {
+            Logger::warn("SQL: Insert query execution time exceeded threshold {$elapsedTime} seconds. {$query} " . $this->extract_caller());
+        }
+        if (!$result) {
+            Logger::error("SQL: Insert query failed {$query} " . $this->GetLastError() . $this->extract_caller());
+            return 0;
+        }
+
+        $row = pg_fetch_assoc($result);
+        return isset($row[$idColumn]) ? (int)$row[$idColumn] : 0;
+    }
+
     public function query($query)
     {
         $startTime = microtime(true);

--- a/lib/schema_clone_function.sql
+++ b/lib/schema_clone_function.sql
@@ -111,15 +111,32 @@ BEGIN
     -- Clone sequences with their current values
     -- Must happen AFTER table data is copied to ensure sync
     FOR obj IN
-        SELECT sequencename FROM pg_sequences WHERE schemaname = source_schema
+        SELECT sequencename, increment_by
+        FROM pg_sequences
+        WHERE schemaname = source_schema
     LOOP
         DECLARE
             table_name text;
-            max_val bigint := 0;
-            source_val bigint := 0;
+            column_name text;
+            boundary_value bigint;
+            table_next_value bigint;
+            source_last_value bigint;
+            source_is_called boolean;
+            source_next_value bigint;
         BEGIN
-            -- Get current sequence value from source
-            EXECUTE format('SELECT last_value FROM %I.%I', source_schema, obj.sequencename) INTO source_val;
+            -- Preserve the source's actual next value. last_value itself is
+            -- still pending when is_called is false.
+            EXECUTE format(
+                'SELECT last_value, is_called FROM %I.%I',
+                source_schema,
+                obj.sequencename
+            ) INTO source_last_value, source_is_called;
+            source_next_value := CASE
+                WHEN source_is_called
+                    THEN source_last_value + obj.increment_by
+                ELSE source_last_value
+            END;
+            seq_val := source_next_value;
             
             -- Create sequence in destination if it doesn't exist
             EXECUTE format('CREATE SEQUENCE IF NOT EXISTS %I.%I', dest_schema, obj.sequencename);
@@ -130,50 +147,37 @@ BEGIN
                 -- Extract table name and column name from sequence name
                 IF obj.sequencename LIKE '%_rowid_seq' THEN
                     table_name := regexp_replace(obj.sequencename, '_rowid_seq$', '');
-                    
-                    -- Try to get max rowid from the destination table
-                    BEGIN
-                        EXECUTE format('SELECT COALESCE(MAX(rowid), 0) FROM %I.%I', dest_schema, table_name) INTO max_val;
-                        
-                        -- Use the greater of: source sequence value or table max + 1
-                        IF max_val >= source_val THEN
-                            seq_val := max_val + 1;
-                            RAISE NOTICE 'Sequence % adjusted: source=% tablemax=% final=%', 
-                                        obj.sequencename, source_val, max_val, seq_val;
-                        ELSE
-                            seq_val := source_val;
-                        END IF;
-                    EXCEPTION WHEN OTHERS THEN
-                        -- Table might not exist or have a 'rowid' column, just use source value
-                        seq_val := source_val;
-                    END;
+                    column_name := 'rowid';
                 ELSIF obj.sequencename LIKE '%_id_seq' THEN
                     table_name := regexp_replace(obj.sequencename, '_id_seq$', '');
-                    
-                    -- Try to get max id from the destination table
-                    BEGIN
-                        EXECUTE format('SELECT COALESCE(MAX(id), 0) FROM %I.%I', dest_schema, table_name) INTO max_val;
-                        
-                        -- Use the greater of: source sequence value or table max + 1
-                        IF max_val >= source_val THEN
-                            seq_val := max_val + 1;
-                            RAISE NOTICE 'Sequence % adjusted: source=% tablemax=% final=%', 
-                                        obj.sequencename, source_val, max_val, seq_val;
-                        ELSE
-                            seq_val := source_val;
-                        END IF;
-                    EXCEPTION WHEN OTHERS THEN
-                        -- Table might not exist or have an 'id' column, just use source value
-                        seq_val := source_val;
-                    END;
+                    column_name := 'id';
                 END IF;
-            ELSE
-                -- Not a table sequence, just copy the value
-                seq_val := source_val;
+
+                BEGIN
+                    EXECUTE format(
+                        'SELECT %s(%I)::bigint FROM %I.%I',
+                        CASE WHEN obj.increment_by > 0 THEN 'MAX' ELSE 'MIN' END,
+                        column_name,
+                        dest_schema,
+                        table_name
+                    ) INTO boundary_value;
+
+                    IF boundary_value IS NOT NULL THEN
+                        table_next_value := boundary_value + obj.increment_by;
+                        IF (obj.increment_by > 0 AND table_next_value > seq_val)
+                            OR (obj.increment_by < 0 AND table_next_value < seq_val) THEN
+                            seq_val := table_next_value;
+                            RAISE NOTICE 'Sequence % adjusted: source_next=% table_boundary=% final=%',
+                                obj.sequencename, source_next_value, boundary_value, seq_val;
+                        END IF;
+                    END IF;
+                EXCEPTION WHEN OTHERS THEN
+                    -- Table might not exist or use the conventional column.
+                    seq_val := source_next_value;
+                END;
             END IF;
             
-            -- seq_val represents the next value to issue, so leave is_called
-            -- false. Marking it called would skip an extra ID.
+            -- seq_val is the exact next value to issue.
             EXECUTE format('SELECT setval(''%I.%I'', %s, false)', dest_schema, obj.sequencename, seq_val);
         END;
     END LOOP;

--- a/lib/schema_clone_function.sql
+++ b/lib/schema_clone_function.sql
@@ -4,6 +4,88 @@
 
 CREATE SCHEMA IF NOT EXISTS chim_meta;
 
+-- Advance sequence-backed columns whose next value would collide with existing
+-- rows. Ownership metadata is used instead of sequence-name conventions.
+CREATE OR REPLACE FUNCTION chim_meta.sync_schema_sequences(target_schema text)
+RETURNS integer AS $$
+DECLARE
+    obj RECORD;
+    boundary_value BIGINT;
+    sequence_last_value BIGINT;
+    sequence_is_called BOOLEAN;
+    sequence_next_value BIGINT;
+    repaired_count integer := 0;
+BEGIN
+    FOR obj IN
+        SELECT
+            sequence_relation.relname AS sequence_name,
+            table_relation.relname AS table_name,
+            table_column.attname AS column_name,
+            sequence_data.seqincrement AS increment_by
+        FROM pg_class AS sequence_relation
+        JOIN pg_namespace AS sequence_namespace
+            ON sequence_namespace.oid = sequence_relation.relnamespace
+        JOIN pg_sequence AS sequence_data
+            ON sequence_data.seqrelid = sequence_relation.oid
+        JOIN pg_depend AS dependency
+            ON dependency.classid = 'pg_class'::regclass
+            AND dependency.objid = sequence_relation.oid
+            AND dependency.refclassid = 'pg_class'::regclass
+            AND dependency.deptype IN ('a', 'i')
+        JOIN pg_class AS table_relation
+            ON table_relation.oid = dependency.refobjid
+        JOIN pg_namespace AS table_namespace
+            ON table_namespace.oid = table_relation.relnamespace
+        JOIN pg_attribute AS table_column
+            ON table_column.attrelid = table_relation.oid
+            AND table_column.attnum = dependency.refobjsubid
+        WHERE sequence_relation.relkind = 'S'
+            AND sequence_namespace.nspname = target_schema
+            AND table_namespace.nspname = target_schema
+            AND table_column.attnum > 0
+            AND NOT table_column.attisdropped
+    LOOP
+        EXECUTE format(
+            'SELECT %s(%I)::bigint FROM %I.%I',
+            CASE WHEN obj.increment_by > 0 THEN 'MAX' ELSE 'MIN' END,
+            obj.column_name,
+            target_schema,
+            obj.table_name
+        ) INTO boundary_value;
+
+        -- Empty tables cannot have a collision and should retain their original
+        -- sequence start state.
+        IF boundary_value IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        EXECUTE format(
+            'SELECT last_value::bigint, is_called FROM %I.%I',
+            target_schema,
+            obj.sequence_name
+        ) INTO sequence_last_value, sequence_is_called;
+
+        sequence_next_value := CASE
+            WHEN sequence_is_called
+                THEN sequence_last_value + obj.increment_by
+            ELSE sequence_last_value
+        END;
+
+        IF (obj.increment_by > 0 AND sequence_next_value <= boundary_value)
+            OR (obj.increment_by < 0 AND sequence_next_value >= boundary_value) THEN
+            EXECUTE format(
+                'SELECT setval(%L::regclass, %s, true)',
+                format('%I.%I', target_schema, obj.sequence_name),
+                boundary_value
+            );
+            repaired_count := repaired_count + 1;
+        END IF;
+    END LOOP;
+
+    RETURN repaired_count;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION chim_meta.clone_schema(source_schema text, dest_schema text)
 RETURNS void AS $$
 DECLARE
@@ -90,8 +172,9 @@ BEGIN
                 seq_val := source_val;
             END IF;
             
-            -- Set sequence to the calculated value
-            EXECUTE format('SELECT setval(''%I.%I'', %s, true)', dest_schema, obj.sequencename, seq_val);
+            -- seq_val represents the next value to issue, so leave is_called
+            -- false. Marking it called would skip an extra ID.
+            EXECUTE format('SELECT setval(''%I.%I'', %s, false)', dest_schema, obj.sequencename, seq_val);
         END;
     END LOOP;
 
@@ -161,6 +244,10 @@ BEGIN
                          obj.tablename, obj.column_name, SQLERRM, obj.column_default;
         END;
     END LOOP;
+
+    -- The copied data can contain explicit serial/identity values. Synchronize
+    -- the destination's owned sequences after defaults and ownership are fixed.
+    PERFORM chim_meta.sync_schema_sequences(dest_schema);
 
     -- Clone views (optional - captures query definitions)
     FOR obj IN

--- a/ui/core/core_profiles.php
+++ b/ui/core/core_profiles.php
@@ -18,6 +18,7 @@ require_once($enginePath . "lib" .DIRECTORY_SEPARATOR."profile_llm_mode.php");
 require_once "{$enginePath}/lib/core/core_profiles.class.php";
 require_once "{$enginePath}/lib/core/llm_connector.class.php";
 require_once "{$enginePath}/lib/core/tts_connector.class.php";
+require_once "{$enginePath}/lib/core/itt_connector.class.php";
 require_once "{$enginePath}/lib/core/api_badge.class.php";
 require_once "{$enginePath}/lib/core/import_rules.class.php";
 
@@ -912,7 +913,8 @@ if (!function_exists('chimNullIfBlank')) {
 if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
     try { while (ob_get_level() > 0) { ob_end_clean(); } } catch (Throwable $e) {}
     header('Content-Type: application/json');
-    
+
+    $importTransactionStarted = false;
     try {
         $importJson = $_POST['import_data'] ?? '';
         
@@ -942,6 +944,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
             echo json_encode(['ok' => false, 'error' => 'Profile slot must be 1-4 or empty']);
             exit;
         }
+
+        if ($GLOBALS["db"]->query("BEGIN") === false) {
+            throw new Exception('Could not start profile import transaction');
+        }
+        $importTransactionStarted = true;
+
         $previousDefaultNpc = $profiles->getDefaultNpc();
         $previousDefaultNpcId = is_array($previousDefaultNpc) && !empty($previousDefaultNpc['id'])
             ? (int)$previousDefaultNpc['id']
@@ -957,6 +965,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
         
         $llmConn = new LLMConnector();
         $ttsConn = new TTSConnector();
+        $ittConn = new ITTConnector();
         $apiBadgeObj = new ApiBadge();
         
         // Step 1: Create or match API badges
@@ -974,6 +983,9 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
                     'label' => $label,
                     'api_key' => '' // Empty, user must fill in
                 ]);
+                if (!$newBadgeId) {
+                    throw new Exception($apiBadgeObj->getLastError() ?: "Could not import API key entry '{$label}'");
+                }
                 $apiBadgeIdMap[$oldId] = $newBadgeId;
             }
         }
@@ -1007,6 +1019,9 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
                 
                 // Create new connector
                 $newConnId = $llmConn->create($connData);
+                if (!$newConnId) {
+                    throw new Exception($llmConn->getLastError() ?: "Could not import LLM connector '{$label}'");
+                }
                 $llmConnectorIdMap[$oldId] = $newConnId;
             }
         }
@@ -1034,6 +1049,9 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
                 }
                 
                 $ttsConnectorId = $ttsConn->create($ttsData);
+                if (!$ttsConnectorId) {
+                    throw new Exception($ttsConn->getLastError() ?: "Could not import TTS connector '{$label}'");
+                }
             }
         }
         
@@ -1053,7 +1071,15 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
             } else {
                 $ittData = $ittConnector;
                 unset($ittData['id']);
-                $ittConnectorId = $GLOBALS["db"]->insert('core_itt_connector', $ittData);
+                if (!empty($ittData['api_badge_id']) && isset($apiBadgeIdMap[$ittData['api_badge_id']])) {
+                    $ittData['api_badge_id'] = $apiBadgeIdMap[$ittData['api_badge_id']];
+                } else {
+                    $ittData['api_badge_id'] = null;
+                }
+                $ittConnectorId = $ittConn->create($ittData);
+                if (!$ittConnectorId) {
+                    throw new Exception($ittConn->getLastError() ?: "Could not import ITT connector '{$label}'");
+                }
             }
         }
         
@@ -1089,7 +1115,9 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
         }
 
         if ($assignSlot !== null) {
-            $GLOBALS["db"]->query("UPDATE core_profiles SET slot = NULL WHERE slot = {$assignSlot}");
+            if ($GLOBALS["db"]->query("UPDATE core_profiles SET slot = NULL WHERE slot = {$assignSlot}") === false) {
+                throw new Exception('Could not clear the selected profile slot');
+            }
             $slotOk = $profiles->update($newProfileId, ['slot' => $assignSlot]);
             if ($slotOk === false) {
                 throw new Exception($profiles->getLastError() ?: 'Could not assign imported profile slot');
@@ -1097,7 +1125,9 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
         }
 
         if ($makeDefaultNpc) {
-            $profiles->promoteToDefaultNpc($newProfileId);
+            if ($profiles->promoteToDefaultNpc($newProfileId) === false) {
+                throw new Exception($profiles->getLastError() ?: 'Could not set imported profile as the default');
+            }
         }
 
         $migratedNpcCount = 0;
@@ -1109,7 +1139,9 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
             $where = implode(' OR ', $whereParts);
             $countRow = $GLOBALS["db"]->fetchOne("SELECT COUNT(*) AS c FROM core_npc_master WHERE {$where}");
             $migratedNpcCount = (int)($countRow['c'] ?? 0);
-            $GLOBALS["db"]->query("UPDATE core_npc_master SET profile_id = {$newProfileId} WHERE {$where}");
+            if ($GLOBALS["db"]->query("UPDATE core_npc_master SET profile_id = {$newProfileId} WHERE {$where}") === false) {
+                throw new Exception('Could not move current default NPCs to the imported profile');
+            }
         }
 
         $messageParts = ['Profile imported successfully'];
@@ -1122,7 +1154,12 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
         if ($migrateOldDefaultNpcs) {
             $messageParts[] = "migrated {$migratedNpcCount} NPCs from old default/empty profile";
         }
-        
+
+        if ($GLOBALS["db"]->query("COMMIT") === false) {
+            throw new Exception('Could not commit imported profile');
+        }
+        $importTransactionStarted = false;
+
         echo json_encode([
             'ok' => true, 
             'id' => $newProfileId,
@@ -1130,6 +1167,9 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["import_profile"])) {
         ]);
         
     } catch (Throwable $e) {
+        if ($importTransactionStarted) {
+            $GLOBALS["db"]->query("ROLLBACK");
+        }
         echo json_encode(['ok' => false, 'error' => $e->getMessage()]);
     }
     exit;

--- a/unittests/tests/ProfileImportCreateIdTest.php
+++ b/unittests/tests/ProfileImportCreateIdTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'api_badge.class.php';
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'core_profiles.class.php';
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'llm_connector.class.php';
+
+final class ProfileImportCreateIdDatabaseStub
+{
+    public array $inserts = [];
+    private array $ids;
+
+    public function __construct(array $ids)
+    {
+        $this->ids = $ids;
+    }
+
+    public function insertReturningId(string $table, array $data): int
+    {
+        $this->inserts[] = ['table' => $table, 'data' => $data];
+        return (int)array_shift($this->ids);
+    }
+
+    public function fetchOne(string $query): array
+    {
+        return [];
+    }
+
+    public function GetLastError(): string
+    {
+        return '';
+    }
+}
+
+final class ProfileImportCreateIdTest extends TestCase
+{
+    private $previousDb;
+
+    protected function setUp(): void
+    {
+        $this->previousDb = $GLOBALS['db'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousDb === null) {
+            unset($GLOBALS['db']);
+            return;
+        }
+
+        $GLOBALS['db'] = $this->previousDb;
+    }
+
+    public function testImportCreatePathsReturnDatabaseIds(): void
+    {
+        $db = new ProfileImportCreateIdDatabaseStub([41, 42, 43]);
+        $GLOBALS['db'] = $db;
+
+        $badgeId = (new ApiBadge())->create([
+            'label' => 'Imported OpenRouter',
+            'api_key' => '',
+        ]);
+        $llmId = (new LLMConnector())->create([
+            'label' => 'Imported Model',
+            'driver' => 'openrouterjson',
+            'model' => 'example/model',
+            'api_badge_id' => $badgeId,
+        ]);
+        $profileId = (new CoreProfile())->create([
+            'label' => 'Imported Profile',
+            'default_npc' => 0,
+            'default_narrator' => 0,
+            'llm_primary_id' => $llmId,
+            'slot' => null,
+        ]);
+
+        $this->assertSame(41, $badgeId);
+        $this->assertSame(42, $llmId);
+        $this->assertSame(43, $profileId);
+        $this->assertSame(
+            ['core_api_badge', 'core_llm_connector', 'core_profiles'],
+            array_column($db->inserts, 'table')
+        );
+        $this->assertSame(42, $db->inserts[2]['data']['llm_primary_id']);
+    }
+}

--- a/unittests/tests/SchemaCloneIdentityTest.php
+++ b/unittests/tests/SchemaCloneIdentityTest.php
@@ -16,9 +16,20 @@ final class SchemaCloneIdentityTest extends TestCase
         $this->assertFalse(pts_clone_function_is_current($legacyDefinition));
     }
 
+    public function testIdentityOnlyCloneFunctionNeedsSequenceRefresh(): void
+    {
+        $identityOnlyDefinition =
+            'INSERT INTO destination OVERRIDING SYSTEM VALUE SELECT * FROM source';
+
+        $this->assertFalse(pts_clone_function_is_current($identityOnlyDefinition));
+    }
+
     public function testIdentityAwareCloneFunctionIsCurrent(): void
     {
-        $currentDefinition = 'INSERT INTO destination OVERRIDING SYSTEM VALUE SELECT * FROM source';
+        $currentDefinition = <<<'SQL'
+INSERT INTO destination OVERRIDING SYSTEM VALUE SELECT * FROM source;
+PERFORM chim_meta.sync_schema_sequences(dest_schema);
+SQL;
 
         $this->assertTrue(pts_clone_function_is_current($currentDefinition));
     }
@@ -34,6 +45,30 @@ final class SchemaCloneIdentityTest extends TestCase
         $this->assertStringContainsString(
             'INSERT INTO %I.%I OVERRIDING SYSTEM VALUE SELECT * FROM %I.%I ON CONFLICT DO NOTHING',
             $sql
+        );
+        $this->assertStringContainsString('sync_schema_sequences', $sql);
+        $this->assertStringContainsString("dependency.deptype IN ('a', 'i')", $sql);
+        $this->assertStringContainsString(
+            'PERFORM chim_meta.sync_schema_sequences(dest_schema)',
+            $sql
+        );
+    }
+
+    public function testDatabaseUpdateRepairsExistingPublicSequences(): void
+    {
+        $updates = file_get_contents(
+            __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..'
+            . DIRECTORY_SEPARATOR . 'debug' . DIRECTORY_SEPARATOR . 'db_updates.php'
+        );
+
+        $this->assertIsString($updates);
+        $this->assertStringContainsString(
+            "SELECT chim_meta.sync_schema_sequences('public')",
+            $updates
+        );
+        $this->assertStringContainsString(
+            '$updateVersion("playthrough_schema", 20260723001)',
+            $updates
         );
     }
 }

--- a/unittests/tests/SchemaCloneIdentityTest.php
+++ b/unittests/tests/SchemaCloneIdentityTest.php
@@ -52,6 +52,18 @@ SQL;
             'PERFORM chim_meta.sync_schema_sequences(dest_schema)',
             $sql
         );
+        $this->assertStringContainsString(
+            'SELECT last_value, is_called FROM %I.%I',
+            $sql
+        );
+        $this->assertStringContainsString(
+            'THEN source_last_value + obj.increment_by',
+            $sql
+        );
+        $this->assertStringContainsString(
+            "SELECT setval(''%I.%I'', %s, false)",
+            $sql
+        );
     }
 
     public function testDatabaseUpdateRepairsExistingPublicSequences(): void


### PR DESCRIPTION
﻿## What changed
- Return inserted IDs when creating profiles, LLM connectors, and API key entries.
- Import ITT connectors through the existing connector model so imported API badge references are remapped correctly.
- Run profile import, connector creation, slot/default changes, and NPC migration in one transaction.
- Roll back all imported records if any step fails instead of leaving partial or duplicate imports.
- Add an idempotent `playthrough_schema` database update that advances only stale sequence-backed columns whose next value would collide with existing rows.
- Resolve sequence ownership through PostgreSQL catalogs instead of sequence-name conventions.
- Synchronize serial and identity sequences after snapshot cloning, including tables whose names do not match their sequence names.
- Preserve the source sequence's actual next value during cloning by accounting for `last_value`, `is_called`, and increment direction.
- Refresh older installed snapshot functions that support identity values but do not yet synchronize sequences.

## Root causes
The generic database insert helper did not return the inserted row ID. Profile rows could be committed successfully while the importer received `null`, reported `Import failed`, and skipped the remaining import actions. Retrying then created duplicate profiles.

Some existing/restored databases also have sequence values behind their stored IDs. This can make a valid insert reuse an existing primary key. The migration repairs those sequences without changing profile rows, while the snapshot update prevents future clones from preserving stale sequence state or reusing a previously issued ID after the highest row was deleted.

## Migration behavior
- Adds database update `playthrough_schema` version `20260723001`.
- Advances a sequence only when its calculated next value would collide with an existing table value.
- Leaves healthy sequences and empty-table sequence start states unchanged.
- Supports serial columns, generated identity columns, nonstandard sequence names, and descending sequences.
- Does not delete or rewrite profiles, connectors, NPCs, snapshots, or other user records.

## Validation
- PHP lint passed for all nine changed PHP files.
- Focused PHPUnit suite passed: 6 tests and 19 assertions.
- Transactional PostgreSQL integration covered stale, healthy, empty, serial, generated identity, nonstandard-name, and descending sequences.
- Snapshot clone regression probes passed for source-sequence-ahead, copied-table-ahead, empty-table, and generated-identity cases.
- A source with `MAX(id)=2` and actual next ID `4` now issues `4` after cloning instead of reusing deleted ID `3`.
- Snapshot clones successfully issued ID `13` after copied maximum `12` and ID `43` after copied maximum `42`.
- Installed legacy clone-function upgrade refreshed to the current definition and exposed the sequence synchronization helper.
- Failed test imports and all integration schemas were rolled back with no persistent test records.
- `git diff --check` passed.

## Notes
- Existing duplicate profiles created by earlier retries are not automatically deleted.
- The repository-wide PHPUnit run exceeded the three-minute local limit; the affected suites and direct PostgreSQL behavior passed independently.
- Not deployed locally and not tested through the browser import UI or in game.
