### PR TITLE
Add deterministic Oghma context rules

### DIFF
--- a/data/database_default.sql
+++ b/data/database_default.sql
@@ -1455,6 +1455,30 @@ CREATE TABLE public.oghma (
 ALTER TABLE public.oghma OWNER TO dwemer;
 
 --
+-- Name: oghma_context_rule; Type: TABLE; Schema: public; Owner: dwemer
+--
+
+CREATE TABLE public.oghma_context_rule (
+    id bigserial NOT NULL,
+    label text NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
+    priority integer DEFAULT 100 NOT NULL,
+    selector_type text DEFAULT 'topic'::text NOT NULL,
+    selector_value text NOT NULL,
+    conditions jsonb DEFAULT '{}'::jsonb NOT NULL,
+    max_articles smallint DEFAULT 1 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT oghma_context_rule_pkey PRIMARY KEY (id),
+    CONSTRAINT oghma_context_rule_selector_type_check CHECK ((selector_type = ANY (ARRAY['topic'::text, 'tag'::text, 'category'::text]))),
+    CONSTRAINT oghma_context_rule_max_articles_check CHECK (((max_articles >= 1) AND (max_articles <= 5)))
+);
+
+ALTER TABLE public.oghma_context_rule OWNER TO dwemer;
+
+CREATE INDEX idx_oghma_context_rule_active ON public.oghma_context_rule USING btree (enabled, priority, id);
+
+--
 -- Name: oghma_dynamic; Type: TABLE; Schema: public; Owner: dwemer
 --
 
@@ -1868,6 +1892,7 @@ INSERT INTO public.database_versioning VALUES ('actions_issued', 20250525001);
 INSERT INTO public.database_versioning VALUES ('moods_issued', 20250526001);
 INSERT INTO public.database_versioning VALUES ('dynamic_bio', 20250710001);
 INSERT INTO public.database_versioning VALUES ('oghma', 20250903001);
+INSERT INTO public.database_versioning VALUES ('oghma_context_rule', 20260724001);
 INSERT INTO public.database_versioning VALUES ('locations', 20250526001);
 INSERT INTO public.database_versioning VALUES ('rolemaster', 20250528001);
 INSERT INTO public.database_versioning VALUES ('db_maintenance', 20250528002);

--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -134,8 +134,19 @@ try {
         $db->execQuery(file_get_contents(__DIR__."/../lib/core/database_schema/core_narrator.sql"));
         $db->execQuery("SET search_path TO public");
     }
+    if ($checkTableExists("oghma_context_rule") == -1) {
+        $db->execQuery(file_get_contents(__DIR__."/../lib/core/database_schema/oghma_context_rule.sql"));
+        $db->execQuery("SET search_path TO public");
+    }
 } catch (Exception $e) {
     Logger::warn("Bootstrap core tables: " . $e->getMessage());
+}
+
+if ($checkVersion("oghma_context_rule") < 20260724001) {
+    Logger::debug("Applying oghma_context_rule 20260724001 - add deterministic Oghma context rules");
+    $db->execQuery(file_get_contents(__DIR__."/../lib/core/database_schema/oghma_context_rule.sql"));
+    $updateVersion("oghma_context_rule", 20260724001);
+    Logger::info("Applied patch oghma_context_rule 20260724001");
 }
 
 if ($checkVersion("core_action") < 20260426001) {

--- a/lib/core/database_schema/oghma_context_rule.sql
+++ b/lib/core/database_schema/oghma_context_rule.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS public.oghma_context_rule (
+    id BIGSERIAL PRIMARY KEY,
+    label TEXT NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    priority INTEGER NOT NULL DEFAULT 100,
+    selector_type TEXT NOT NULL DEFAULT 'topic',
+    selector_value TEXT NOT NULL,
+    conditions JSONB NOT NULL DEFAULT '{}'::jsonb,
+    max_articles SMALLINT NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT oghma_context_rule_selector_type_check
+        CHECK (selector_type IN ('topic', 'tag', 'category')),
+    CONSTRAINT oghma_context_rule_max_articles_check
+        CHECK (max_articles BETWEEN 1 AND 5)
+);
+
+CREATE INDEX IF NOT EXISTS idx_oghma_context_rule_active
+    ON public.oghma_context_rule (enabled, priority, id);

--- a/lib/oghma_context_rule_admin.php
+++ b/lib/oghma_context_rule_admin.php
@@ -1,0 +1,111 @@
+<?php
+
+function oghma_context_rule_values($value): array
+{
+    $values = preg_split('/\s*,\s*/u', trim((string)$value)) ?: [];
+
+    return array_values(array_filter(array_map('trim', $values), static function ($entry) {
+        return $entry !== '';
+    }));
+}
+
+function oghma_context_rule_conditions_from_post(array $post): array
+{
+    $conditions = [];
+    $fields = [
+        'npc',
+        'nearby_actor',
+        'race',
+        'faction',
+        'profile',
+        'location',
+        'hold',
+        'environment',
+        'weather',
+        'event_type',
+    ];
+
+    foreach ($fields as $field) {
+        $values = oghma_context_rule_values($post['condition_' . $field] ?? '');
+        if (!empty($values)) {
+            $conditions[$field] = $values;
+        }
+    }
+
+    return $conditions;
+}
+
+function oghma_context_rule_condition_text(array $conditions, string $field): string
+{
+    $values = $conditions[$field] ?? [];
+    if (!is_array($values)) {
+        return trim((string)$values);
+    }
+
+    return implode(', ', array_map('strval', $values));
+}
+
+function oghma_context_rule_handle_post($conn, string $schema, array $post, string $method): string
+{
+    if ($method !== 'POST') {
+        return '';
+    }
+
+    if (isset($post['delete_context_rule'])) {
+        $ruleId = max(0, (int)($post['context_rule_id'] ?? 0));
+        if ($ruleId <= 0) {
+            return '';
+        }
+
+        $result = pg_query_params(
+            $conn,
+            "DELETE FROM {$schema}.oghma_context_rule WHERE id = $1",
+            [$ruleId]
+        );
+
+        return $result ? '<p>Context rule deleted.</p>' : '<p>Unable to delete context rule.</p>';
+    }
+
+    if (!isset($post['save_context_rule'])) {
+        return '';
+    }
+
+    $ruleId = max(0, (int)($post['context_rule_id'] ?? 0));
+    $label = trim((string)($post['context_rule_label'] ?? ''));
+    $enabled = isset($post['context_rule_enabled']) && $post['context_rule_enabled'] === '1';
+    $priority = (int)($post['context_rule_priority'] ?? 100);
+    $selectorType = strtolower(trim((string)($post['context_rule_selector_type'] ?? 'topic')));
+    $selectorValue = trim((string)($post['context_rule_selector_value'] ?? ''));
+    $maxArticles = max(1, min(5, (int)($post['context_rule_max_articles'] ?? 1)));
+    $conditionsJson = json_encode(
+        oghma_context_rule_conditions_from_post($post),
+        JSON_UNESCAPED_UNICODE
+    );
+
+    if ($label === '' || $selectorValue === '' || !in_array($selectorType, ['topic', 'tag', 'category'], true)) {
+        return '<p>Context rule name, selector type, and selector value are required.</p>';
+    }
+
+    if ($ruleId > 0) {
+        $result = pg_query_params(
+            $conn,
+            "UPDATE {$schema}.oghma_context_rule
+                SET label = $1, enabled = $2, priority = $3, selector_type = $4,
+                    selector_value = $5, conditions = $6::jsonb, max_articles = $7, updated_at = NOW()
+              WHERE id = $8",
+            [$label, $enabled ? 't' : 'f', $priority, $selectorType, $selectorValue, $conditionsJson, $maxArticles, $ruleId]
+        );
+
+        return $result ? '<p>Context rule updated.</p>' : '<p>Unable to update context rule.</p>';
+    }
+
+    $result = pg_query_params(
+        $conn,
+        "INSERT INTO {$schema}.oghma_context_rule
+            (label, enabled, priority, selector_type, selector_value, conditions, max_articles)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)",
+        [$label, $enabled ? 't' : 'f', $priority, $selectorType, $selectorValue, $conditionsJson, $maxArticles]
+    );
+
+    return $result ? '<p>Context rule created.</p>' : '<p>Unable to create context rule.</p>';
+}

--- a/lib/oghma_context_rules.php
+++ b/lib/oghma_context_rules.php
@@ -1,0 +1,254 @@
+<?php
+
+if (!function_exists('chimOghmaRuleValues')) {
+    function chimOghmaRuleValues($value): array
+    {
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+            if (is_array($decoded)) {
+                $value = $decoded;
+            } else {
+                $value = preg_split('/\s*,\s*/u', $value) ?: [];
+            }
+        }
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($value as $entry) {
+            $normalized = chimOghmaNormalizeLookupLabel($entry);
+            if ($normalized !== '') {
+                $values[$normalized] = $normalized;
+            }
+        }
+        return array_values($values);
+    }
+}
+
+if (!function_exists('chimOghmaRuleExtendedDataFactions')) {
+    function chimOghmaRuleExtendedDataFactions($npcMaster, array $currentNpcData): array
+    {
+        if (!$npcMaster || !method_exists($npcMaster, 'getExtendedData')) {
+            return [];
+        }
+        $extendedData = $npcMaster->getExtendedData($currentNpcData);
+        if (!is_array($extendedData) || !is_array($extendedData['factions'] ?? null)) {
+            return [];
+        }
+
+        $factions = [];
+        foreach ($extendedData['factions'] as $faction) {
+            if (!is_array($faction)) {
+                continue;
+            }
+            foreach (['name', 'editorid', 'formid'] as $field) {
+                if (!empty($faction[$field])) {
+                    $factions[] = $faction[$field];
+                }
+            }
+            if (!empty($faction['formid']) && function_exists('lookupDescriptionByFormID')) {
+                $description = lookupDescriptionByFormID($faction['formid']);
+                if (is_array($description) && !empty($description['name'])) {
+                    $factions[] = $description['name'];
+                }
+            }
+        }
+        return chimOghmaUniqueSignals($factions);
+    }
+}
+
+if (!function_exists('chimOghmaWeatherSignals')) {
+    function chimOghmaWeatherSignals($weather): array
+    {
+        $weather = trim((string) $weather);
+        if ($weather === '') {
+            return [];
+        }
+        $signals = [$weather];
+        $withoutPrefix = preg_replace('/^outdoors\s+it\s+is\s+/iu', '', $weather);
+        $signals[] = $withoutPrefix;
+        $signals = array_merge($signals, preg_split('/\s*,\s*/u', (string) $withoutPrefix) ?: []);
+        return chimOghmaUniqueSignals($signals);
+    }
+}
+
+if (!function_exists('chimOghmaBuildContextRuleContext')) {
+    function chimOghmaBuildContextRuleContext($db, $npcMaster = null): array
+    {
+        $currentNpcData = is_array($GLOBALS['CHIM_CORE_CURRENT_NPC_DATA'] ?? null)
+            ? $GLOBALS['CHIM_CORE_CURRENT_NPC_DATA']
+            : [];
+        $locationGroups = chimOghmaCollectLocationSignalGroups($db);
+        $locationParts = function_exists('DataLastKnownLocationContextParts')
+            ? DataLastKnownLocationContextParts(false)
+            : [];
+        $rawLocation = trim((string) ($locationParts['location'] ?? ''));
+        $environment = '';
+        if (preg_match('/\s+(interior|outdoors)\s*$/iu', $rawLocation, $matches)) {
+            $environment = strtolower($matches[1]) === 'interior' ? 'interior' : 'exterior';
+        }
+
+        $gameRequest = is_array($GLOBALS['gameRequest'] ?? null) ? $GLOBALS['gameRequest'] : [];
+        $npcNames = array_filter([
+            $currentNpcData['npc_name'] ?? '',
+            $GLOBALS['HERIKA_NAME'] ?? '',
+        ]);
+
+        return [
+            'npc' => chimOghmaUniqueSignals($npcNames),
+            'nearby_actor' => chimOghmaUniqueSignals(chimOghmaPeopleNames($GLOBALS['CACHE_PEOPLE'] ?? '')),
+            'race' => chimOghmaRaceSignals($currentNpcData['race'] ?? ''),
+            'faction' => chimOghmaRuleExtendedDataFactions($npcMaster, $currentNpcData),
+            'profile' => chimOghmaRuleValues([$currentNpcData['profile_id'] ?? '']),
+            'location' => chimOghmaUniqueSignals($locationGroups['location'] ?? []),
+            'hold' => chimOghmaUniqueSignals($locationGroups['hold'] ?? []),
+            'environment' => chimOghmaRuleValues([$environment]),
+            'weather' => chimOghmaWeatherSignals(
+                function_exists('DataLastKnownWeatherHuman') ? DataLastKnownWeatherHuman() : ''
+            ),
+            'event_type' => chimOghmaRuleValues([$gameRequest[0] ?? '']),
+        ];
+    }
+}
+
+if (!function_exists('chimOghmaContextRuleMatches')) {
+    function chimOghmaContextRuleMatches(array $conditions, array $context, ?array &$reasons = null): bool
+    {
+        $reasons = [];
+        foreach ($conditions as $field => $expectedValues) {
+            $expected = chimOghmaRuleValues($expectedValues);
+            if (empty($expected)) {
+                continue;
+            }
+            $actual = chimOghmaRuleValues($context[$field] ?? []);
+            $matched = array_values(array_intersect($expected, $actual));
+            if (empty($matched)) {
+                return false;
+            }
+            $reasons[] = $field . '=' . implode('|', $matched);
+        }
+        return true;
+    }
+}
+
+if (!function_exists('chimOghmaFindRowsForRuleSelector')) {
+    function chimOghmaFindRowsForRuleSelector($db, string $selectorType, string $selectorValue, int $limit): array
+    {
+        if (!$db || !method_exists($db, 'fetchAll')) {
+            return [];
+        }
+        $selectorType = strtolower(trim($selectorType));
+        $selectorValue = chimOghmaNormalizeLookupLabel($selectorValue);
+        if ($selectorValue === '' || !in_array($selectorType, ['topic', 'tag', 'category'], true)) {
+            return [];
+        }
+
+        $escaped = $db->escape($selectorValue);
+        if ($selectorType === 'topic') {
+            $condition = "EXISTS (
+                SELECT 1
+                  FROM regexp_split_to_table(topic, E'\\\\s*,\\\\s*') AS selector_value
+                 WHERE regexp_replace(replace(lower(selector_value), '_', ' '), '[^a-z0-9]+', ' ', 'g') = '{$escaped}'
+            )";
+        } elseif ($selectorType === 'tag') {
+            $condition = "EXISTS (
+                SELECT 1
+                  FROM regexp_split_to_table(coalesce(tags, ''), E'\\\\s*,\\\\s*') AS selector_value
+                 WHERE regexp_replace(replace(lower(selector_value), '_', ' '), '[^a-z0-9]+', ' ', 'g') = '{$escaped}'
+            )";
+        } else {
+            $condition = "regexp_replace(replace(lower(coalesce(category, '')), '_', ' '), '[^a-z0-9]+', ' ', 'g') = '{$escaped}'";
+        }
+
+        $limit = max(1, min(5, $limit));
+        $rows = $db->fetchAll(
+            "SELECT topic, topic_desc, knowledge_class, topic_desc_basic, knowledge_class_basic
+               FROM public.oghma
+              WHERE {$condition}
+              ORDER BY topic
+              LIMIT {$limit}"
+        );
+        return is_array($rows) ? $rows : [];
+    }
+}
+
+if (!function_exists('chimOghmaLoadContextRules')) {
+    function chimOghmaLoadContextRules($db): array
+    {
+        if (!$db || !method_exists($db, 'fetchAll')) {
+            return [];
+        }
+        try {
+            $rules = $db->fetchAll(
+                "SELECT id, label, priority, selector_type, selector_value, conditions, max_articles
+                   FROM public.oghma_context_rule
+                  WHERE enabled = TRUE
+                  ORDER BY priority, id"
+            );
+            return is_array($rules) ? $rules : [];
+        } catch (Throwable $exception) {
+            if (class_exists('Logger')) {
+                Logger::warn('[OGHMA] Context rules unavailable: ' . $exception->getMessage());
+            }
+            return [];
+        }
+    }
+}
+
+if (!function_exists('chimOghmaInjectContextRules')) {
+    function chimOghmaInjectContextRules($db, $npcMaster = null): int
+    {
+        $rules = chimOghmaLoadContextRules($db);
+        if (empty($rules)) {
+            return 0;
+        }
+
+        $knowledgeTags = array_values(array_filter(array_map(
+            'trim',
+            explode(',', (string) ($GLOBALS['OGHMA_KNOWLEDGE'] ?? ''))
+        )));
+        $knowledgeTags[] = (string) ($GLOBALS['HERIKA_NAME'] ?? '');
+        $context = chimOghmaBuildContextRuleContext($db, $npcMaster);
+        $added = 0;
+
+        foreach ($rules as $rule) {
+            $conditions = $rule['conditions'] ?? [];
+            if (is_string($conditions)) {
+                $conditions = json_decode($conditions, true);
+            }
+            if (!is_array($conditions)) {
+                $conditions = [];
+            }
+            $reasons = [];
+            if (!chimOghmaContextRuleMatches($conditions, $context, $reasons)) {
+                continue;
+            }
+
+            $limit = max(1, min(5, (int) ($rule['max_articles'] ?? 1)));
+            $rows = chimOghmaFindRowsForRuleSelector(
+                $db,
+                (string) ($rule['selector_type'] ?? 'topic'),
+                (string) ($rule['selector_value'] ?? ''),
+                $limit
+            );
+            $ruleAdded = chimOghmaAppendForcedRows(
+                $rows,
+                $knowledgeTags,
+                'context rule ' . (int) ($rule['id'] ?? 0),
+                $limit
+            );
+            $added += $ruleAdded;
+
+            if (class_exists('Logger')) {
+                $label = trim((string) ($rule['label'] ?? 'Unnamed rule'));
+                $reasonText = empty($reasons) ? 'always' : implode(', ', $reasons);
+                Logger::info(
+                    "[OGHMA] Context rule " . (int) ($rule['id'] ?? 0)
+                    . " '{$label}' matched ({$reasonText}); added {$ruleAdded} article(s)"
+                );
+            }
+        }
+        return $added;
+    }
+}

--- a/lib/oghma_forced_context.php
+++ b/lib/oghma_forced_context.php
@@ -340,6 +340,8 @@ if (!function_exists('chimOghmaAppendForcedRows')) {
     }
 }
 
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'oghma_context_rules.php';
+
 if (!function_exists('chimOghmaInjectForcedContext')) {
     function chimOghmaInjectForcedContext($db, $npcMaster = null): int
     {
@@ -385,6 +387,8 @@ if (!function_exists('chimOghmaInjectForcedContext')) {
                 1
             );
         }
+
+        $added += chimOghmaInjectContextRules($db, $npcMaster);
 
         return $added;
     }

--- a/ui/oghma_upload.php
+++ b/ui/oghma_upload.php
@@ -44,163 +44,13 @@ if (!$conn) {
     exit;
 }
 
-function oghma_context_rule_values($value): array {
-    $values = preg_split('/\s*,\s*/u', trim((string)$value)) ?: [];
-    return array_values(array_filter(array_map('trim', $values), static function ($entry) {
-        return $entry !== '';
-    }));
-}
-
-function oghma_context_rule_conditions_from_post(): array {
-    $conditions = [];
-    foreach (['npc', 'nearby_actor', 'race', 'faction', 'profile', 'location', 'hold', 'environment', 'weather', 'event_type'] as $field) {
-        $values = oghma_context_rule_values($_POST['condition_' . $field] ?? '');
-        if (!empty($values)) {
-            $conditions[$field] = $values;
-        }
-    }
-    return $conditions;
-}
-
-function oghma_context_rule_condition_text(array $conditions, string $field): string {
-    $values = $conditions[$field] ?? [];
-    if (!is_array($values)) {
-        return trim((string)$values);
-    }
-    return implode(', ', array_map('strval', $values));
-}
-
-function oghma_render_context_rule_form(array $rule, bool $isNew = false): void {
-    $conditions = $rule['conditions'] ?? [];
-    if (is_string($conditions)) {
-        $conditions = json_decode($conditions, true);
-    }
-    if (!is_array($conditions)) {
-        $conditions = [];
-    }
-    $ruleId = (int)($rule['id'] ?? 0);
-    $enabledValue = strtolower(trim((string)($rule['enabled'] ?? '')));
-    $enabled = $isNew || in_array($enabledValue, ['1', 't', 'true', 'on', 'yes'], true);
-    $fields = [
-        'npc' => ['NPC Name', 'Current speaking NPC name.'],
-        'nearby_actor' => ['Nearby Actor', 'Any actor listed as present.'],
-        'race' => ['Race', 'Current NPC race, including common aliases.'],
-        'faction' => ['Faction', 'Current NPC faction name, editor ID, or form ID.'],
-        'profile' => ['Profile ID', 'Current NPC profile ID.'],
-        'location' => ['Location or Region', 'Current location, parent location, or region.'],
-        'hold' => ['Hold', 'Current canonical or reported hold.'],
-        'environment' => ['Environment', 'Use interior or exterior.'],
-        'weather' => ['Weather', 'Current weather description.'],
-        'event_type' => ['Event Type', 'Current request type, such as inputtext or combat.'],
-    ];
-    ?>
-    <form method="post" class="context-rule-card">
-        <input type="hidden" name="save_context_rule" value="1">
-        <input type="hidden" name="context_rule_id" value="<?php echo $ruleId; ?>">
-        <h3><?php echo $isNew ? 'Create Context Rule' : htmlspecialchars((string)($rule['label'] ?? 'Context Rule'), ENT_QUOTES, 'UTF-8'); ?></h3>
-        <div class="context-rule-grid">
-            <div class="context-rule-field">
-                <label>Rule Name</label>
-                <small>Human-readable label used in audit logs.</small>
-                <input type="text" name="context_rule_label" required value="<?php echo htmlspecialchars((string)($rule['label'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>">
-            </div>
-            <div class="context-rule-field">
-                <label>Selector Type</label>
-                <small>Choose how this rule finds Oghma articles.</small>
-                <select name="context_rule_selector_type">
-                    <?php foreach (['topic' => 'Exact Topic', 'tag' => 'Tag', 'category' => 'Category'] as $value => $label): ?>
-                        <option value="<?php echo $value; ?>" <?php echo (($rule['selector_type'] ?? 'topic') === $value) ? 'selected' : ''; ?>><?php echo $label; ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            <div class="context-rule-field">
-                <label>Selector Value</label>
-                <small>Exact topic alias, tag, or category to inject.</small>
-                <input type="text" name="context_rule_selector_value" required value="<?php echo htmlspecialchars((string)($rule['selector_value'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>">
-            </div>
-            <div class="context-rule-field">
-                <label>Priority</label>
-                <small>Lower numbers run first.</small>
-                <input type="number" name="context_rule_priority" value="<?php echo (int)($rule['priority'] ?? 100); ?>">
-            </div>
-            <div class="context-rule-field">
-                <label>Maximum Articles</label>
-                <small>Limits tag and category selectors to 1-5 articles.</small>
-                <input type="number" name="context_rule_max_articles" min="1" max="5" value="<?php echo max(1, min(5, (int)($rule['max_articles'] ?? 1))); ?>">
-            </div>
-            <?php foreach ($fields as $field => [$label, $description]): ?>
-                <div class="context-rule-field">
-                    <label><?php echo htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?></label>
-                    <small><?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?> Separate alternatives with commas.</small>
-                    <input type="text" name="condition_<?php echo $field; ?>" value="<?php echo htmlspecialchars(oghma_context_rule_condition_text($conditions, $field), ENT_QUOTES, 'UTF-8'); ?>">
-                </div>
-            <?php endforeach; ?>
-        </div>
-        <div class="context-rule-actions">
-            <label class="context-rule-enabled">
-                <input type="checkbox" name="context_rule_enabled" value="1" <?php echo $enabled ? 'checked' : ''; ?>>
-                Enabled
-            </label>
-            <button type="submit" class="btn-save"><?php echo $isNew ? 'Create Rule' : 'Save Rule'; ?></button>
-            <?php if (!$isNew): ?>
-                <button
-                    type="submit"
-                    name="delete_context_rule"
-                    value="1"
-                    class="btn-danger"
-                    onclick="return confirm('Delete this context rule?');"
-                >Delete</button>
-            <?php endif; ?>
-        </div>
-    </form>
-    <?php
-}
-
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_context_rule']) && !isset($_POST['delete_context_rule'])) {
-    $ruleId = max(0, (int)($_POST['context_rule_id'] ?? 0));
-    $label = trim((string)($_POST['context_rule_label'] ?? ''));
-    $enabled = isset($_POST['context_rule_enabled']) && $_POST['context_rule_enabled'] === '1';
-    $priority = (int)($_POST['context_rule_priority'] ?? 100);
-    $selectorType = strtolower(trim((string)($_POST['context_rule_selector_type'] ?? 'topic')));
-    $selectorValue = trim((string)($_POST['context_rule_selector_value'] ?? ''));
-    $maxArticles = max(1, min(5, (int)($_POST['context_rule_max_articles'] ?? 1)));
-    $conditionsJson = json_encode(oghma_context_rule_conditions_from_post(), JSON_UNESCAPED_UNICODE);
-
-    if ($label === '' || $selectorValue === '' || !in_array($selectorType, ['topic', 'tag', 'category'], true)) {
-        $message .= '<p>Context rule name, selector type, and selector value are required.</p>';
-    } elseif ($ruleId > 0) {
-        $result = pg_query_params(
-            $conn,
-            "UPDATE {$schema}.oghma_context_rule
-                SET label = $1, enabled = $2, priority = $3, selector_type = $4,
-                    selector_value = $5, conditions = $6::jsonb, max_articles = $7, updated_at = NOW()
-              WHERE id = $8",
-            [$label, $enabled ? 't' : 'f', $priority, $selectorType, $selectorValue, $conditionsJson, $maxArticles, $ruleId]
-        );
-        $message .= $result ? '<p>Context rule updated.</p>' : '<p>Unable to update context rule.</p>';
-    } else {
-        $result = pg_query_params(
-            $conn,
-            "INSERT INTO {$schema}.oghma_context_rule
-                (label, enabled, priority, selector_type, selector_value, conditions, max_articles)
-             VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)",
-            [$label, $enabled ? 't' : 'f', $priority, $selectorType, $selectorValue, $conditionsJson, $maxArticles]
-        );
-        $message .= $result ? '<p>Context rule created.</p>' : '<p>Unable to create context rule.</p>';
-    }
-}
-
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_context_rule'])) {
-    $ruleId = max(0, (int)($_POST['context_rule_id'] ?? 0));
-    if ($ruleId > 0) {
-        $result = pg_query_params(
-            $conn,
-            "DELETE FROM {$schema}.oghma_context_rule WHERE id = $1",
-            [$ruleId]
-        );
-        $message .= $result ? '<p>Context rule deleted.</p>' : '<p>Unable to delete context rule.</p>';
-    }
-}
+require_once $rootPath . 'lib' . DIRECTORY_SEPARATOR . 'oghma_context_rule_admin.php';
+$message .= oghma_context_rule_handle_post(
+    $conn,
+    $schema,
+    $_POST,
+    $_SERVER['REQUEST_METHOD'] ?? 'GET'
+);
 
 /********************************************************************
  *  1) SINGLE TOPIC UPLOAD
@@ -1565,73 +1415,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
         }
     }
 
-    .context-rule-intro {
-        margin-bottom: 16px;
-    }
-
-    .context-rule-grid {
-        display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 12px;
-    }
-
-    .context-rule-card {
-        border: 1px solid #4a4a4a;
-        border-radius: 6px;
-        background: #242424;
-        padding: 14px;
-        margin-bottom: 14px;
-    }
-
-    .context-rule-card h3 {
-        margin: 0 0 12px;
-        color: rgb(242, 124, 17);
-    }
-
-    .context-rule-field label {
-        display: block;
-        margin-bottom: 4px;
-        font-weight: 600;
-    }
-
-    .context-rule-field small {
-        display: block;
-        min-height: 34px;
-        margin-bottom: 5px;
-        color: #b8b8b8;
-    }
-
-    .context-rule-field input,
-    .context-rule-field select {
-        width: 100%;
-        box-sizing: border-box;
-    }
-
-    .context-rule-actions {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        margin-top: 12px;
-    }
-
-    .context-rule-enabled {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        margin-right: auto;
-    }
-
-    @media (max-width: 1100px) {
-        .context-rule-grid {
-            grid-template-columns: repeat(2, minmax(0, 1fr));
-        }
-    }
-
-    @media (max-width: 700px) {
-        .context-rule-grid {
-            grid-template-columns: 1fr;
-        }
-    }
 </style>
 
 <?php if ($isEmbed): ?>
@@ -2175,43 +1958,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
         </div>
     </div>
 
-    <div id="rules-tab" class="tab-content">
-        <div class="full-width-section">
-            <div class="context-rule-intro">
-                <h2>&#x1F3AF; Oghma Context Rules</h2>
-                <p>All populated conditions on a rule must match. Comma-separated values within one condition are alternatives. Leave every condition blank to create an always-on rule.</p>
-                <p>Normal Oghma search and the existing Force Racial Oghma and Force Location Oghma settings continue to work alongside these rules.</p>
-            </div>
-
-            <?php
-            oghma_render_context_rule_form([
-                'priority' => 100,
-                'selector_type' => 'topic',
-                'max_articles' => 1,
-                'conditions' => [],
-            ], true);
-
-            $contextRulesResult = pg_query(
-                $conn,
-                "SELECT id, label, enabled, priority, selector_type, selector_value, conditions, max_articles
-                   FROM {$schema}.oghma_context_rule
-                  ORDER BY priority, id"
-            );
-            if ($contextRulesResult) {
-                $contextRuleCount = 0;
-                while ($contextRule = pg_fetch_assoc($contextRulesResult)) {
-                    oghma_render_context_rule_form($contextRule, false);
-                    $contextRuleCount++;
-                }
-                if ($contextRuleCount === 0) {
-                    echo '<p>No context rules have been created.</p>';
-                }
-            } else {
-                echo '<p>Unable to load context rules. Apply database updates, then refresh this page.</p>';
-            }
-            ?>
-        </div>
-    </div>
+    <?php include __DIR__ . DIRECTORY_SEPARATOR . 'tmpl' . DIRECTORY_SEPARATOR . 'oghma_context_rules_panel.php'; ?>
 
 <div id="editModal" class="modal-backdrop">
     <div class="modal-container">

--- a/ui/oghma_upload.php
+++ b/ui/oghma_upload.php
@@ -44,6 +44,164 @@ if (!$conn) {
     exit;
 }
 
+function oghma_context_rule_values($value): array {
+    $values = preg_split('/\s*,\s*/u', trim((string)$value)) ?: [];
+    return array_values(array_filter(array_map('trim', $values), static function ($entry) {
+        return $entry !== '';
+    }));
+}
+
+function oghma_context_rule_conditions_from_post(): array {
+    $conditions = [];
+    foreach (['npc', 'nearby_actor', 'race', 'faction', 'profile', 'location', 'hold', 'environment', 'weather', 'event_type'] as $field) {
+        $values = oghma_context_rule_values($_POST['condition_' . $field] ?? '');
+        if (!empty($values)) {
+            $conditions[$field] = $values;
+        }
+    }
+    return $conditions;
+}
+
+function oghma_context_rule_condition_text(array $conditions, string $field): string {
+    $values = $conditions[$field] ?? [];
+    if (!is_array($values)) {
+        return trim((string)$values);
+    }
+    return implode(', ', array_map('strval', $values));
+}
+
+function oghma_render_context_rule_form(array $rule, bool $isNew = false): void {
+    $conditions = $rule['conditions'] ?? [];
+    if (is_string($conditions)) {
+        $conditions = json_decode($conditions, true);
+    }
+    if (!is_array($conditions)) {
+        $conditions = [];
+    }
+    $ruleId = (int)($rule['id'] ?? 0);
+    $enabledValue = strtolower(trim((string)($rule['enabled'] ?? '')));
+    $enabled = $isNew || in_array($enabledValue, ['1', 't', 'true', 'on', 'yes'], true);
+    $fields = [
+        'npc' => ['NPC Name', 'Current speaking NPC name.'],
+        'nearby_actor' => ['Nearby Actor', 'Any actor listed as present.'],
+        'race' => ['Race', 'Current NPC race, including common aliases.'],
+        'faction' => ['Faction', 'Current NPC faction name, editor ID, or form ID.'],
+        'profile' => ['Profile ID', 'Current NPC profile ID.'],
+        'location' => ['Location or Region', 'Current location, parent location, or region.'],
+        'hold' => ['Hold', 'Current canonical or reported hold.'],
+        'environment' => ['Environment', 'Use interior or exterior.'],
+        'weather' => ['Weather', 'Current weather description.'],
+        'event_type' => ['Event Type', 'Current request type, such as inputtext or combat.'],
+    ];
+    ?>
+    <form method="post" class="context-rule-card">
+        <input type="hidden" name="save_context_rule" value="1">
+        <input type="hidden" name="context_rule_id" value="<?php echo $ruleId; ?>">
+        <h3><?php echo $isNew ? 'Create Context Rule' : htmlspecialchars((string)($rule['label'] ?? 'Context Rule'), ENT_QUOTES, 'UTF-8'); ?></h3>
+        <div class="context-rule-grid">
+            <div class="context-rule-field">
+                <label>Rule Name</label>
+                <small>Human-readable label used in audit logs.</small>
+                <input type="text" name="context_rule_label" required value="<?php echo htmlspecialchars((string)($rule['label'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>">
+            </div>
+            <div class="context-rule-field">
+                <label>Selector Type</label>
+                <small>Choose how this rule finds Oghma articles.</small>
+                <select name="context_rule_selector_type">
+                    <?php foreach (['topic' => 'Exact Topic', 'tag' => 'Tag', 'category' => 'Category'] as $value => $label): ?>
+                        <option value="<?php echo $value; ?>" <?php echo (($rule['selector_type'] ?? 'topic') === $value) ? 'selected' : ''; ?>><?php echo $label; ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="context-rule-field">
+                <label>Selector Value</label>
+                <small>Exact topic alias, tag, or category to inject.</small>
+                <input type="text" name="context_rule_selector_value" required value="<?php echo htmlspecialchars((string)($rule['selector_value'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>">
+            </div>
+            <div class="context-rule-field">
+                <label>Priority</label>
+                <small>Lower numbers run first.</small>
+                <input type="number" name="context_rule_priority" value="<?php echo (int)($rule['priority'] ?? 100); ?>">
+            </div>
+            <div class="context-rule-field">
+                <label>Maximum Articles</label>
+                <small>Limits tag and category selectors to 1-5 articles.</small>
+                <input type="number" name="context_rule_max_articles" min="1" max="5" value="<?php echo max(1, min(5, (int)($rule['max_articles'] ?? 1))); ?>">
+            </div>
+            <?php foreach ($fields as $field => [$label, $description]): ?>
+                <div class="context-rule-field">
+                    <label><?php echo htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?></label>
+                    <small><?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?> Separate alternatives with commas.</small>
+                    <input type="text" name="condition_<?php echo $field; ?>" value="<?php echo htmlspecialchars(oghma_context_rule_condition_text($conditions, $field), ENT_QUOTES, 'UTF-8'); ?>">
+                </div>
+            <?php endforeach; ?>
+        </div>
+        <div class="context-rule-actions">
+            <label class="context-rule-enabled">
+                <input type="checkbox" name="context_rule_enabled" value="1" <?php echo $enabled ? 'checked' : ''; ?>>
+                Enabled
+            </label>
+            <button type="submit" class="btn-save"><?php echo $isNew ? 'Create Rule' : 'Save Rule'; ?></button>
+            <?php if (!$isNew): ?>
+                <button
+                    type="submit"
+                    name="delete_context_rule"
+                    value="1"
+                    class="btn-danger"
+                    onclick="return confirm('Delete this context rule?');"
+                >Delete</button>
+            <?php endif; ?>
+        </div>
+    </form>
+    <?php
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_context_rule']) && !isset($_POST['delete_context_rule'])) {
+    $ruleId = max(0, (int)($_POST['context_rule_id'] ?? 0));
+    $label = trim((string)($_POST['context_rule_label'] ?? ''));
+    $enabled = isset($_POST['context_rule_enabled']) && $_POST['context_rule_enabled'] === '1';
+    $priority = (int)($_POST['context_rule_priority'] ?? 100);
+    $selectorType = strtolower(trim((string)($_POST['context_rule_selector_type'] ?? 'topic')));
+    $selectorValue = trim((string)($_POST['context_rule_selector_value'] ?? ''));
+    $maxArticles = max(1, min(5, (int)($_POST['context_rule_max_articles'] ?? 1)));
+    $conditionsJson = json_encode(oghma_context_rule_conditions_from_post(), JSON_UNESCAPED_UNICODE);
+
+    if ($label === '' || $selectorValue === '' || !in_array($selectorType, ['topic', 'tag', 'category'], true)) {
+        $message .= '<p>Context rule name, selector type, and selector value are required.</p>';
+    } elseif ($ruleId > 0) {
+        $result = pg_query_params(
+            $conn,
+            "UPDATE {$schema}.oghma_context_rule
+                SET label = $1, enabled = $2, priority = $3, selector_type = $4,
+                    selector_value = $5, conditions = $6::jsonb, max_articles = $7, updated_at = NOW()
+              WHERE id = $8",
+            [$label, $enabled ? 't' : 'f', $priority, $selectorType, $selectorValue, $conditionsJson, $maxArticles, $ruleId]
+        );
+        $message .= $result ? '<p>Context rule updated.</p>' : '<p>Unable to update context rule.</p>';
+    } else {
+        $result = pg_query_params(
+            $conn,
+            "INSERT INTO {$schema}.oghma_context_rule
+                (label, enabled, priority, selector_type, selector_value, conditions, max_articles)
+             VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)",
+            [$label, $enabled ? 't' : 'f', $priority, $selectorType, $selectorValue, $conditionsJson, $maxArticles]
+        );
+        $message .= $result ? '<p>Context rule created.</p>' : '<p>Unable to create context rule.</p>';
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_context_rule'])) {
+    $ruleId = max(0, (int)($_POST['context_rule_id'] ?? 0));
+    if ($ruleId > 0) {
+        $result = pg_query_params(
+            $conn,
+            "DELETE FROM {$schema}.oghma_context_rule WHERE id = $1",
+            [$ruleId]
+        );
+        $message .= $result ? '<p>Context rule deleted.</p>' : '<p>Unable to delete context rule.</p>';
+    }
+}
+
 /********************************************************************
  *  1) SINGLE TOPIC UPLOAD
  ********************************************************************/
@@ -1406,6 +1564,74 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
             align-self: center;
         }
     }
+
+    .context-rule-intro {
+        margin-bottom: 16px;
+    }
+
+    .context-rule-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 12px;
+    }
+
+    .context-rule-card {
+        border: 1px solid #4a4a4a;
+        border-radius: 6px;
+        background: #242424;
+        padding: 14px;
+        margin-bottom: 14px;
+    }
+
+    .context-rule-card h3 {
+        margin: 0 0 12px;
+        color: rgb(242, 124, 17);
+    }
+
+    .context-rule-field label {
+        display: block;
+        margin-bottom: 4px;
+        font-weight: 600;
+    }
+
+    .context-rule-field small {
+        display: block;
+        min-height: 34px;
+        margin-bottom: 5px;
+        color: #b8b8b8;
+    }
+
+    .context-rule-field input,
+    .context-rule-field select {
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    .context-rule-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 12px;
+    }
+
+    .context-rule-enabled {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        margin-right: auto;
+    }
+
+    @media (max-width: 1100px) {
+        .context-rule-grid {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+    }
+
+    @media (max-width: 700px) {
+        .context-rule-grid {
+            grid-template-columns: 1fr;
+        }
+    }
 </style>
 
 <?php if ($isEmbed): ?>
@@ -1481,6 +1707,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
                 <p>It is currently empty by default. We need your help adding more entries!</p>
                 <p><a href="https://docs.google.com/spreadsheets/d/1dcfctU-iOqprwy2BOc7___4Awteczgdlv8886KalPsQ/edit?gid=243486711#gid=243486711" style="color: yellow;" target="_blank" rel="noopener noreferrer">Would you like to know more?</a></p>
             </div>
+
+            <div id="rules-header-content" style="display: none;">
+                <p><b>Context Rules</b> inject selected Oghma articles when the current NPC and scene match your conditions.</p>
+                <p>Rules are deterministic, preserve each article's knowledge permissions, and never replace normal Oghma topic search.</p>
+            </div>
         </div>
     </div>
 
@@ -1491,6 +1722,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
         </button>
         <button class="tab-button" onclick="switchTab('dynamic-tab')">
             &#x26A1; Dynamic Oghma
+        </button>
+        <button class="tab-button" onclick="switchTab('rules-tab')">
+            &#x1F3AF; Context Rules
         </button>
     </div>
 
@@ -1941,6 +2175,44 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
         </div>
     </div>
 
+    <div id="rules-tab" class="tab-content">
+        <div class="full-width-section">
+            <div class="context-rule-intro">
+                <h2>&#x1F3AF; Oghma Context Rules</h2>
+                <p>All populated conditions on a rule must match. Comma-separated values within one condition are alternatives. Leave every condition blank to create an always-on rule.</p>
+                <p>Normal Oghma search and the existing Force Racial Oghma and Force Location Oghma settings continue to work alongside these rules.</p>
+            </div>
+
+            <?php
+            oghma_render_context_rule_form([
+                'priority' => 100,
+                'selector_type' => 'topic',
+                'max_articles' => 1,
+                'conditions' => [],
+            ], true);
+
+            $contextRulesResult = pg_query(
+                $conn,
+                "SELECT id, label, enabled, priority, selector_type, selector_value, conditions, max_articles
+                   FROM {$schema}.oghma_context_rule
+                  ORDER BY priority, id"
+            );
+            if ($contextRulesResult) {
+                $contextRuleCount = 0;
+                while ($contextRule = pg_fetch_assoc($contextRulesResult)) {
+                    oghma_render_context_rule_form($contextRule, false);
+                    $contextRuleCount++;
+                }
+                if ($contextRuleCount === 0) {
+                    echo '<p>No context rules have been created.</p>';
+                }
+            } else {
+                echo '<p>Unable to load context rules. Apply database updates, then refresh this page.</p>';
+            }
+            ?>
+        </div>
+    </div>
+
 <div id="editModal" class="modal-backdrop">
     <div class="modal-container">
         <div class="modal-header">
@@ -2190,10 +2462,12 @@ function updateHeaderContent(tabId) {
     const titleText = document.getElementById('title-text');
     const oghmaContent = document.getElementById('oghma-header-content');
     const dynamicContent = document.getElementById('dynamic-header-content');
+    const rulesContent = document.getElementById('rules-header-content');
     
     // Fade out current content
     oghmaContent.style.opacity = '0';
     dynamicContent.style.opacity = '0';
+    rulesContent.style.opacity = '0';
     
     setTimeout(() => {
         if (tabId === 'dynamic-tab') {
@@ -2201,16 +2475,27 @@ function updateHeaderContent(tabId) {
             titleText.textContent = 'Dynamic Oghma';
             oghmaContent.style.display = 'none';
             dynamicContent.style.display = 'block';
+            rulesContent.style.display = 'none';
             
             // Fade in new content
             setTimeout(() => {
                 dynamicContent.style.opacity = '1';
+            }, 50);
+        } else if (tabId === 'rules-tab') {
+            titleText.textContent = 'Oghma Context Rules';
+            oghmaContent.style.display = 'none';
+            dynamicContent.style.display = 'none';
+            rulesContent.style.display = 'block';
+
+            setTimeout(() => {
+                rulesContent.style.opacity = '1';
             }, 50);
         } else {
             // Switch to regular Oghma
             titleText.textContent = 'Oghma Infinium';
             oghmaContent.style.display = 'block';
             dynamicContent.style.display = 'none';
+            rulesContent.style.display = 'none';
             
             // Fade in new content
             setTimeout(() => {

--- a/ui/tmpl/oghma_context_rules_panel.php
+++ b/ui/tmpl/oghma_context_rules_panel.php
@@ -1,0 +1,198 @@
+<?php
+
+function oghma_render_context_rule_form(array $rule, bool $isNew = false): void
+{
+    $conditions = $rule['conditions'] ?? [];
+    if (is_string($conditions)) {
+        $conditions = json_decode($conditions, true);
+    }
+    if (!is_array($conditions)) {
+        $conditions = [];
+    }
+
+    $ruleId = (int)($rule['id'] ?? 0);
+    $enabledValue = strtolower(trim((string)($rule['enabled'] ?? '')));
+    $enabled = $isNew || in_array($enabledValue, ['1', 't', 'true', 'on', 'yes'], true);
+    $fields = [
+        'npc' => ['NPC Name', 'Current speaking NPC name.'],
+        'nearby_actor' => ['Nearby Actor', 'Any actor listed as present.'],
+        'race' => ['Race', 'Current NPC race, including common aliases.'],
+        'faction' => ['Faction', 'Current NPC faction name, editor ID, or form ID.'],
+        'profile' => ['Profile ID', 'Current NPC profile ID.'],
+        'location' => ['Location or Region', 'Current location, parent location, or region.'],
+        'hold' => ['Hold', 'Current canonical or reported hold.'],
+        'environment' => ['Environment', 'Use interior or exterior.'],
+        'weather' => ['Weather', 'Current weather description.'],
+        'event_type' => ['Event Type', 'Current request type, such as inputtext or combat.'],
+    ];
+    ?>
+    <form method="post" class="context-rule-card">
+        <input type="hidden" name="save_context_rule" value="1">
+        <input type="hidden" name="context_rule_id" value="<?php echo $ruleId; ?>">
+        <h3><?php echo $isNew ? 'Create Context Rule' : htmlspecialchars((string)($rule['label'] ?? 'Context Rule'), ENT_QUOTES, 'UTF-8'); ?></h3>
+        <div class="context-rule-grid">
+            <div class="context-rule-field">
+                <label>Rule Name</label>
+                <small>Human-readable label used in audit logs.</small>
+                <input type="text" name="context_rule_label" required value="<?php echo htmlspecialchars((string)($rule['label'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>">
+            </div>
+            <div class="context-rule-field">
+                <label>Selector Type</label>
+                <small>Choose how this rule finds Oghma articles.</small>
+                <select name="context_rule_selector_type">
+                    <?php foreach (['topic' => 'Exact Topic', 'tag' => 'Tag', 'category' => 'Category'] as $value => $label): ?>
+                        <option value="<?php echo $value; ?>" <?php echo (($rule['selector_type'] ?? 'topic') === $value) ? 'selected' : ''; ?>><?php echo $label; ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="context-rule-field">
+                <label>Selector Value</label>
+                <small>Exact topic alias, tag, or category to inject.</small>
+                <input type="text" name="context_rule_selector_value" required value="<?php echo htmlspecialchars((string)($rule['selector_value'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>">
+            </div>
+            <div class="context-rule-field">
+                <label>Priority</label>
+                <small>Lower numbers run first.</small>
+                <input type="number" name="context_rule_priority" value="<?php echo (int)($rule['priority'] ?? 100); ?>">
+            </div>
+            <div class="context-rule-field">
+                <label>Maximum Articles</label>
+                <small>Limits tag and category selectors to 1-5 articles.</small>
+                <input type="number" name="context_rule_max_articles" min="1" max="5" value="<?php echo max(1, min(5, (int)($rule['max_articles'] ?? 1))); ?>">
+            </div>
+            <?php foreach ($fields as $field => [$label, $description]): ?>
+                <div class="context-rule-field">
+                    <label><?php echo htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?></label>
+                    <small><?php echo htmlspecialchars($description, ENT_QUOTES, 'UTF-8'); ?> Separate alternatives with commas.</small>
+                    <input type="text" name="condition_<?php echo $field; ?>" value="<?php echo htmlspecialchars(oghma_context_rule_condition_text($conditions, $field), ENT_QUOTES, 'UTF-8'); ?>">
+                </div>
+            <?php endforeach; ?>
+        </div>
+        <div class="context-rule-actions">
+            <label class="context-rule-enabled">
+                <input type="checkbox" name="context_rule_enabled" value="1" <?php echo $enabled ? 'checked' : ''; ?>>
+                Enabled
+            </label>
+            <button type="submit" class="btn-save"><?php echo $isNew ? 'Create Rule' : 'Save Rule'; ?></button>
+            <?php if (!$isNew): ?>
+                <button
+                    type="submit"
+                    name="delete_context_rule"
+                    value="1"
+                    class="btn-danger"
+                    onclick="return confirm('Delete this context rule?');"
+                >Delete</button>
+            <?php endif; ?>
+        </div>
+    </form>
+    <?php
+}
+
+?>
+<style>
+    .context-rule-intro {
+        margin-bottom: 16px;
+    }
+
+    .context-rule-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 12px;
+    }
+
+    .context-rule-card {
+        border: 1px solid #4a4a4a;
+        border-radius: 6px;
+        background: #242424;
+        padding: 14px;
+        margin-bottom: 14px;
+    }
+
+    .context-rule-card h3 {
+        margin: 0 0 12px;
+        color: rgb(242, 124, 17);
+    }
+
+    .context-rule-field label {
+        display: block;
+        margin-bottom: 4px;
+        font-weight: 600;
+    }
+
+    .context-rule-field small {
+        display: block;
+        min-height: 34px;
+        margin-bottom: 5px;
+        color: #b8b8b8;
+    }
+
+    .context-rule-field input,
+    .context-rule-field select {
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    .context-rule-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 12px;
+    }
+
+    .context-rule-enabled {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        margin-right: auto;
+    }
+
+    @media (max-width: 1100px) {
+        .context-rule-grid {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+    }
+
+    @media (max-width: 700px) {
+        .context-rule-grid {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>
+
+<div id="rules-tab" class="tab-content">
+    <div class="full-width-section">
+        <div class="context-rule-intro">
+            <h2>&#x1F3AF; Oghma Context Rules</h2>
+            <p>All populated conditions on a rule must match. Comma-separated values within one condition are alternatives. Leave every condition blank to create an always-on rule.</p>
+            <p>Normal Oghma search and the existing Force Racial Oghma and Force Location Oghma settings continue to work alongside these rules.</p>
+        </div>
+
+        <?php
+        oghma_render_context_rule_form([
+            'priority' => 100,
+            'selector_type' => 'topic',
+            'max_articles' => 1,
+            'conditions' => [],
+        ], true);
+
+        $contextRulesResult = pg_query(
+            $conn,
+            "SELECT id, label, enabled, priority, selector_type, selector_value, conditions, max_articles
+               FROM {$schema}.oghma_context_rule
+              ORDER BY priority, id"
+        );
+        if ($contextRulesResult) {
+            $contextRuleCount = 0;
+            while ($contextRule = pg_fetch_assoc($contextRulesResult)) {
+                oghma_render_context_rule_form($contextRule, false);
+                $contextRuleCount++;
+            }
+            if ($contextRuleCount === 0) {
+                echo '<p>No context rules have been created.</p>';
+            }
+        } else {
+            echo '<p>Unable to load context rules. Apply database updates, then refresh this page.</p>';
+        }
+        ?>
+    </div>
+</div>

--- a/unittests/tests/OghmaContextRulesTest.php
+++ b/unittests/tests/OghmaContextRulesTest.php
@@ -55,6 +55,8 @@ final class OghmaContextRulesTest extends TestCase
             'OGHMA_KNOWLEDGE',
             'OGHMA_HINT',
             'OGHMA_INJECTED_TOPICS',
+            'CACHE_LAST_KNOWN_LOCATION_CONTEXT_PARTS',
+            'CACHE_LAST_KNOWN_LOCATION_HUMAN',
         ] as $key) {
             unset($GLOBALS[$key]);
         }
@@ -94,6 +96,15 @@ final class OghmaContextRulesTest extends TestCase
         $GLOBALS['OGHMA_KNOWLEDGE'] = 'knowall';
         $GLOBALS['OGHMA_HINT'] = '';
         $GLOBALS['OGHMA_INJECTED_TOPICS'] = [];
+        $GLOBALS['CACHE_LAST_KNOWN_LOCATION_CONTEXT_PARTS'] = [
+            'location' => '',
+            'location_base' => '',
+            'hold_raw' => '',
+        ];
+        $GLOBALS['CACHE_LAST_KNOWN_LOCATION_HUMAN'] = [
+            'HOLD_CANONICAL' => '',
+            'WEATHER' => '',
+        ];
 
         $db = new OghmaContextRuleFakeDb();
         $this->assertSame(1, chimOghmaInjectContextRules($db));

--- a/unittests/tests/OghmaContextRulesTest.php
+++ b/unittests/tests/OghmaContextRulesTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/oghma_forced_context.php';
+
+final class OghmaContextRuleFakeDb
+{
+    public array $queries = [];
+
+    public function escape($value): string
+    {
+        return str_replace("'", "''", (string)$value);
+    }
+
+    public function fetchAll($query): array
+    {
+        $this->queries[] = $query;
+        if (str_contains($query, 'FROM public.oghma_context_rule')) {
+            return [[
+                'id' => 7,
+                'label' => 'Nord dialogue lore',
+                'priority' => 10,
+                'selector_type' => 'topic',
+                'selector_value' => 'nord',
+                'conditions' => json_encode([
+                    'race' => ['Nord'],
+                    'event_type' => ['inputtext'],
+                ]),
+                'max_articles' => 1,
+            ]];
+        }
+        if (str_contains($query, 'FROM public.oghma')) {
+            return [[
+                'topic' => 'nord',
+                'topic_desc' => 'Advanced Nord lore.',
+                'knowledge_class' => '',
+                'topic_desc_basic' => 'Basic Nord lore.',
+                'knowledge_class_basic' => '',
+            ]];
+        }
+        return [];
+    }
+}
+
+final class OghmaContextRulesTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        foreach ([
+            'CHIM_CORE_CURRENT_NPC_DATA',
+            'HERIKA_NAME',
+            'CACHE_PEOPLE',
+            'gameRequest',
+            'OGHMA_KNOWLEDGE',
+            'OGHMA_HINT',
+            'OGHMA_INJECTED_TOPICS',
+        ] as $key) {
+            unset($GLOBALS[$key]);
+        }
+    }
+
+    public function testConditionsRequireEveryFieldAndAllowAlternativesWithinAField(): void
+    {
+        $context = [
+            'race' => ['dark elf', 'dunmer'],
+            'hold' => ['whiterun hold', 'whiterun'],
+            'event_type' => ['inputtext'],
+        ];
+        $reasons = [];
+
+        $this->assertTrue(chimOghmaContextRuleMatches([
+            'race' => ['Nord', 'Dunmer'],
+            'hold' => ['Whiterun'],
+        ], $context, $reasons));
+        $this->assertSame(['race=dunmer', 'hold=whiterun'], $reasons);
+
+        $this->assertFalse(chimOghmaContextRuleMatches([
+            'race' => ['Dunmer'],
+            'hold' => ['The Rift'],
+        ], $context));
+    }
+
+    public function testContextRuleInjectionUsesExistingPermissionAndDeduplicationPath(): void
+    {
+        $GLOBALS['CHIM_CORE_CURRENT_NPC_DATA'] = [
+            'npc_name' => 'Hilde',
+            'race' => 'NordRace',
+            'profile_id' => 1,
+        ];
+        $GLOBALS['HERIKA_NAME'] = 'Hilde';
+        $GLOBALS['CACHE_PEOPLE'] = '|Hilde|RANGROO|';
+        $GLOBALS['gameRequest'] = ['inputtext'];
+        $GLOBALS['OGHMA_KNOWLEDGE'] = 'knowall';
+        $GLOBALS['OGHMA_HINT'] = '';
+        $GLOBALS['OGHMA_INJECTED_TOPICS'] = [];
+
+        $db = new OghmaContextRuleFakeDb();
+        $this->assertSame(1, chimOghmaInjectContextRules($db));
+        $this->assertStringContainsString('Advanced Nord lore.', $GLOBALS['OGHMA_HINT']);
+        $this->assertTrue(chimOghmaTopicWasInjected('nord'));
+    }
+
+    public function testSelectorQueriesAreBoundedToFiveArticles(): void
+    {
+        $db = new OghmaContextRuleFakeDb();
+        chimOghmaFindRowsForRuleSelector($db, 'category', 'Lore', 99);
+
+        $this->assertStringContainsString('LIMIT 5', end($db->queries));
+    }
+
+    public function testWeatherConditionsCanMatchOnePartOfCombinedWeather(): void
+    {
+        $this->assertSame(
+            ['outdoors it is rainy foggy', 'rainy foggy', 'rainy', 'foggy'],
+            chimOghmaWeatherSignals('Outdoors it is rainy, foggy')
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add deterministic Oghma context rules selected by exact topic, tag, or category
- match rules against NPC, nearby actor, race, faction, profile, location, hold, environment, weather, and request type
- manage rules from a dedicated Oghma Infinium tab with priority, article limits, and enable controls
- preserve normal Oghma search, forced racial/location Oghma, permissions, and duplicate suppression

## Database
- add an idempotent `oghma_context_rule` migration for fresh installs and upgrades
- avoid hard-coded row IDs and preserve existing Oghma data

## Validation
- PHP syntax checks passed for all changed PHP files
- focused deterministic-rule PHPUnit coverage passed
- combined integration suite passed: **43 tests, 258 assertions**
- fresh/upgrade migration applied successfully to the local PostgreSQL database
- local transaction/runtime probe confirmed a matching Nord rule selects its bounded article while a Breton context is filtered; temporary test data was removed
- Oghma rule creation and deletion were exercised through the deployed local UI/runtime
- `git diff --check` passed

## Deployment
- deployed as part of the combined local HerikaServer validation build
- no additional LLM or external network call is introduced by rule matching
