### PR TITLE
Add Oghma context rule preview

### DIFF
--- a/lib/oghma_context_rule_admin.php
+++ b/lib/oghma_context_rule_admin.php
@@ -45,6 +45,106 @@ function oghma_context_rule_condition_text(array $conditions, string $field): st
     return implode(', ', array_map('strval', $values));
 }
 
+function oghma_context_rule_preview_context_from_post(array $post): array
+{
+    $context = [];
+    foreach ([
+        'npc',
+        'nearby_actor',
+        'race',
+        'faction',
+        'profile',
+        'location',
+        'hold',
+        'environment',
+        'weather',
+        'event_type',
+    ] as $field) {
+        $context[$field] = oghma_context_rule_values($post['preview_' . $field] ?? '');
+    }
+    return $context;
+}
+
+function oghma_context_rule_preview_articles($conn, string $schema, array $rule): array
+{
+    $selectorType = strtolower(trim((string)($rule['selector_type'] ?? '')));
+    $selectorValue = chimOghmaNormalizeLookupLabel($rule['selector_value'] ?? '');
+    if ($selectorValue === '' || !in_array($selectorType, ['topic', 'tag', 'category'], true)) {
+        return [];
+    }
+
+    if ($selectorType === 'topic') {
+        $condition = "EXISTS (
+            SELECT 1
+              FROM regexp_split_to_table(topic, E'\\\\s*,\\\\s*') AS selector_value
+             WHERE regexp_replace(replace(lower(selector_value), '_', ' '), '[^a-z0-9]+', ' ', 'g') = $1
+        )";
+    } elseif ($selectorType === 'tag') {
+        $condition = "EXISTS (
+            SELECT 1
+              FROM regexp_split_to_table(coalesce(tags, ''), E'\\\\s*,\\\\s*') AS selector_value
+             WHERE regexp_replace(replace(lower(selector_value), '_', ' '), '[^a-z0-9]+', ' ', 'g') = $1
+        )";
+    } else {
+        $condition = "regexp_replace(replace(lower(coalesce(category, '')), '_', ' '), '[^a-z0-9]+', ' ', 'g') = $1";
+    }
+
+    $limit = max(1, min(5, (int)($rule['max_articles'] ?? 1)));
+    $result = pg_query_params(
+        $conn,
+        "SELECT topic, category, tags
+           FROM {$schema}.oghma
+          WHERE {$condition}
+          ORDER BY topic
+          LIMIT {$limit}",
+        [$selectorValue]
+    );
+    if (!$result) {
+        return [];
+    }
+
+    $rows = pg_fetch_all($result);
+    return is_array($rows) ? $rows : [];
+}
+
+function oghma_context_rule_build_preview($conn, string $schema, array $post): ?array
+{
+    $ruleId = max(0, (int)($post['preview_context_rule_id'] ?? 0));
+    if ($ruleId <= 0) {
+        return null;
+    }
+
+    $result = pg_query_params(
+        $conn,
+        "SELECT id, label, selector_type, selector_value, conditions, max_articles
+           FROM {$schema}.oghma_context_rule
+          WHERE id = $1",
+        [$ruleId]
+    );
+    $rule = $result ? pg_fetch_assoc($result) : false;
+    if (!is_array($rule)) {
+        return null;
+    }
+
+    $conditions = json_decode((string)($rule['conditions'] ?? '{}'), true);
+    if (!is_array($conditions)) {
+        $conditions = [];
+    }
+    $context = oghma_context_rule_preview_context_from_post($post);
+    $inspection = chimOghmaInspectContextRuleConditions($conditions, $context);
+    $articles = !empty($inspection['matches'])
+        ? oghma_context_rule_preview_articles($conn, $schema, $rule)
+        : [];
+
+    return [
+        'rule' => $rule,
+        'context' => $context,
+        'matches' => !empty($inspection['matches']),
+        'conditions' => $inspection['conditions'] ?? [],
+        'articles' => $articles,
+    ];
+}
+
 function oghma_context_rule_handle_post($conn, string $schema, array $post, string $method): string
 {
     if ($method !== 'POST') {

--- a/lib/oghma_context_rule_admin.php
+++ b/lib/oghma_context_rule_admin.php
@@ -47,7 +47,7 @@ function oghma_context_rule_condition_text(array $conditions, string $field): st
 
 function oghma_context_rule_preview_context_from_post(array $post): array
 {
-    $context = [];
+    $rawContext = [];
     foreach ([
         'npc',
         'nearby_actor',
@@ -60,9 +60,9 @@ function oghma_context_rule_preview_context_from_post(array $post): array
         'weather',
         'event_type',
     ] as $field) {
-        $context[$field] = oghma_context_rule_values($post['preview_' . $field] ?? '');
+        $rawContext[$field] = oghma_context_rule_values($post['preview_' . $field] ?? '');
     }
-    return $context;
+    return chimOghmaBuildContextRulePreviewContext($rawContext);
 }
 
 function oghma_context_rule_preview_articles($conn, string $schema, array $rule): array

--- a/lib/oghma_context_rules.php
+++ b/lib/oghma_context_rules.php
@@ -113,22 +113,50 @@ if (!function_exists('chimOghmaBuildContextRuleContext')) {
 }
 
 if (!function_exists('chimOghmaContextRuleMatches')) {
-    function chimOghmaContextRuleMatches(array $conditions, array $context, ?array &$reasons = null): bool
+    function chimOghmaInspectContextRuleConditions(array $conditions, array $context): array
     {
-        $reasons = [];
+        $conditionResults = [];
+        $matchesAll = true;
+
         foreach ($conditions as $field => $expectedValues) {
             $expected = chimOghmaRuleValues($expectedValues);
             if (empty($expected)) {
                 continue;
             }
+
             $actual = chimOghmaRuleValues($context[$field] ?? []);
             $matched = array_values(array_intersect($expected, $actual));
-            if (empty($matched)) {
-                return false;
+            $matches = !empty($matched);
+            if (!$matches) {
+                $matchesAll = false;
             }
-            $reasons[] = $field . '=' . implode('|', $matched);
+
+            $conditionResults[] = [
+                'field' => (string) $field,
+                'expected' => $expected,
+                'actual' => $actual,
+                'matched' => $matched,
+                'matches' => $matches,
+            ];
         }
-        return true;
+
+        return [
+            'matches' => $matchesAll,
+            'conditions' => $conditionResults,
+        ];
+    }
+
+    function chimOghmaContextRuleMatches(array $conditions, array $context, ?array &$reasons = null): bool
+    {
+        $inspection = chimOghmaInspectContextRuleConditions($conditions, $context);
+        $reasons = [];
+        foreach ($inspection['conditions'] as $condition) {
+            if (empty($condition['matches'])) {
+                continue;
+            }
+            $reasons[] = $condition['field'] . '=' . implode('|', $condition['matched']);
+        }
+        return !empty($inspection['matches']);
     }
 }
 

--- a/lib/oghma_context_rules.php
+++ b/lib/oghma_context_rules.php
@@ -73,6 +73,58 @@ if (!function_exists('chimOghmaWeatherSignals')) {
     }
 }
 
+if (!function_exists('chimOghmaBuildContextRulePreviewContext')) {
+    function chimOghmaBuildContextRulePreviewContext(array $rawContext): array
+    {
+        $context = [];
+        foreach (['npc', 'nearby_actor', 'faction', 'profile', 'event_type'] as $field) {
+            $context[$field] = chimOghmaRuleValues($rawContext[$field] ?? []);
+        }
+
+        $raceSignals = [];
+        foreach (chimOghmaRuleValues($rawContext['race'] ?? []) as $race) {
+            $raceSignals = array_merge($raceSignals, chimOghmaRaceSignals($race));
+        }
+        $context['race'] = chimOghmaUniqueSignals($raceSignals);
+
+        $locationSignals = [];
+        foreach (chimOghmaRuleValues($rawContext['location'] ?? []) as $location) {
+            $locationSignals = array_merge($locationSignals, chimOghmaLocationNameSignals($location));
+        }
+        $context['location'] = chimOghmaUniqueSignals($locationSignals);
+
+        $holdSignals = [];
+        foreach (chimOghmaRuleValues($rawContext['hold'] ?? []) as $hold) {
+            $holdSignals = array_merge($holdSignals, chimOghmaHoldSignals($hold));
+        }
+        $context['hold'] = chimOghmaUniqueSignals($holdSignals);
+
+        $weatherSignals = [];
+        $weatherValues = $rawContext['weather'] ?? [];
+        if (!is_array($weatherValues)) {
+            $weatherValues = [$weatherValues];
+        }
+        foreach ($weatherValues as $weather) {
+            $weatherSignals = array_merge($weatherSignals, chimOghmaWeatherSignals($weather));
+        }
+        $context['weather'] = chimOghmaUniqueSignals($weatherSignals);
+
+        $environment = [];
+        foreach (chimOghmaRuleValues($rawContext['environment'] ?? []) as $value) {
+            if (in_array($value, ['outdoor', 'outdoors', 'outside', 'exterior'], true)) {
+                $environment[] = 'exterior';
+            } elseif (in_array($value, ['indoor', 'indoors', 'inside', 'interior'], true)) {
+                $environment[] = 'interior';
+            } else {
+                $environment[] = $value;
+            }
+        }
+        $context['environment'] = chimOghmaUniqueSignals($environment);
+
+        return $context;
+    }
+}
+
 if (!function_exists('chimOghmaBuildContextRuleContext')) {
     function chimOghmaBuildContextRuleContext($db, $npcMaster = null): array
     {

--- a/ui/oghma_upload.php
+++ b/ui/oghma_upload.php
@@ -45,12 +45,16 @@ if (!$conn) {
 }
 
 require_once $rootPath . 'lib' . DIRECTORY_SEPARATOR . 'oghma_context_rule_admin.php';
+require_once $rootPath . 'lib' . DIRECTORY_SEPARATOR . 'oghma_forced_context.php';
 $message .= oghma_context_rule_handle_post(
     $conn,
     $schema,
     $_POST,
     $_SERVER['REQUEST_METHOD'] ?? 'GET'
 );
+$contextRulePreviewResult = isset($_POST['preview_context_rule'])
+    ? oghma_context_rule_build_preview($conn, $schema, $_POST)
+    : null;
 
 /********************************************************************
  *  1) SINGLE TOPIC UPLOAD

--- a/ui/tmpl/oghma_context_rules_panel.php
+++ b/ui/tmpl/oghma_context_rules_panel.php
@@ -146,6 +146,54 @@ function oghma_render_context_rule_form(array $rule, bool $isNew = false): void
         margin-right: auto;
     }
 
+    .context-rule-preview {
+        border: 1px solid #4a4a4a;
+        border-radius: 6px;
+        background: #1f2328;
+        padding: 14px;
+        margin: 16px 0;
+    }
+
+    .context-rule-preview h3 {
+        margin: 0 0 12px;
+        color: rgb(242, 124, 17);
+    }
+
+    .context-rule-preview-result {
+        margin-top: 14px;
+        padding: 12px;
+        border: 1px solid #4a4a4a;
+        border-radius: 5px;
+    }
+
+    .context-rule-preview-result.matches {
+        border-color: #4c8f63;
+    }
+
+    .context-rule-preview-result.filtered {
+        border-color: #9b4d4d;
+    }
+
+    .context-rule-preview-condition {
+        display: grid;
+        grid-template-columns: 120px 90px 1fr;
+        gap: 10px;
+        padding: 7px 0;
+        border-bottom: 1px solid #363636;
+    }
+
+    .context-rule-preview-condition:last-child {
+        border-bottom: 0;
+    }
+
+    .context-rule-preview-state.matches {
+        color: #72c68a;
+    }
+
+    .context-rule-preview-state.filtered {
+        color: #e18b8b;
+    }
+
     @media (max-width: 1100px) {
         .context-rule-grid {
             grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -154,6 +202,9 @@ function oghma_render_context_rule_form(array $rule, bool $isNew = false): void
 
     @media (max-width: 700px) {
         .context-rule-grid {
+            grid-template-columns: 1fr;
+        }
+        .context-rule-preview-condition {
             grid-template-columns: 1fr;
         }
     }
@@ -165,6 +216,116 @@ function oghma_render_context_rule_form(array $rule, bool $isNew = false): void
             <h2>&#x1F3AF; Oghma Context Rules</h2>
             <p>All populated conditions on a rule must match. Comma-separated values within one condition are alternatives. Leave every condition blank to create an always-on rule.</p>
             <p>Normal Oghma search and the existing Force Racial Oghma and Force Location Oghma settings continue to work alongside these rules.</p>
+        </div>
+
+        <div class="context-rule-preview">
+            <h3>Preview Saved Rule</h3>
+            <p>Test a rule against simulated context. Previewing does not save a rule or inject articles into a prompt.</p>
+            <form method="post">
+                <input type="hidden" name="preview_context_rule" value="1">
+                <div class="context-rule-grid">
+                    <div class="context-rule-field">
+                        <label>Saved Rule</label>
+                        <small>Select the rule to inspect.</small>
+                        <select name="preview_context_rule_id" required>
+                            <option value="">Select a rule</option>
+                            <?php
+                            $previewRuleOptions = pg_query(
+                                $conn,
+                                "SELECT id, label
+                                   FROM {$schema}.oghma_context_rule
+                                  ORDER BY priority, id"
+                            );
+                            if ($previewRuleOptions):
+                                while ($previewRuleOption = pg_fetch_assoc($previewRuleOptions)):
+                                    $previewRuleId = (int)($previewRuleOption['id'] ?? 0);
+                                    $previewRuleSelected = $previewRuleId === (int)($_POST['preview_context_rule_id'] ?? 0);
+                                    ?>
+                                    <option value="<?php echo $previewRuleId; ?>" <?php echo $previewRuleSelected ? 'selected' : ''; ?>>
+                                        <?php echo htmlspecialchars((string)($previewRuleOption['label'] ?? 'Unnamed rule'), ENT_QUOTES, 'UTF-8'); ?>
+                                    </option>
+                                    <?php
+                                endwhile;
+                            endif;
+                            ?>
+                        </select>
+                    </div>
+                    <?php
+                    $previewFields = [
+                        'npc' => 'NPC Name',
+                        'nearby_actor' => 'Nearby Actor',
+                        'race' => 'Race',
+                        'faction' => 'Faction',
+                        'profile' => 'Profile ID',
+                        'location' => 'Location or Region',
+                        'hold' => 'Hold',
+                        'environment' => 'Environment',
+                        'weather' => 'Weather',
+                        'event_type' => 'Event Type',
+                    ];
+                    ?>
+                    <?php foreach ($previewFields as $previewField => $previewLabel): ?>
+                        <div class="context-rule-field">
+                            <label><?php echo htmlspecialchars($previewLabel, ENT_QUOTES, 'UTF-8'); ?></label>
+                            <small>Comma-separated simulated values.</small>
+                            <input
+                                type="text"
+                                name="preview_<?php echo $previewField; ?>"
+                                value="<?php echo htmlspecialchars((string)($_POST['preview_' . $previewField] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
+                            >
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+                <div class="context-rule-actions">
+                    <button type="submit" class="btn-save">Preview Rule</button>
+                </div>
+            </form>
+
+            <?php if (is_array($contextRulePreviewResult ?? null)): ?>
+                <div class="context-rule-preview-result <?php echo !empty($contextRulePreviewResult['matches']) ? 'matches' : 'filtered'; ?>">
+                    <strong>
+                        <?php echo htmlspecialchars((string)($contextRulePreviewResult['rule']['label'] ?? 'Rule'), ENT_QUOTES, 'UTF-8'); ?>:
+                        <?php echo !empty($contextRulePreviewResult['matches']) ? 'Matched' : 'Filtered'; ?>
+                    </strong>
+
+                    <?php if (empty($contextRulePreviewResult['conditions'])): ?>
+                        <p>No conditions are configured, so this rule always matches.</p>
+                    <?php else: ?>
+                        <?php foreach ($contextRulePreviewResult['conditions'] as $conditionResult): ?>
+                            <?php $conditionMatches = !empty($conditionResult['matches']); ?>
+                            <div class="context-rule-preview-condition">
+                                <strong><?php echo htmlspecialchars((string)($conditionResult['field'] ?? ''), ENT_QUOTES, 'UTF-8'); ?></strong>
+                                <span class="context-rule-preview-state <?php echo $conditionMatches ? 'matches' : 'filtered'; ?>">
+                                    <?php echo $conditionMatches ? 'Matched' : 'Failed'; ?>
+                                </span>
+                                <span>
+                                    Expected: <?php echo htmlspecialchars(implode(', ', $conditionResult['expected'] ?? []), ENT_QUOTES, 'UTF-8'); ?>.
+                                    Actual: <?php echo htmlspecialchars(implode(', ', $conditionResult['actual'] ?? []), ENT_QUOTES, 'UTF-8'); ?>.
+                                    <?php if ($conditionMatches): ?>
+                                        Matched: <?php echo htmlspecialchars(implode(', ', $conditionResult['matched'] ?? []), ENT_QUOTES, 'UTF-8'); ?>.
+                                    <?php endif; ?>
+                                </span>
+                            </div>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+
+                    <?php if (!empty($contextRulePreviewResult['matches'])): ?>
+                        <p>
+                            Selected articles:
+                            <?php if (empty($contextRulePreviewResult['articles'])): ?>
+                                none found for this selector.
+                            <?php else: ?>
+                                <?php echo htmlspecialchars(implode(', ', array_map(
+                                    static function ($article) {
+                                        return (string)($article['topic'] ?? '');
+                                    },
+                                    $contextRulePreviewResult['articles']
+                                )), ENT_QUOTES, 'UTF-8'); ?>.
+                            <?php endif; ?>
+                        </p>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
         </div>
 
         <?php

--- a/unittests/tests/OghmaContextRulesTest.php
+++ b/unittests/tests/OghmaContextRulesTest.php
@@ -81,6 +81,27 @@ final class OghmaContextRulesTest extends TestCase
         ], $context));
     }
 
+    public function testRuleInspectionReportsEveryConditionWithoutChangingMatchSemantics(): void
+    {
+        $inspection = chimOghmaInspectContextRuleConditions([
+            'race' => ['Nord', 'Dunmer'],
+            'hold' => ['The Rift'],
+            'event_type' => ['inputtext'],
+        ], [
+            'race' => ['Dunmer'],
+            'hold' => ['Whiterun'],
+            'event_type' => ['inputtext'],
+        ]);
+
+        $this->assertFalse($inspection['matches']);
+        $this->assertCount(3, $inspection['conditions']);
+        $this->assertTrue($inspection['conditions'][0]['matches']);
+        $this->assertSame(['dunmer'], $inspection['conditions'][0]['matched']);
+        $this->assertFalse($inspection['conditions'][1]['matches']);
+        $this->assertSame(['whiterun'], $inspection['conditions'][1]['actual']);
+        $this->assertTrue($inspection['conditions'][2]['matches']);
+    }
+
     public function testContextRuleInjectionUsesExistingPermissionAndDeduplicationPath(): void
     {
         $GLOBALS['CHIM_CORE_CURRENT_NPC_DATA'] = [

--- a/unittests/tests/OghmaContextRulesTest.php
+++ b/unittests/tests/OghmaContextRulesTest.php
@@ -137,4 +137,22 @@ final class OghmaContextRulesTest extends TestCase
             chimOghmaWeatherSignals('Outdoors it is rainy, foggy')
         );
     }
+
+    public function testPreviewContextUsesRuntimeAliasesAndEnvironmentTerms(): void
+    {
+        $context = chimOghmaBuildContextRulePreviewContext([
+            'race' => ['Dark Elf'],
+            'location' => ['Riverwood Trader'],
+            'hold' => ['Whiterun Hold'],
+            'environment' => ['Outdoors'],
+            'weather' => ['Outdoors it is Rainy, Foggy'],
+        ]);
+
+        $this->assertSame(['dark elf', 'dunmer'], $context['race']);
+        $this->assertSame(['riverwood trader', 'riverwood'], $context['location']);
+        $this->assertContains('whiterun', $context['hold']);
+        $this->assertSame(['exterior'], $context['environment']);
+        $this->assertContains('rainy', $context['weather']);
+        $this->assertContains('foggy', $context['weather']);
+    }
 }


### PR DESCRIPTION
## Summary
- add a read-only preview for saved Oghma context rules
- simulate NPC, nearby actor, race, faction, profile, location, hold, environment, weather, and event context
- show expected, normalized actual, and matched values for every configured condition
- show the exact bounded article topics selected when a rule matches

## Safety
- previewing does not save rules or inject articles into prompts
- no LLM or external network calls are made
- article lookup preserves the existing one-to-five article limit

## Dependency
- stacked on #611
- merge #611 first, then retarget this PR to `unstable`

## Validation
- PHP syntax checks passed for all changed PHP files
- focused Oghma preview PHPUnit coverage passed
- combined integration suite passed: **43 tests, 258 assertions**
- deployed preview verified full alias/signal normalization, a matching Nord context, a filtered Breton context, and bounded selected articles
- preview left no temporary database rows or configuration changes
- browser endpoint returned HTTP 200 and rendered without console errors
- `git diff --check` passed

## Deployment
- deployed and exercised locally together with #611
