### PR TITLE
Use hybrid scoring for memory recall

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -5242,9 +5242,11 @@ function DataSearchMemoryByVector($rawstring,$npcfilter,$useContextKw=false,$tim
                     and $companionConditionSql
                     and (gamets_truncated<$timeThreshold or $timeThreshold=0)
                     
-                    ORDER BY 
-                        round((embedding <-> $vectorString)::numeric, 2) ASC,
-                        $rankCombinedSql DESC
+                    ORDER BY
+                        mixed_distance ASC,
+                        distance ASC,
+                        gamets_truncated DESC,
+                        rowid DESC
                     LIMIT 50 OFFSET 0
                 ";    
             $memory=$GLOBALS["db"]->fetchAll($finalQuery);

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -16,6 +16,7 @@ require_once(__DIR__."/core/core_profiles.class.php");
 require_once(__DIR__."/prompt_injections.php");
 require_once(__DIR__."/vr_items.php");
 require_once(__DIR__."/visual_context.php");
+require_once(__DIR__."/memory_ranking.php");
 
 
 function ChangeHerikaName($new_name="") {
@@ -5232,8 +5233,7 @@ function DataSearchMemoryByVector($rawstring,$npcfilter,$useContextKw=false,$tim
                         embedding <-> $vectorString as distance,
                          $rankAnySql AS rank_any_fts_raw,
                          $rankAllSql AS rank_all_fts_raw,
-                         $rankCombinedSql AS rank_any_fts,
-                         $rankCombinedSql AS rank_all_fts,
+                         $rankCombinedSql AS rank_fts,
                          (embedding <-> $vectorString) - $rankCombinedSql AS mixed_distance,
                          summary
                     FROM public.memory_summary 
@@ -5248,24 +5248,16 @@ function DataSearchMemoryByVector($rawstring,$npcfilter,$useContextKw=false,$tim
                     LIMIT 50 OFFSET 0
                 ";    
             $memory=$GLOBALS["db"]->fetchAll($finalQuery);
-            //error_log($finalQuery);
-            $singleMemory = null;
-            $maxRankAny = -INF;
-
-            foreach ($memory as $entry) {
-                if (isset($entry['rank_any_fts']) && $entry['rank_any_fts'] > $maxRankAny) {
-                    $maxRankAny = $entry['rank_any_fts'];
-                    $singleMemory = $entry;
-                }
-            }
+            $singleMemory = chimSelectBestHybridMemoryCandidate($memory);
          
             if (!isset($singleMemory)) {
-                $singleMemory=["rank_any"=>null,"rank_all"=>null,"summary"=>null];
-                $singleMemory["distance"]=1.4;
-            }
-            else {
-                 $singleMemory['rank_any']=(($singleMemory["rank_any_fts"])+($singleMemory["rank_all_fts"])/2);
-                 $singleMemory['rank_all']=($singleMemory["rank_all_fts"]);
+                $singleMemory = [
+                    "rank_any" => null,
+                    "rank_all" => null,
+                    "summary" => null,
+                    "distance" => 1.4,
+                    "mixed_distance" => 1.4,
+                ];
             }
             
             /*error_log("

--- a/lib/memory_ranking.php
+++ b/lib/memory_ranking.php
@@ -1,0 +1,71 @@
+<?php
+
+function chimMemoryCandidateNumber(array $candidate, string $field, float $default): float
+{
+    $value = $candidate[$field] ?? null;
+
+    return is_numeric($value) ? (float)$value : $default;
+}
+
+function chimMemoryCandidateMixedDistance(array $candidate): float
+{
+    if (isset($candidate['mixed_distance']) && is_numeric($candidate['mixed_distance'])) {
+        return (float)$candidate['mixed_distance'];
+    }
+
+    $distance = chimMemoryCandidateNumber($candidate, 'distance', INF);
+    $keywordRank = chimMemoryCandidateNumber($candidate, 'rank_fts', 0.0);
+
+    return $distance - $keywordRank;
+}
+
+function chimSelectBestHybridMemoryCandidate(array $candidates): ?array
+{
+    $best = null;
+    $bestMixedDistance = INF;
+    $bestDistance = INF;
+    $bestGamets = -INF;
+    $bestRowId = -INF;
+
+    foreach ($candidates as $candidate) {
+        if (!is_array($candidate)) {
+            continue;
+        }
+
+        $mixedDistance = chimMemoryCandidateMixedDistance($candidate);
+        $distance = chimMemoryCandidateNumber($candidate, 'distance', INF);
+        $gamets = chimMemoryCandidateNumber($candidate, 'gamets_truncated', -INF);
+        $rowId = chimMemoryCandidateNumber($candidate, 'rowid', -INF);
+
+        $isBetter = $mixedDistance < $bestMixedDistance
+            || ($mixedDistance === $bestMixedDistance && $distance < $bestDistance)
+            || ($mixedDistance === $bestMixedDistance && $distance === $bestDistance && $gamets > $bestGamets)
+            || (
+                $mixedDistance === $bestMixedDistance
+                && $distance === $bestDistance
+                && $gamets === $bestGamets
+                && $rowId > $bestRowId
+            );
+
+        if (!$isBetter) {
+            continue;
+        }
+
+        $best = $candidate;
+        $bestMixedDistance = $mixedDistance;
+        $bestDistance = $distance;
+        $bestGamets = $gamets;
+        $bestRowId = $rowId;
+    }
+
+    if ($best === null) {
+        return null;
+    }
+
+    $best['mixed_distance'] = $bestMixedDistance;
+    $best['distance'] = $bestDistance;
+    $best['rank_any'] = 1.4 - $bestMixedDistance;
+    $best['rank_all'] = 1.4 - $bestDistance;
+
+    return $best;
+}

--- a/unittests/tests/MemoryRankingTest.php
+++ b/unittests/tests/MemoryRankingTest.php
@@ -63,4 +63,15 @@ final class MemoryRankingTest extends TestCase
     {
         $this->assertNull(chimSelectBestHybridMemoryCandidate([]));
     }
+
+    public function testDatabaseCandidatePoolUsesHybridOrdering(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../lib/data_functions.php');
+
+        $this->assertIsString($source);
+        $this->assertMatchesRegularExpression(
+            '/ORDER BY\s+mixed_distance ASC,\s+distance ASC,\s+gamets_truncated DESC,\s+rowid DESC\s+LIMIT 50/s',
+            $source
+        );
+    }
 }

--- a/unittests/tests/MemoryRankingTest.php
+++ b/unittests/tests/MemoryRankingTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/memory_ranking.php';
+
+final class MemoryRankingTest extends TestCase
+{
+    public function testCombinedDistanceSelectsBalancedSemanticAndKeywordMatch(): void
+    {
+        $selected = chimSelectBestHybridMemoryCandidate([
+            [
+                'rowid' => 1,
+                'distance' => 0.20,
+                'mixed_distance' => 0.20,
+                'summary' => 'Semantic only',
+            ],
+            [
+                'rowid' => 2,
+                'distance' => 0.45,
+                'mixed_distance' => 0.10,
+                'summary' => 'Balanced match',
+            ],
+        ]);
+
+        $this->assertSame('Balanced match', $selected['summary']);
+        $this->assertEqualsWithDelta(1.30, $selected['rank_any'], 0.00001);
+        $this->assertEqualsWithDelta(0.95, $selected['rank_all'], 0.00001);
+    }
+
+    public function testSemanticDistanceBreaksCombinedScoreTie(): void
+    {
+        $selected = chimSelectBestHybridMemoryCandidate([
+            ['rowid' => 1, 'distance' => 0.35, 'mixed_distance' => 0.10],
+            ['rowid' => 2, 'distance' => 0.25, 'mixed_distance' => 0.10],
+        ]);
+
+        $this->assertSame(2, $selected['rowid']);
+    }
+
+    public function testNewerMemoryBreaksEquivalentScoreTie(): void
+    {
+        $selected = chimSelectBestHybridMemoryCandidate([
+            ['rowid' => 1, 'distance' => 0.25, 'mixed_distance' => 0.10, 'gamets_truncated' => 100],
+            ['rowid' => 2, 'distance' => 0.25, 'mixed_distance' => 0.10, 'gamets_truncated' => 200],
+        ]);
+
+        $this->assertSame(2, $selected['rowid']);
+    }
+
+    public function testFallbackComputesMixedDistanceFromKeywordRank(): void
+    {
+        $selected = chimSelectBestHybridMemoryCandidate([
+            ['rowid' => 1, 'distance' => 0.30, 'rank_fts' => 0.05],
+            ['rowid' => 2, 'distance' => 0.40, 'rank_fts' => 0.20],
+        ]);
+
+        $this->assertSame(2, $selected['rowid']);
+        $this->assertEqualsWithDelta(0.20, $selected['mixed_distance'], 0.00001);
+    }
+
+    public function testEmptyCandidateListReturnsNull(): void
+    {
+        $this->assertNull(chimSelectBestHybridMemoryCandidate([]));
+    }
+}


### PR DESCRIPTION
## Summary
- rank vector-memory recalls using the existing hybrid semantic-plus-keyword score
- rank the full eligible candidate pool before applying the result limit
- use semantic distance, newer game time, and row ID as deterministic tie-breakers
- preserve embedding requests, NPC/time scope filters, thresholds, and existing audit storage
- provide complete empty-search fallback scores so `mixed_distance` remains defined

## Validation
- PHP syntax checks passed for the changed runtime and test files
- focused hybrid-ranking PHPUnit coverage passed
- combined integration suite passed: **43 tests, 258 assertions**
- local fixtures verified hybrid ordering, deterministic ties, pre-limit ranking, and empty-keyword fallback behavior
- `git diff --check` passed

## Deployment
- deployed as part of the combined local HerikaServer validation build
- no additional embedding, LLM, or network request is introduced
