### PR TITLE
Add prompt composition diagnostics

### DIFF
--- a/lib/dynamic_update_util.php
+++ b/lib/dynamic_update_util.php
@@ -1,4 +1,6 @@
-<?php 
+<?php
+
+require_once(__DIR__ . DIRECTORY_SEPARATOR . "prompt_composition.php");
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'physical_npc_diaries.php';
 
 // Function to process diary entries for all nearby NPCs (triggered by C++ with 400 unit range)
@@ -140,6 +142,16 @@ function generateNearbyDiary($npcName, $gameRequest, $eventType) {
         } else {
             $maxTokens = 2048;
         }
+
+        chimLogPromptComposition(
+            'diary',
+            [
+                'character_head' => $head,
+                'history' => !empty($contextDataHistoric) ? $prompt[0] : [],
+                'diary_instruction' => $diaryPrompt,
+            ],
+            $contextData
+        );
 
         // Pass provider-agnostic MAX_TOKENS override so connectors map to correct API field
         $connectionHandler->open($contextData, ["MAX_TOKENS" => $maxTokens]);
@@ -417,6 +429,16 @@ function generatePlayerDiary($gameRequest, $eventType)
         $defaultDiaryConnector = chimResolvePlayerDiaryConnectorFromDefaultProfile();
         $coreConnectorId = intval($defaultDiaryConnector['connector_id'] ?? 0);
         $currentConnectorData = $defaultDiaryConnector['connector_data'] ?? null;
+
+        chimLogPromptComposition(
+            'diary_player',
+            [
+                'character_head' => $head,
+                'history' => !empty($contextDataHistoric) ? $prompt[0] : [],
+                'diary_instruction' => $prompt[count($prompt) - 1] ?? [],
+            ],
+            $contextData
+        );
 
         if (!empty($currentConnectorData)) {
             $profileLabel = trim((string)($defaultDiaryConnector['profile_label'] ?? 'Default Profile'));
@@ -1200,6 +1222,15 @@ function generateFollowerDiary($followerName, $gameRequest, $eventType) {
 
     $overrideParameters["MAX_TOKENS"] = $maxTokens;
     $connectionHandler = $connector->getConnector($GLOBALS["CHIM_CORE_CURRENT_CONNECTOR_DATA"]);
+    chimLogPromptComposition(
+        'diary',
+        [
+            'character_head' => $head,
+            'history' => !empty($contextDataHistoric) ? $prompt[0] : [],
+            'diary_instruction' => $diaryPrompt,
+        ],
+        $contextData
+    );
     $buffer=$connectionHandler->fast_request($contextData,$overrideParameters,"diary");
 
     // Restore previous FORCE_MAX_TOKENS if it existed

--- a/lib/prompt_composition.php
+++ b/lib/prompt_composition.php
@@ -1,0 +1,64 @@
+<?php
+
+function chimPromptCompositionCharacterCount($value)
+{
+    if (is_string($value) || is_numeric($value)) {
+        $text = strval($value);
+        return function_exists('mb_strlen') ? mb_strlen($text, 'UTF-8') : strlen($text);
+    }
+
+    if (!is_array($value)) {
+        return 0;
+    }
+
+    $characters = 0;
+    foreach ($value as $item) {
+        if (is_array($item) && array_key_exists('content', $item)) {
+            $characters += chimPromptCompositionCharacterCount($item['content']);
+            continue;
+        }
+
+        $characters += chimPromptCompositionCharacterCount($item);
+    }
+
+    return $characters;
+}
+
+function chimPromptCompositionMeasure($value)
+{
+    $characters = chimPromptCompositionCharacterCount($value);
+
+    return [
+        'characters' => $characters,
+        'estimated_tokens' => $characters > 0 ? intval(ceil($characters / 4)) : 0,
+    ];
+}
+
+function chimBuildPromptCompositionReport($requestType, array $sections, array $messages)
+{
+    $measuredSections = [];
+    foreach ($sections as $name => $value) {
+        $measuredSections[strval($name)] = chimPromptCompositionMeasure($value);
+    }
+
+    $messageMeasurement = chimPromptCompositionMeasure($messages);
+
+    return [
+        'request_type' => strval($requestType),
+        'message_count' => count($messages),
+        'total_characters' => $messageMeasurement['characters'],
+        'estimated_total_tokens' => $messageMeasurement['estimated_tokens'],
+        'sections' => $measuredSections,
+    ];
+}
+
+function chimLogPromptComposition($requestType, array $sections, array $messages)
+{
+    $report = chimBuildPromptCompositionReport($requestType, $sections, $messages);
+    $json = json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    if (is_string($json)) {
+        Logger::debug('[PROMPT-COMPOSITION] ' . $json);
+    }
+
+    return $report;
+}

--- a/main.php
+++ b/main.php
@@ -2591,17 +2591,19 @@ if (microtime(true) - $startTime > 0.25) {
     error_log("*TRACE: ".__LINE__. " at ".__FILE__.": ".(microtime(true) - $startTime)." secs building call");
 }
 
-chimLogPromptComposition(
-    $gameRequest[0] ?? '',
-    array_merge(
-        $promptCompositionSections ?? [],
-        [
-        'history' => $contextDataFull ?? [],
-        'memory_injection' => $memoryInjectionCtx ?? [],
-        ]
-    ),
-    $contextData ?? []
-);
+if (($gameRequest[0] ?? '') !== 'diary') {
+    chimLogPromptComposition(
+        $gameRequest[0] ?? '',
+        array_merge(
+            $promptCompositionSections ?? [],
+            [
+            'history' => $contextDataFull ?? [],
+            'memory_injection' => $memoryInjectionCtx ?? [],
+            ]
+        ),
+        $contextData ?? []
+    );
+}
 
 //returnLines(["Mmm..let me think"]);
 

--- a/main.php
+++ b/main.php
@@ -2328,6 +2328,7 @@ if (function_exists('chimQuestEngineApplyActionSuppressionsForTurn')) {
 
 // Ensure actions and nearby sections are added to PROMPT_HEAD before building system prompt
 require_once(__DIR__.DIRECTORY_SEPARATOR."functions".DIRECTORY_SEPARATOR."json_response.php");
+require_once(__DIR__.DIRECTORY_SEPARATOR."lib".DIRECTORY_SEPARATOR."prompt_composition.php");
 
 if (
     $gameRequest[0] === "narrator_inputtext"
@@ -2432,6 +2433,19 @@ $systemPromptRaw = "<roleplay_instructions>\n" . $GLOBALS["PROMPT_HEAD"] .
     "\n\n<general_instructions>\n" . $GLOBALS["COMMAND_PROMPT"] .
     "\n</general_instructions>" . $actionsList . $nearbySections . $promptBottomInjections . $paralinguisticTagsPrompt .
     "\n" . $rumorsText . "\n";
+
+$promptCompositionSections = [
+    'roleplay_instructions' => $GLOBALS["PROMPT_HEAD"] ?? '',
+    'world' => $worldPrompt ?? '',
+    'character' => ($GLOBALS["HERIKA_PERS"] ?? '') . ($dynamicBiography ?? '') . ($characterBottomInjections ?? ''),
+    'knowledge' => $knowledgeSection ?? '',
+    'general_instructions' => $GLOBALS["COMMAND_PROMPT"] ?? '',
+    'actions' => $actionsList ?? '',
+    'nearby_actors' => $nearbySections ?? '',
+    'plugin_injections' => $promptBottomInjections ?? '',
+    'paralinguistic_tags' => $paralinguisticTagsPrompt ?? '',
+    'rumors' => $rumorsText ?? '',
+];
 
 $systemPrompt = chimFormatPromptXmlSections(
     strtr(
@@ -2576,6 +2590,18 @@ if (microtime(true) - $startTime > 0.25) {
     error_log("*TRACE SQL: TOTAL DATABASE query execution time: {$GLOBALS["DB_EXECUTION_TIME"]} seconds");
     error_log("*TRACE: ".__LINE__. " at ".__FILE__.": ".(microtime(true) - $startTime)." secs building call");
 }
+
+chimLogPromptComposition(
+    $gameRequest[0] ?? '',
+    array_merge(
+        $promptCompositionSections ?? [],
+        [
+        'history' => $contextDataFull ?? [],
+        'memory_injection' => $memoryInjectionCtx ?? [],
+        ]
+    ),
+    $contextData ?? []
+);
 
 //returnLines(["Mmm..let me think"]);
 

--- a/unittests/tests/PromptCompositionTest.php
+++ b/unittests/tests/PromptCompositionTest.php
@@ -62,4 +62,26 @@ final class PromptCompositionTest extends TestCase
         $this->assertSame($expectedCharacters, $measurement['characters']);
         $this->assertSame(intval(ceil($expectedCharacters / 4)), $measurement['estimated_tokens']);
     }
+
+    public function testDiaryCompositionMeasuresTheConnectorBoundPrompt(): void
+    {
+        $main = file_get_contents(dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'main.php');
+        $diary = file_get_contents(
+            dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'dynamic_update_util.php'
+        );
+
+        $this->assertIsString($main);
+        $this->assertIsString($diary);
+        $this->assertStringContainsString("if ((\$gameRequest[0] ?? '') !== 'diary')", $main);
+
+        $followerStart = strpos($diary, 'function generateFollowerDiary');
+        $this->assertNotFalse($followerStart);
+        $followerSource = substr($diary, $followerStart);
+        $logPosition = strpos($followerSource, "chimLogPromptComposition(\n        'diary'");
+        $requestPosition = strpos($followerSource, '$connectionHandler->fast_request($contextData');
+
+        $this->assertNotFalse($logPosition);
+        $this->assertNotFalse($requestPosition);
+        $this->assertLessThan($requestPosition, $logPosition);
+    }
 }

--- a/unittests/tests/PromptCompositionTest.php
+++ b/unittests/tests/PromptCompositionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'prompt_composition.php';
+
+final class PromptCompositionTest extends TestCase
+{
+    public function testMeasuresStringsAndMessageArraysWithoutSerializingMetadata(): void
+    {
+        $messages = [
+            ['role' => 'system', 'content' => 'abcd'],
+            ['role' => 'user', 'content' => '12345678'],
+        ];
+
+        $measurement = chimPromptCompositionMeasure($messages);
+
+        $this->assertSame(12, $measurement['characters']);
+        $this->assertSame(3, $measurement['estimated_tokens']);
+    }
+
+    public function testBuildsSectionBreakdownAndFinalMessageTotal(): void
+    {
+        $report = chimBuildPromptCompositionReport(
+            'inputtext',
+            [
+                'roleplay_instructions' => '1234',
+                'history' => [
+                    ['role' => 'user', 'content' => '12345678'],
+                ],
+                'empty' => null,
+            ],
+            [
+                ['role' => 'system', 'content' => '1234'],
+                ['role' => 'user', 'content' => '12345678'],
+            ]
+        );
+
+        $this->assertSame('inputtext', $report['request_type']);
+        $this->assertSame(2, $report['message_count']);
+        $this->assertSame(12, $report['total_characters']);
+        $this->assertSame(3, $report['estimated_total_tokens']);
+        $this->assertSame(
+            ['characters' => 4, 'estimated_tokens' => 1],
+            $report['sections']['roleplay_instructions']
+        );
+        $this->assertSame(
+            ['characters' => 8, 'estimated_tokens' => 2],
+            $report['sections']['history']
+        );
+        $this->assertSame(
+            ['characters' => 0, 'estimated_tokens' => 0],
+            $report['sections']['empty']
+        );
+    }
+
+    public function testCountsUtf8CharactersWhenMbstringIsAvailable(): void
+    {
+        $measurement = chimPromptCompositionMeasure('éééé');
+
+        $expectedCharacters = function_exists('mb_strlen') ? 4 : strlen('éééé');
+        $this->assertSame($expectedCharacters, $measurement['characters']);
+        $this->assertSame(intval(ceil($expectedCharacters / 4)), $measurement['estimated_tokens']);
+    }
+}

--- a/unittests/tests/PromptCompositionTest.php
+++ b/unittests/tests/PromptCompositionTest.php
@@ -77,7 +77,13 @@ final class PromptCompositionTest extends TestCase
         $followerStart = strpos($diary, 'function generateFollowerDiary');
         $this->assertNotFalse($followerStart);
         $followerSource = substr($diary, $followerStart);
-        $logPosition = strpos($followerSource, "chimLogPromptComposition(\n        'diary'");
+        $matched = preg_match(
+            "/chimLogPromptComposition\\s*\\(\\s*'diary'/",
+            $followerSource,
+            $logMatch,
+            PREG_OFFSET_CAPTURE
+        );
+        $logPosition = $matched === 1 ? $logMatch[0][1] : false;
         $requestPosition = strpos($followerSource, '$connectionHandler->fast_request($contextData');
 
         $this->assertNotFalse($logPosition);


### PR DESCRIPTION
## Summary
- add structured prompt-composition diagnostics without logging prompt text
- report per-section character counts and estimated token counts
- report final connector-bound message count and total prompt size
- cover standard response and diary prompt construction paths, including nearby/player/follower diary contexts

## Runtime impact
- emit one local structured debug record per LLM-bound request
- make no database writes, network requests, tokenizer calls, or additional LLM calls
- do not change prompt contents or connector behavior

## Validation
- PHP syntax checks passed for all changed PHP files
- focused prompt-composition PHPUnit coverage passed
- combined integration suite passed: **43 tests, 258 assertions**
- local helper/runtime probes verified section totals, message totals, and estimated-token output
- connector-bound diary diagnostics and line-ending coverage were added after review
- `git diff --check` passed

## Deployment
- deployed as part of the combined local HerikaServer validation build
