### PR TITLE
Add structured request performance tracing

### DIFF
--- a/lib/auditing.php
+++ b/lib/auditing.php
@@ -3,9 +3,7 @@ require_once __DIR__ . '/request_performance.php';
 chimRequestPerformanceInitialize();
 
 function aiff_audit_end() {
-    chimRequestPerformanceFinish(
-        !empty($GLOBALS['ERROR_TRIGGERED']) ? 'error' : 'complete'
-    );
+    chimRequestPerformanceFinish(chimRequestPerformanceTerminalStatus(error_get_last()));
 
     $endTime = microtime(true);
     $startTime = $GLOBALS["AUDIT_START_TIME"];

--- a/lib/auditing.php
+++ b/lib/auditing.php
@@ -1,5 +1,12 @@
 <?php
+require_once __DIR__ . '/request_performance.php';
+chimRequestPerformanceInitialize();
+
 function aiff_audit_end() {
+    chimRequestPerformanceFinish(
+        !empty($GLOBALS['ERROR_TRIGGERED']) ? 'error' : 'complete'
+    );
+
     $endTime = microtime(true);
     $startTime = $GLOBALS["AUDIT_START_TIME"];
     $elapsedTime = $endTime - $startTime;

--- a/lib/request_performance.php
+++ b/lib/request_performance.php
@@ -1,0 +1,89 @@
+<?php
+
+function chimRequestPerformanceNow(): float
+{
+    $clock = $GLOBALS['CHIM_REQUEST_PERFORMANCE_CLOCK'] ?? null;
+
+    return is_callable($clock) ? (float)$clock() : microtime(true);
+}
+
+function chimRequestPerformanceInitialize(?callable $clock = null): void
+{
+    if ($clock !== null) {
+        $GLOBALS['CHIM_REQUEST_PERFORMANCE_CLOCK'] = $clock;
+    }
+
+    $now = chimRequestPerformanceNow();
+    $GLOBALS['CHIM_REQUEST_PERFORMANCE'] = [
+        'started_at' => $now,
+        'last_mark_at' => $now,
+        'request_type' => 'unknown',
+        'phases' => [],
+        'finished' => false,
+    ];
+}
+
+function chimRequestPerformanceSetRequestType(string $requestType): void
+{
+    if (!isset($GLOBALS['CHIM_REQUEST_PERFORMANCE'])) {
+        chimRequestPerformanceInitialize();
+    }
+
+    $GLOBALS['CHIM_REQUEST_PERFORMANCE']['request_type'] = strtolower(trim($requestType)) ?: 'unknown';
+}
+
+function chimRequestPerformanceMark(string $phase): void
+{
+    if (!isset($GLOBALS['CHIM_REQUEST_PERFORMANCE'])) {
+        chimRequestPerformanceInitialize();
+    }
+
+    $phase = strtolower(trim($phase));
+    if ($phase === '') {
+        return;
+    }
+
+    $now = chimRequestPerformanceNow();
+    $state = &$GLOBALS['CHIM_REQUEST_PERFORMANCE'];
+    $state['phases'][] = [
+        'name' => $phase,
+        'delta_ms' => round(($now - $state['last_mark_at']) * 1000, 2),
+        'total_ms' => round(($now - $state['started_at']) * 1000, 2),
+    ];
+    $state['last_mark_at'] = $now;
+}
+
+function chimRequestPerformanceFinish(string $status = 'complete', bool $emit = true): ?array
+{
+    if (!isset($GLOBALS['CHIM_REQUEST_PERFORMANCE'])) {
+        return null;
+    }
+
+    $state = &$GLOBALS['CHIM_REQUEST_PERFORMANCE'];
+    if (!empty($state['finished'])) {
+        return $state['payload'] ?? null;
+    }
+
+    $now = chimRequestPerformanceNow();
+    $payload = [
+        'run_id' => (string)($GLOBALS['runid'] ?? $GLOBALS['AUDIT_RUNID'] ?? ''),
+        'request_type' => (string)($state['request_type'] ?? 'unknown'),
+        'status' => trim($status) ?: 'complete',
+        'total_ms' => round(($now - $state['started_at']) * 1000, 2),
+        'sql_ms' => round(((float)($GLOBALS['DB_EXECUTION_TIME'] ?? 0)) * 1000, 2),
+        'peak_memory_mb' => round(memory_get_peak_usage(true) / 1048576, 2),
+        'phases' => $state['phases'],
+    ];
+
+    $state['finished'] = true;
+    $state['payload'] = $payload;
+
+    if ($emit) {
+        $encoded = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($encoded !== false && class_exists('Logger')) {
+            Logger::trace('[PERF] ' . $encoded);
+        }
+    }
+
+    return $payload;
+}

--- a/lib/request_performance.php
+++ b/lib/request_performance.php
@@ -53,6 +53,25 @@ function chimRequestPerformanceMark(string $phase): void
     $state['last_mark_at'] = $now;
 }
 
+function chimRequestPerformanceTerminalStatus(?array $lastError = null): string
+{
+    if (!empty($GLOBALS['ERROR_TRIGGERED'])) {
+        return 'error';
+    }
+
+    $fatalTypes = [
+        E_ERROR,
+        E_PARSE,
+        E_CORE_ERROR,
+        E_COMPILE_ERROR,
+        E_USER_ERROR,
+        E_RECOVERABLE_ERROR,
+    ];
+    $lastErrorType = intval($lastError['type'] ?? 0);
+
+    return in_array($lastErrorType, $fatalTypes, true) ? 'error' : 'complete';
+}
+
 function chimRequestPerformanceFinish(string $status = 'complete', bool $emit = true): ?array
 {
     if (!isset($GLOBALS['CHIM_REQUEST_PERFORMANCE'])) {

--- a/main.php
+++ b/main.php
@@ -137,6 +137,8 @@ $startTime = microtime(true);
 $GLOBALS["AUDIT_RUNID_REQUEST"]=$gameRequest[0];
 
 $gameRequest[0] = strtolower($gameRequest[0]); // Who put 'diary' uppercase?
+chimRequestPerformanceSetRequestType($gameRequest[0]);
+chimRequestPerformanceMark('request_parsed');
 
 // Handle deprecated events now processed by gamedata.php
 if (in_array($gameRequest[0], ['updateequipment', 'updateinventory', 'updateskills', 'updatestats'])) {
@@ -222,6 +224,7 @@ if (!in_array($gameRequest[0],$fast_commands)) {
     }
     Logger::info("Audit:Lock acquired by {$gameRequest[0]}");
 } 
+chimRequestPerformanceMark('lock_ready');
 
 // adnpc has its custom semaphore, as it write files
 if (in_array($gameRequest[0],["addnpc"])) {
@@ -1918,6 +1921,7 @@ if (isset($GLOBALS["NARRATOR_TALKS"])&&($GLOBALS["NARRATOR_TALKS"]==false)) {
 }
 
 // Use diary-specific context history if this is a diary request and CONTEXT_HISTORY_DIARY is set
+chimRequestPerformanceMark('profile_ready');
 if (($gameRequest[0] == "diary" || $gameRequest[0] == "diary_followers") && isset($GLOBALS["CONTEXT_HISTORY_DIARY"]) && $GLOBALS["CONTEXT_HISTORY_DIARY"] > 0) {
     $lastNDataForContext = $GLOBALS["CONTEXT_HISTORY_DIARY"];
 } else {
@@ -1952,6 +1956,7 @@ $contextDataWorld = DataLastInfoFor("", -2,true);
 if (!is_array($contextDataWorld)) {
     $contextDataWorld = [];
 }
+chimRequestPerformanceMark('context_history_ready');
 
 // Add current motto to COMMAND_PROMPT
 if (isset($GLOBALS["CURRENT_TASK"]) && $GLOBALS["CURRENT_TASK"] && $gameRequest[0] != "diary") {
@@ -1989,6 +1994,7 @@ if (in_array($gameRequest[0],["inputtext","inputtext_s","ginputtext","ginputtext
 } else
      $memoryInjectionCtx=[];
 
+chimRequestPerformanceMark('memory_ready');
 error_log("TRACE:\t".__LINE__. "\t".__FILE__.":\t".(microtime(true) - $startTime));
 
 // Whisper-mode speaking behavior: make the NPC explicitly treat this exchange as whispered.
@@ -2197,6 +2203,7 @@ if (($minimeEnabled || $oghmaCustomEnabled || $racialOghmaEnabled || $locationOg
         $GLOBALS["OGHMA_CALLED"] = true;
     }
 }
+chimRequestPerformanceMark('oghma_ready');
 
 error_log("TRACE:\t".__LINE__. "\t".__FILE__.":\t".(microtime(true) - $startTime));
 
@@ -2570,6 +2577,7 @@ if ($gameRequest[0] == "funcret") {
     $contextData = array_merge($head, ($contextDataFull), $prompt);
     
 }
+chimRequestPerformanceMark('prompt_ready');
 
 
 if (microtime(true) - $startTime > 0.25) {
@@ -2609,6 +2617,7 @@ audit_log(__FILE__." [PRE LLM CALL]  ".__LINE__);
 pipeline_status_set('llm', true);
 
 $outputWasValid = call_llm();
+chimRequestPerformanceMark('llm_complete');
 
 // Clear LLM processing status
 pipeline_status_set('llm', false);

--- a/unittests/tests/RequestPerformanceTest.php
+++ b/unittests/tests/RequestPerformanceTest.php
@@ -12,7 +12,8 @@ final class RequestPerformanceTest extends TestCase
             $GLOBALS['CHIM_REQUEST_PERFORMANCE'],
             $GLOBALS['CHIM_REQUEST_PERFORMANCE_CLOCK'],
             $GLOBALS['DB_EXECUTION_TIME'],
-            $GLOBALS['runid']
+            $GLOBALS['runid'],
+            $GLOBALS['ERROR_TRIGGERED']
         );
     }
 
@@ -51,5 +52,16 @@ final class RequestPerformanceTest extends TestCase
 
         $this->assertSame($first, $second);
         $this->assertSame('complete', $second['status']);
+    }
+
+    public function testTerminalStatusRecognizesFatalErrorsButNotWarnings(): void
+    {
+        $this->assertSame('error', chimRequestPerformanceTerminalStatus(['type' => E_ERROR]));
+        $this->assertSame('error', chimRequestPerformanceTerminalStatus(['type' => E_PARSE]));
+        $this->assertSame('complete', chimRequestPerformanceTerminalStatus(['type' => E_WARNING]));
+        $this->assertSame('complete', chimRequestPerformanceTerminalStatus(null));
+
+        $GLOBALS['ERROR_TRIGGERED'] = true;
+        $this->assertSame('error', chimRequestPerformanceTerminalStatus(null));
     }
 }

--- a/unittests/tests/RequestPerformanceTest.php
+++ b/unittests/tests/RequestPerformanceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/request_performance.php';
+
+final class RequestPerformanceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset(
+            $GLOBALS['CHIM_REQUEST_PERFORMANCE'],
+            $GLOBALS['CHIM_REQUEST_PERFORMANCE_CLOCK'],
+            $GLOBALS['DB_EXECUTION_TIME'],
+            $GLOBALS['runid']
+        );
+    }
+
+    public function testRecordsPhaseDeltasAndTotalTime(): void
+    {
+        $times = [10.0, 10.125, 10.400, 10.500];
+        chimRequestPerformanceInitialize(static function () use (&$times): float {
+            return array_shift($times);
+        });
+        chimRequestPerformanceSetRequestType('InputText');
+        chimRequestPerformanceMark('lock_acquired');
+        chimRequestPerformanceMark('context_ready');
+
+        $GLOBALS['DB_EXECUTION_TIME'] = 0.032;
+        $GLOBALS['runid'] = 'run_test';
+        $payload = chimRequestPerformanceFinish('complete', false);
+
+        $this->assertSame('run_test', $payload['run_id']);
+        $this->assertSame('inputtext', $payload['request_type']);
+        $this->assertSame(500.0, $payload['total_ms']);
+        $this->assertSame(32.0, $payload['sql_ms']);
+        $this->assertSame('lock_acquired', $payload['phases'][0]['name']);
+        $this->assertSame(125.0, $payload['phases'][0]['delta_ms']);
+        $this->assertSame(400.0, $payload['phases'][1]['total_ms']);
+    }
+
+    public function testFinishIsIdempotent(): void
+    {
+        $times = [2.0, 2.25, 9.0];
+        chimRequestPerformanceInitialize(static function () use (&$times): float {
+            return array_shift($times);
+        });
+
+        $first = chimRequestPerformanceFinish('complete', false);
+        $second = chimRequestPerformanceFinish('failed', false);
+
+        $this->assertSame($first, $second);
+        $this->assertSame('complete', $second['status']);
+    }
+}


### PR DESCRIPTION
## Summary
- emit one structured `[PERF]` trace for each server request
- measure request parsing, lock wait, profile setup, history construction, memory recall, Oghma injection, prompt assembly, LLM execution, SQL time, and total time
- retain partial phase data for early termination and fatal shutdowns
- avoid database writes, network calls, and additional LLM calls

## Validation
- PHP syntax checks passed for all changed runtime and test files
- focused performance-trace PHPUnit coverage passed
- combined integration suite passed: **43 tests, 258 assertions**
- local runtime helper probe verified total duration, named phases, SQL duration, memory fields, and terminal status output
- fatal-shutdown handling was added and covered after review
- `git diff --check` passed

## Deployment
- deployed as part of the combined local HerikaServer validation build
- instrumentation is local structured logging only
