### PR TITLE
Add action availability inspector

### DIFF
--- a/lib/core/action_catalog.php
+++ b/lib/core/action_catalog.php
@@ -1830,55 +1830,64 @@ function herikaActionCatalogMatchesActivityRequirements($requirements, $status)
     return true;
 }
 
-function herikaActionCatalogRequirementsMatch($requirements, $context)
+function herikaActionCatalogInspectRequirements($requirements, $context)
 {
     $requirements = herikaActionCatalogDecodeJson($requirements, []);
     if (!is_array($requirements) || count($requirements) === 0) {
-        return true;
+        return [
+            'available' => true,
+            'reasons' => [],
+        ];
     }
 
     $context = is_array($context) ? $context : herikaActionCatalogGetRuntimeRequirementContext();
+    $reasons = [];
 
     if (isset($requirements['requires_rolemaster'])) {
         $expectedRolemaster = herikaActionCatalogToBool($requirements['requires_rolemaster']);
         if (herikaActionCatalogToBool($context['is_rolemastered'] ?? false) !== $expectedRolemaster) {
-            return false;
+            $reasons[] = $expectedRolemaster
+                ? 'Requires rolemaster control.'
+                : 'Unavailable while rolemaster control is active.';
         }
     }
 
     if (isset($requirements['requires_training_service'])) {
         $hasTrainingService = !empty($context['npc_extended']['class']['teaches']);
-        if ($hasTrainingService !== herikaActionCatalogToBool($requirements['requires_training_service'])) {
-            return false;
+        $expectedTrainingService = herikaActionCatalogToBool($requirements['requires_training_service']);
+        if ($hasTrainingService !== $expectedTrainingService) {
+            $reasons[] = $expectedTrainingService
+                ? 'Requires an NPC that offers training.'
+                : 'Unavailable for NPCs that offer training.';
         }
     }
 
     if (!empty($requirements['hide_in_rechat']) && !empty($context['is_rechat'])) {
-        return false;
+        $reasons[] = 'Hidden during rechat requests.';
     }
     if (!empty($requirements['show_only_in_rechat']) && empty($context['is_rechat'])) {
-        return false;
+        $reasons[] = 'Only available during rechat requests.';
     }
 
     $requestTypesAny = herikaActionCatalogNormalizeRequirementStringList($requirements['request_types_any'] ?? []);
     if (count($requestTypesAny) > 0 && !in_array(strtolower(trim(strval($context['request_type'] ?? ''))), $requestTypesAny, true)) {
-        return false;
+        $reasons[] = 'Request type must be one of: ' . implode(', ', $requestTypesAny) . '.';
     }
 
     $requestTypesNone = herikaActionCatalogNormalizeRequirementStringList($requirements['request_types_none'] ?? []);
     if (count($requestTypesNone) > 0 && in_array(strtolower(trim(strval($context['request_type'] ?? ''))), $requestTypesNone, true)) {
-        return false;
+        $reasons[] = 'Unavailable for request type: ' . strtolower(trim(strval($context['request_type'] ?? ''))) . '.';
     }
 
     $npcNamesAny = herikaActionCatalogNormalizeRequirementStringList($requirements['npc_names_any'] ?? []);
     if (count($npcNamesAny) > 0 && !in_array(strtolower(trim(strval($context['npc_name'] ?? ''))), $npcNamesAny, true)) {
-        return false;
+        $reasons[] = 'NPC name must be one of: ' . implode(', ', $npcNamesAny) . '.';
     }
 
     if (isset($requirements['npc_name_in_config_list'])) {
         $allowedNpcNames = herikaActionCatalogGetConfigListValues($requirements['npc_name_in_config_list']);
         if (count($allowedNpcNames) > 0 && !in_array(strtolower(trim(strval($context['npc_name'] ?? ''))), $allowedNpcNames, true)) {
-            return false;
+            $reasons[] = 'NPC is not included in the required configured name list.';
         }
     }
 
@@ -1888,7 +1897,7 @@ function herikaActionCatalogRequirementsMatch($requirements, $context)
             $requirements['npc_name_in_action_config_list']
         );
         if (count($allowedNpcNames) > 0 && !in_array(strtolower(trim(strval($context['npc_name'] ?? ''))), $allowedNpcNames, true)) {
-            return false;
+            $reasons[] = 'NPC is not included in this action configuration list.';
         }
     }
 
@@ -1898,7 +1907,7 @@ function herikaActionCatalogRequirementsMatch($requirements, $context)
         $requirements['npc_factions_any'] ?? [],
         false
     )) {
-        return false;
+        $reasons[] = 'NPC does not match any required faction.';
     }
 
     if (!herikaActionCatalogNpcMatchesFactionRequirement(
@@ -1907,14 +1916,57 @@ function herikaActionCatalogRequirementsMatch($requirements, $context)
         $requirements['npc_factions_all'] ?? [],
         true
     )) {
-        return false;
+        $reasons[] = 'NPC does not match all required factions.';
     }
 
     if (!herikaActionCatalogMatchesActivityRequirements($requirements['activity'] ?? [], $context['activity_status'] ?? [])) {
-        return false;
+        $reasons[] = 'NPC activity state does not meet this action requirement.';
     }
 
-    return true;
+    return [
+        'available' => count($reasons) === 0,
+        'reasons' => $reasons,
+    ];
+}
+
+function herikaActionCatalogRequirementsMatch($requirements, $context)
+{
+    $inspection = herikaActionCatalogInspectRequirements($requirements, $context);
+    return !empty($inspection['available']);
+}
+
+function herikaActionCatalogInspectRowAvailability($row, $context = null)
+{
+    if (!is_array($row)) {
+        return [
+            'available' => true,
+            'reasons' => [],
+        ];
+    }
+
+    $reasons = [];
+    if (!herikaActionCatalogToBool($row['is_activated'] ?? false)) {
+        $reasons[] = 'Action is disabled in the Action Editor.';
+    }
+
+    $metadata = herikaActionCatalogDecodeJson($row['metadata'] ?? [], []);
+    $context = is_array($context) ? $context : herikaActionCatalogGetRuntimeRequirementContext();
+    $context['action_config'] = function_exists('herikaActionCatalogGetResolvedCustomConfig')
+        ? herikaActionCatalogGetResolvedCustomConfig($row['code_name'] ?? '', $row)
+        : [];
+
+    $inspection = herikaActionCatalogInspectRequirements($metadata['requirements'] ?? [], $context);
+    $reasons = array_merge($reasons, $inspection['reasons'] ?? []);
+
+    $cooldownSeconds = intval($metadata['cooldown_seconds'] ?? 0);
+    return [
+        'available' => count($reasons) === 0,
+        'reasons' => $reasons,
+        'cooldown_seconds' => $cooldownSeconds,
+        'cooldown_note' => $cooldownSeconds > 0
+            ? "Runtime cooldown is {$cooldownSeconds} seconds and is checked when the action is issued."
+            : '',
+    ];
 }
 
 function herikaActionCatalogGetLastActionsIssuedMap()

--- a/ui/function_editor.php
+++ b/ui/function_editor.php
@@ -871,6 +871,15 @@ $availabilityInspectionContext = [
         "is_sitting" => functionEditorToBool($_POST["inspector_is_sitting"] ?? "0"),
     ],
 ];
+
+if ($availabilityInspectionContext["npc_name"] !== "" && class_exists("NpcMaster")) {
+    $inspectionNpcMaster = new NpcMaster();
+    $inspectionNpcData = $inspectionNpcMaster->getByName($availabilityInspectionContext["npc_name"]);
+    if (is_array($inspectionNpcData) && count($inspectionNpcData) > 0) {
+        $availabilityInspectionContext["npc_master"] = $inspectionNpcMaster;
+        $availabilityInspectionContext["npc_data"] = $inspectionNpcData;
+    }
+}
 $availabilityInspectionRows = [];
 $activeActionScopeGroups = functionEditorCreateActiveScopeGroups();
 $catalogReady = function_exists("herikaActionCatalogDbReady") && herikaActionCatalogDbReady();

--- a/ui/function_editor.php
+++ b/ui/function_editor.php
@@ -851,6 +851,27 @@ $rows = [];
 $countAll = 0;
 $countEnabled = 0;
 $countDisabled = 0;
+$availabilityInspectionRequested = ($_SERVER["REQUEST_METHOD"] === "POST"
+    && strval($_POST["action"] ?? "") === "inspect_action_availability");
+$availabilityInspectionContext = [
+    "npc_name" => functionEditorTrim($_POST["inspector_npc_name"] ?? ""),
+    "request_type" => strtolower(functionEditorTrim($_POST["inspector_request_type"] ?? "inputtext")),
+    "is_rechat" => functionEditorToBool($_POST["inspector_is_rechat"] ?? "0"),
+    "is_rolemastered" => functionEditorToBool($_POST["inspector_is_rolemastered"] ?? "0"),
+    "npc_extended" => [
+        "class" => [
+            "teaches" => functionEditorToBool($_POST["inspector_training_service"] ?? "0") ? "training" : "",
+        ],
+    ],
+    "activity_status" => [
+        "available" => true,
+        "fresh" => true,
+        "is_in_combat" => functionEditorToBool($_POST["inspector_is_in_combat"] ?? "0"),
+        "is_moving" => functionEditorToBool($_POST["inspector_is_moving"] ?? "0"),
+        "is_sitting" => functionEditorToBool($_POST["inspector_is_sitting"] ?? "0"),
+    ],
+];
+$availabilityInspectionRows = [];
 $activeActionScopeGroups = functionEditorCreateActiveScopeGroups();
 $catalogReady = function_exists("herikaActionCatalogDbReady") && herikaActionCatalogDbReady();
 
@@ -947,6 +968,32 @@ if ($catalogReady) {
         ORDER BY LOWER(v.action_name), LOWER(v.code_name)
     ");
     $activeActionScopeGroups = functionEditorBuildActiveScopeGroups($activeActionRows);
+
+    if ($availabilityInspectionRequested) {
+        $inspectionRows = $GLOBALS["db"]->fetchAll("
+            SELECT
+                v.code_name,
+                v.action_name,
+                v.is_activated,
+                v.metadata
+            FROM public.combined_core_action v
+            ORDER BY LOWER(v.action_name), LOWER(v.code_name)
+        ");
+
+        foreach ($inspectionRows as $inspectionRow) {
+            $inspection = herikaActionCatalogInspectRowAvailability(
+                $inspectionRow,
+                $availabilityInspectionContext
+            );
+            $availabilityInspectionRows[] = [
+                "code_name" => strval($inspectionRow["code_name"] ?? ""),
+                "action_name" => strval($inspectionRow["action_name"] ?? ""),
+                "available" => !empty($inspection["available"]),
+                "reasons" => is_array($inspection["reasons"] ?? null) ? $inspection["reasons"] : [],
+                "cooldown_note" => strval($inspection["cooldown_note"] ?? ""),
+            ];
+        }
+    }
 }
 
 ob_start();
@@ -1047,6 +1094,68 @@ if (!$isEmbed) {
         margin-bottom: 15px;
         font-size: 1.6em;
         text-align: center;
+    }
+    .availability-inspector-form {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(180px, 1fr));
+        gap: 12px;
+        align-items: end;
+    }
+    .availability-inspector-field {
+        display: grid;
+        gap: 6px;
+    }
+    .availability-inspector-field label {
+        color: #e6b76c;
+        font-weight: 700;
+    }
+    .availability-inspector-checks {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px 18px;
+        grid-column: 1 / -1;
+    }
+    .availability-inspector-checks label {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        color: #d0d6df;
+    }
+    .availability-results {
+        margin-top: 16px;
+        display: grid;
+        gap: 8px;
+    }
+    .availability-result {
+        display: grid;
+        grid-template-columns: minmax(180px, 0.8fr) 110px minmax(280px, 2fr);
+        gap: 12px;
+        align-items: start;
+        padding: 10px 12px;
+        border: 1px solid #3a3a3a;
+        border-radius: 6px;
+        background: #20242a;
+    }
+    .availability-result-state {
+        font-weight: 700;
+    }
+    .availability-result-state.available {
+        color: #72c68a;
+    }
+    .availability-result-state.filtered {
+        color: #e18b8b;
+    }
+    .availability-result-reasons {
+        color: #cbd1da;
+        line-height: 1.4;
+    }
+    @media (max-width: 900px) {
+        .availability-inspector-form {
+            grid-template-columns: 1fr;
+        }
+        .availability-result {
+            grid-template-columns: 1fr;
+        }
     }
     .stat-line {
         margin: 8px 0;
@@ -1965,6 +2074,105 @@ if (!$isEmbed) {
                     <strong>Disable</strong> to control whether the AI may use it. Confirmation rules, return messages,
                     parameters, and technical settings are available under <strong>Advanced Options</strong>.
                 </p>
+            </div>
+
+            <div class="content-section full-width-section">
+                <div class="section-header">
+                    <h2>Action Availability Inspector</h2>
+                </div>
+                <p style="margin:0 0 16px; color:#d0d6df; line-height:1.45;">
+                    Preview which actions would be offered for a simulated request. This does not execute an action,
+                    contact an LLM, or change configuration. Runtime cooldowns remain checked only when an action is issued.
+                </p>
+                <form method="post" class="availability-inspector-form">
+                    <?php if ($isEmbed): ?><input type="hidden" name="embed" value="1"><?php endif; ?>
+                    <input type="hidden" name="action" value="inspect_action_availability">
+                    <div class="availability-inspector-field">
+                        <label for="inspector-npc-name">NPC Name</label>
+                        <input
+                            type="text"
+                            id="inspector-npc-name"
+                            name="inspector_npc_name"
+                            value="<?php echo h($availabilityInspectionContext["npc_name"]); ?>"
+                            placeholder="Hilde"
+                        >
+                    </div>
+                    <div class="availability-inspector-field">
+                        <label for="inspector-request-type">Request Type</label>
+                        <input
+                            type="text"
+                            id="inspector-request-type"
+                            name="inspector_request_type"
+                            value="<?php echo h($availabilityInspectionContext["request_type"]); ?>"
+                            placeholder="inputtext"
+                        >
+                    </div>
+                    <div>
+                        <button type="submit" class="btn-save">Inspect Actions</button>
+                    </div>
+                    <div class="availability-inspector-checks">
+                        <?php
+                        $inspectorChecks = [
+                            "inspector_is_rechat" => ["Rechat request", $availabilityInspectionContext["is_rechat"]],
+                            "inspector_is_rolemastered" => ["Rolemaster active", $availabilityInspectionContext["is_rolemastered"]],
+                            "inspector_training_service" => ["NPC offers training", !empty($availabilityInspectionContext["npc_extended"]["class"]["teaches"])],
+                            "inspector_is_in_combat" => ["NPC in combat", !empty($availabilityInspectionContext["activity_status"]["is_in_combat"])],
+                            "inspector_is_moving" => ["NPC moving", !empty($availabilityInspectionContext["activity_status"]["is_moving"])],
+                            "inspector_is_sitting" => ["NPC sitting", !empty($availabilityInspectionContext["activity_status"]["is_sitting"])],
+                        ];
+                        ?>
+                        <?php foreach ($inspectorChecks as $checkName => $checkDefinition): ?>
+                            <label>
+                                <input type="checkbox" name="<?php echo h($checkName); ?>" value="1" <?php echo !empty($checkDefinition[1]) ? "checked" : ""; ?>>
+                                <?php echo h($checkDefinition[0]); ?>
+                            </label>
+                        <?php endforeach; ?>
+                    </div>
+                </form>
+
+                <?php if ($availabilityInspectionRequested): ?>
+                    <?php
+                    $availableInspectionCount = count(array_filter(
+                        $availabilityInspectionRows,
+                        static function ($row) {
+                            return !empty($row["available"]);
+                        }
+                    ));
+                    ?>
+                    <div class="availability-results">
+                        <div class="filter-summary">
+                            <?php echo h($availableInspectionCount); ?> available,
+                            <?php echo h(count($availabilityInspectionRows) - $availableInspectionCount); ?> filtered
+                        </div>
+                        <?php foreach ($availabilityInspectionRows as $inspectionRow): ?>
+                            <?php
+                            $inspectionName = trim(strval($inspectionRow["action_name"] ?? ""));
+                            $inspectionCode = strval($inspectionRow["code_name"] ?? "");
+                            $inspectionReasons = $inspectionRow["reasons"] ?? [];
+                            $inspectionCooldownNote = trim(strval($inspectionRow["cooldown_note"] ?? ""));
+                            ?>
+                            <div class="availability-result">
+                                <div>
+                                    <strong><?php echo h($inspectionName !== "" ? $inspectionName : $inspectionCode); ?></strong><br>
+                                    <code><?php echo h($inspectionCode); ?></code>
+                                </div>
+                                <div class="availability-result-state <?php echo !empty($inspectionRow["available"]) ? "available" : "filtered"; ?>">
+                                    <?php echo !empty($inspectionRow["available"]) ? "Available" : "Filtered"; ?>
+                                </div>
+                                <div class="availability-result-reasons">
+                                    <?php if (count($inspectionReasons) === 0): ?>
+                                        All configured requirements match.
+                                    <?php else: ?>
+                                        <?php echo h(implode(" ", $inspectionReasons)); ?>
+                                    <?php endif; ?>
+                                    <?php if ($inspectionCooldownNote !== ""): ?>
+                                        <div><?php echo h($inspectionCooldownNote); ?></div>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
             </div>
 
             <div id="activeActionsModal" class="action-modal" hidden>

--- a/unittests/tests/ActionCatalogTest.php
+++ b/unittests/tests/ActionCatalogTest.php
@@ -833,6 +833,25 @@ final class ActionCatalogTest extends TestCase
         $this->assertStringContainsString('30 seconds', $inspection['cooldown_note']);
     }
 
+    public function testInspectorLoadsNamedNpcDataForFactionRequirements(): void
+    {
+        $source = file_get_contents(dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'ui' . DIRECTORY_SEPARATOR . 'function_editor.php');
+
+        $this->assertIsString($source);
+        $this->assertStringContainsString(
+            '$inspectionNpcData = $inspectionNpcMaster->getByName($availabilityInspectionContext["npc_name"]);',
+            $source
+        );
+        $this->assertStringContainsString(
+            '$availabilityInspectionContext["npc_master"] = $inspectionNpcMaster;',
+            $source
+        );
+        $this->assertStringContainsString(
+            '$availabilityInspectionContext["npc_data"] = $inspectionNpcData;',
+            $source
+        );
+    }
+
     public function testActionCatalogRowIsAvailableInCurrentMode_UsesNarratorScopeForNarrator(): void
     {
         $previousHerikaName = $GLOBALS['HERIKA_NAME'] ?? null;

--- a/unittests/tests/ActionCatalogTest.php
+++ b/unittests/tests/ActionCatalogTest.php
@@ -784,6 +784,55 @@ final class ActionCatalogTest extends TestCase
         }
     }
 
+    public function testRequirementInspectionExplainsFilteredActions(): void
+    {
+        $inspection = herikaActionCatalogInspectRequirements([
+            'requires_rolemaster' => true,
+            'hide_in_rechat' => true,
+            'request_types_any' => ['inputtext', 'ginputtext'],
+            'npc_names_any' => ['Hilde'],
+            'activity' => ['is_in_combat' => true],
+        ], [
+            'is_rolemastered' => false,
+            'is_rechat' => true,
+            'request_type' => 'rechat',
+            'npc_name' => 'Alvor',
+            'activity_status' => [
+                'available' => true,
+                'is_in_combat' => false,
+            ],
+        ]);
+
+        $this->assertFalse($inspection['available']);
+        $this->assertContains('Requires rolemaster control.', $inspection['reasons']);
+        $this->assertContains('Hidden during rechat requests.', $inspection['reasons']);
+        $this->assertContains('Request type must be one of: inputtext, ginputtext.', $inspection['reasons']);
+        $this->assertContains('NPC name must be one of: hilde.', $inspection['reasons']);
+        $this->assertContains('NPC activity state does not meet this action requirement.', $inspection['reasons']);
+        $this->assertFalse(herikaActionCatalogRequirementsMatch([
+            'requires_rolemaster' => true,
+        ], [
+            'is_rolemastered' => false,
+        ]));
+    }
+
+    public function testRowInspectionReportsDisabledStateAndCooldownWithoutExecutingIt(): void
+    {
+        $inspection = herikaActionCatalogInspectRowAvailability([
+            'code_name' => 'FollowPlayer',
+            'is_activated' => false,
+            'metadata' => [
+                'requirements' => [],
+                'cooldown_seconds' => 30,
+            ],
+        ], []);
+
+        $this->assertFalse($inspection['available']);
+        $this->assertSame(['Action is disabled in the Action Editor.'], $inspection['reasons']);
+        $this->assertSame(30, $inspection['cooldown_seconds']);
+        $this->assertStringContainsString('30 seconds', $inspection['cooldown_note']);
+    }
+
     public function testActionCatalogRowIsAvailableInCurrentMode_UsesNarratorScopeForNarrator(): void
     {
         $previousHerikaName = $GLOBALS['HERIKA_NAME'] ?? null;


### PR DESCRIPTION
## Summary
- add a read-only Action Availability Inspector to the Action Editor
- explain why each action is available or filtered for a simulated request context
- use the same diagnostic evaluator in the live requirement matcher
- surface disabled state and runtime cooldown notes without executing actions
- resolve the inspected NPC through `NpcMaster`, including their actual faction list

## Inspector inputs
- NPC name and request type
- rechat and rolemaster state
- training-service availability
- common activity states such as combat, movement, and sitting

## Safety
- does not execute actions, contact an LLM, make network requests, or save configuration
- runtime cooldowns are reported but remain enforced only when actions are issued

## Validation
- PHP syntax checks passed for all changed PHP files
- focused ActionCatalog PHPUnit coverage passed
- combined integration suite passed: **43 tests, 258 assertions**
- deployed inspector resolved Hilde and reported **73 available / 21 filtered** actions
- faction-gated actions such as `Add_Bounty` and `Arrest` were correctly filtered using the NPC's resolved factions
- browser endpoint returned HTTP 200 and rendered without console errors
- `git diff --check` passed

## Deployment
- deployed and exercised through the local Action Editor
