### PR TITLE
Add memory recall candidate audit

### DIFF
--- a/data/database_default.sql
+++ b/data/database_default.sql
@@ -540,6 +540,7 @@ CREATE TABLE public.audit_memory (
     rank_all numeric(20,10),
     memory text,
     "time" text,
+    recall_candidates jsonb,
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -1776,6 +1776,11 @@ if (!$existsColumn[0]["column_name"]) {
     echo '<script>alert("A patch (0.1.5p1) has been applied to Database")</script>';
 }
 
+$db->execQuery(
+    "ALTER TABLE IF EXISTS public.audit_memory
+     ADD COLUMN IF NOT EXISTS recall_candidates jsonb"
+);
+
 // Memory ts
 $query = "
     SELECT column_name 

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -5249,6 +5249,7 @@ function DataSearchMemoryByVector($rawstring,$npcfilter,$useContextKw=false,$tim
                 ";    
             $memory=$GLOBALS["db"]->fetchAll($finalQuery);
             $singleMemory = chimSelectBestHybridMemoryCandidate($memory);
+            $recallCandidates = chimBuildMemoryRecallAuditCandidates($memory, $singleMemory, 10);
          
             if (!isset($singleMemory)) {
                 $singleMemory = [
@@ -5280,7 +5281,11 @@ function DataSearchMemoryByVector($rawstring,$npcfilter,$useContextKw=false,$tim
                         'rank_any'=> (1.40-$singleMemory["mixed_distance"]),// Try to mimic FTS query rank
                         'rank_all'=> (1.40-$singleMemory["distance"]),// Try to mimic FTS query rank
                         'memory'=>$singleMemory["summary"],
-                        'time'=>isset($vector["timing"])?$vector["timing"]["generation_time_seconds"]:"0 secs (text2vec)"
+                        'time'=>isset($vector["timing"])?$vector["timing"]["generation_time_seconds"]:"0 secs (text2vec)",
+                        'recall_candidates'=>json_encode(
+                            $recallCandidates,
+                            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+                        )
                     )
                 );
             

--- a/lib/memory_ranking.php
+++ b/lib/memory_ranking.php
@@ -83,6 +83,7 @@ function chimBuildMemoryRecallAuditCandidates(array $candidates, ?array $selecte
 
         $distance = chimMemoryCandidateNumber($candidate, 'distance', INF);
         $keywordScore = chimMemoryCandidateNumber($candidate, 'rank_fts', 0.0);
+        $gameTime = chimMemoryCandidateNumber($candidate, 'gamets_truncated', -INF);
         $mixedDistance = chimMemoryCandidateMixedDistance($candidate);
         if (!is_finite($distance) || !is_finite($mixedDistance)) {
             continue;
@@ -102,6 +103,7 @@ function chimBuildMemoryRecallAuditCandidates(array $candidates, ?array $selecte
             'keyword_score' => $keywordScore,
             'hybrid_score' => 1.4 - $mixedDistance,
             'hybrid_distance' => $mixedDistance,
+            'game_time' => is_finite($gameTime) ? $gameTime : null,
             'selected' => $selectedRowId !== '' && $rowId === $selectedRowId,
             'memory_preview' => $summary,
         ];
@@ -116,6 +118,11 @@ function chimBuildMemoryRecallAuditCandidates(array $candidates, ?array $selecte
         $distanceCompare = ($left['semantic_distance'] ?? INF) <=> ($right['semantic_distance'] ?? INF);
         if ($distanceCompare !== 0) {
             return $distanceCompare;
+        }
+
+        $gameTimeCompare = ($right['game_time'] ?? -INF) <=> ($left['game_time'] ?? -INF);
+        if ($gameTimeCompare !== 0) {
+            return $gameTimeCompare;
         }
 
         return intval($right['rowid'] ?? 0) <=> intval($left['rowid'] ?? 0);

--- a/lib/memory_ranking.php
+++ b/lib/memory_ranking.php
@@ -69,3 +69,57 @@ function chimSelectBestHybridMemoryCandidate(array $candidates): ?array
 
     return $best;
 }
+
+function chimBuildMemoryRecallAuditCandidates(array $candidates, ?array $selected, int $limit = 10): array
+{
+    $limit = max(1, min(25, $limit));
+    $selectedRowId = strval($selected['rowid'] ?? '');
+    $normalized = [];
+
+    foreach ($candidates as $candidate) {
+        if (!is_array($candidate)) {
+            continue;
+        }
+
+        $distance = chimMemoryCandidateNumber($candidate, 'distance', INF);
+        $keywordScore = chimMemoryCandidateNumber($candidate, 'rank_fts', 0.0);
+        $mixedDistance = chimMemoryCandidateMixedDistance($candidate);
+        if (!is_finite($distance) || !is_finite($mixedDistance)) {
+            continue;
+        }
+
+        $summary = trim(strval($candidate['summary'] ?? ''));
+        if (function_exists('mb_substr')) {
+            $summary = mb_substr($summary, 0, 300, 'UTF-8');
+        } else {
+            $summary = substr($summary, 0, 300);
+        }
+
+        $rowId = strval($candidate['rowid'] ?? '');
+        $normalized[] = [
+            'rowid' => $rowId,
+            'semantic_distance' => $distance,
+            'keyword_score' => $keywordScore,
+            'hybrid_score' => 1.4 - $mixedDistance,
+            'hybrid_distance' => $mixedDistance,
+            'selected' => $selectedRowId !== '' && $rowId === $selectedRowId,
+            'memory_preview' => $summary,
+        ];
+    }
+
+    usort($normalized, static function (array $left, array $right): int {
+        $hybridCompare = ($left['hybrid_distance'] ?? INF) <=> ($right['hybrid_distance'] ?? INF);
+        if ($hybridCompare !== 0) {
+            return $hybridCompare;
+        }
+
+        $distanceCompare = ($left['semantic_distance'] ?? INF) <=> ($right['semantic_distance'] ?? INF);
+        if ($distanceCompare !== 0) {
+            return $distanceCompare;
+        }
+
+        return intval($right['rowid'] ?? 0) <=> intval($left['rowid'] ?? 0);
+    });
+
+    return array_slice($normalized, 0, $limit);
+}

--- a/ui/oghma_audit.php
+++ b/ui/oghma_audit.php
@@ -10,6 +10,7 @@ chimRuntimeBootstrap($enginePath, [
 ]);
 
 require_once($enginePath . "lib" . DIRECTORY_SEPARATOR . "logger.php");
+require_once(__DIR__ . DIRECTORY_SEPARATOR . "profile_loader.php");
 
 function h(mixed $value): string
 {

--- a/ui/oghma_audit.php
+++ b/ui/oghma_audit.php
@@ -48,9 +48,42 @@ function oghmaAuditParseKeyValueString(string $raw, string $separator): array
     return $pairs;
 }
 
+function oghmaAuditHasRecallCandidatesColumn(): bool
+{
+    static $hasColumn = null;
+    if (is_bool($hasColumn)) {
+        return $hasColumn;
+    }
+
+    $db = $GLOBALS['db'] ?? null;
+    if (!$db) {
+        return false;
+    }
+
+    try {
+        $row = $db->fetchOne(
+            "SELECT 1 AS available
+               FROM information_schema.columns
+              WHERE table_schema = 'public'
+                AND table_name = 'audit_memory'
+                AND column_name = 'recall_candidates'
+              LIMIT 1"
+        );
+        $hasColumn = !empty($row['available']);
+    } catch (Throwable $exception) {
+        $hasColumn = false;
+    }
+
+    return $hasColumn;
+}
+
 function oghmaAuditBuildWhereClause(bool $matchedOnly): string
 {
     if ($matchedOnly) {
+        if (oghmaAuditHasRecallCandidatesColumn()) {
+            return "WHERE COALESCE(memory, '') LIKE '%selected=%'
+                OR jsonb_array_length(COALESCE(recall_candidates, '[]'::jsonb)) > 0";
+        }
         return "WHERE COALESCE(memory, '') LIKE '%selected=%'";
     }
     return '';
@@ -84,8 +117,11 @@ function oghmaAuditFetchRows(int $limit = 50, int $offset = 0, bool $matchedOnly
     $safeOffset = max(0, $offset);
     try {
         $whereSql = oghmaAuditBuildWhereClause($matchedOnly);
+        $candidateSelect = oghmaAuditHasRecallCandidatesColumn()
+            ? 'recall_candidates'
+            : 'NULL::jsonb AS recall_candidates';
         return $db->fetchAll(
-            'SELECT created_at, input, keywords, rank_any, rank_all, memory, "time"
+            'SELECT created_at, input, keywords, rank_any, rank_all, memory, "time", ' . $candidateSelect . '
              FROM audit_memory
              ' . $whereSql . '
              ORDER BY created_at DESC
@@ -176,7 +212,7 @@ $rangeEnd = min($offset + $perPage, $totalRows);
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Oghma Audit</title>
+    <title>Oghma and Memory Audit</title>
     <link rel="icon" type="image/x-icon" href="/HerikaServer/ui/images/favicon.ico">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="css/main.css">
@@ -273,8 +309,32 @@ $rangeEnd = min($offset + $perPage, $totalRows);
             background:#111; color:#f2f2f2; border:1px solid #4a4a4a; border-radius:8px; padding:6px 8px;
         }
         .empty-state { padding: 20px; text-align:center; color:#aaa; }
+        .candidate-list {
+            display: grid;
+            gap: 7px;
+        }
+        .candidate-row {
+            display: grid;
+            grid-template-columns: 70px 100px 120px 110px minmax(240px, 1fr);
+            gap: 10px;
+            align-items: start;
+            padding: 8px 10px;
+            border: 1px solid rgba(255,255,255,.08);
+            border-radius: 7px;
+            background: rgba(255,255,255,.025);
+        }
+        .candidate-row.selected {
+            border-color: rgba(76,143,99,.9);
+            background: rgba(76,143,99,.10);
+        }
+        .candidate-label {
+            color: #b8b8b8;
+            font-size: .75rem;
+            text-transform: uppercase;
+        }
         @media (max-width: 850px) {
             .toolbar-wrap { grid-template-columns: 1fr; }
+            .candidate-row { grid-template-columns: 1fr; }
         }
     </style>
 </head>
@@ -284,8 +344,8 @@ $rangeEnd = min($offset + $perPage, $totalRows);
 <?php endif; ?>
 <main class="page-wrap container-fluid">
     <div class="page-header">
-        <h1>Oghma Audit</h1>
-        <div>Review Oghma retrieval attempts, selected topics, ranks, and captured search signals.</div>
+        <h1>Oghma and Memory Audit</h1>
+        <div>Review Oghma retrieval attempts and memory recall candidate scoring.</div>
     </div>
 
     <div class="toolbar-wrap">
@@ -346,6 +406,16 @@ $rangeEnd = min($offset + $perPage, $totalRows);
                 $rank = strval($row['rank_any'] ?? '0');
                 $elapsed = strval($row['time'] ?? '');
                 $created = strval($row['created_at'] ?? '');
+                $recallCandidates = json_decode(strval($row['recall_candidates'] ?? '[]'), true);
+                $recallCandidates = is_array($recallCandidates) ? $recallCandidates : [];
+                $isMemoryRecall = count($recallCandidates) > 0;
+                $selectedRecallCandidate = null;
+                foreach ($recallCandidates as $recallCandidate) {
+                    if (is_array($recallCandidate) && !empty($recallCandidate['selected'])) {
+                        $selectedRecallCandidate = $recallCandidate;
+                        break;
+                    }
+                }
                 $keywordMap = oghmaAuditParseKeyValueString($keywords, ' | ');
                 $memoryMap = oghmaAuditParseKeyValueString($memory, ' / ');
                 $selected = oghmaAuditSelectedTopic($memoryMap, $memory);
@@ -358,16 +428,29 @@ $rangeEnd = min($offset + $perPage, $totalRows);
                 $signals = oghmaAuditSignalTrace(strval($keywordMap['signals'] ?? ($memoryMap['signals'] ?? '')), $memory);
                 $context = strval($memoryMap['context'] ?? '');
                 $location = strval($memoryMap['location'] ?? '');
-                $status = $selected !== '' ? 'Matched' : 'No Match';
-                $searchBlob = strtolower(implode(' ', [$input, $selected, $topics, $notes, $signals, $context, $location, $created, $npcName, $eventType]));
+                $status = $isMemoryRecall
+                    ? (is_array($selectedRecallCandidate) ? 'Memory Selected' : 'No Memory')
+                    : ($selected !== '' ? 'Matched' : 'No Match');
+                $auditType = $isMemoryRecall ? 'Memory Recall' : 'Oghma';
+                $selectedResult = $isMemoryRecall
+                    ? strval($selectedRecallCandidate['rowid'] ?? '')
+                    : $selected;
+                $displayRank = $isMemoryRecall
+                    ? strval($selectedRecallCandidate['hybrid_score'] ?? $rank)
+                    : $rank;
+                $candidateSearchText = $isMemoryRecall
+                    ? json_encode($recallCandidates, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+                    : '';
+                $searchBlob = strtolower(implode(' ', [$input, $selectedResult, $topics, $notes, $signals, $context, $location, $created, $npcName, $eventType, $candidateSearchText]));
             ?>
             <section class="audit-card" data-search="<?= h($searchBlob) ?>">
                 <div class="meta-grid">
+                    <div class="meta-pill"><div class="meta-label">Audit Type</div><div class="meta-value"><?= h($auditType) ?></div></div>
                     <div class="meta-pill"><div class="meta-label">Status</div><div class="meta-value"><?= h($status) ?></div></div>
                     <div class="meta-pill"><div class="meta-label">NPC</div><div class="meta-value"><?= h($npcName !== '' ? $npcName : '(unknown)') ?></div></div>
                     <div class="meta-pill"><div class="meta-label">Event</div><div class="meta-value"><?= h($eventType !== '' ? $eventType : '(unknown)') ?></div></div>
-                    <div class="meta-pill"><div class="meta-label">Selected Topic</div><div class="meta-value"><?= h($selected !== '' ? $selected : '(none)') ?></div></div>
-                    <div class="meta-pill"><div class="meta-label">Rank</div><div class="meta-value"><?= h($rank) ?></div></div>
+                    <div class="meta-pill"><div class="meta-label"><?= $isMemoryRecall ? 'Selected Memory ID' : 'Selected Topic' ?></div><div class="meta-value"><?= h($selectedResult !== '' ? $selectedResult : '(none)') ?></div></div>
+                    <div class="meta-pill"><div class="meta-label"><?= $isMemoryRecall ? 'Hybrid Score' : 'Rank' ?></div><div class="meta-value"><?= h($displayRank) ?></div></div>
                     <div class="meta-pill"><div class="meta-label">Mode</div><div class="meta-value"><?= h($selectedMode !== '' ? $selectedMode : '(n/a)') ?></div></div>
                     <div class="meta-pill"><div class="meta-label">Entry ID</div><div class="meta-value"><?= h($entryId !== '' ? $entryId : '(n/a)') ?></div></div>
                     <div class="meta-pill"><div class="meta-label">Created</div><div class="meta-value"><?= h($created) ?></div></div>
@@ -376,6 +459,22 @@ $rangeEnd = min($offset + $perPage, $totalRows);
 
                 <div class="section-label">Input</div>
                 <div class="trace-box"><?= h($input) ?></div>
+
+                <?php if ($isMemoryRecall): ?>
+                    <div class="section-label" style="margin-top:10px;">Memory Recall Candidates</div>
+                    <div class="candidate-list">
+                        <?php foreach ($recallCandidates as $recallCandidate): ?>
+                            <?php if (!is_array($recallCandidate)) { continue; } ?>
+                            <div class="candidate-row <?= !empty($recallCandidate['selected']) ? 'selected' : '' ?>">
+                                <div><div class="candidate-label">Memory ID</div><?= h(strval($recallCandidate['rowid'] ?? '')) ?></div>
+                                <div><div class="candidate-label">Semantic</div><?= h(strval($recallCandidate['semantic_distance'] ?? '')) ?></div>
+                                <div><div class="candidate-label">Keyword</div><?= h(strval($recallCandidate['keyword_score'] ?? '')) ?></div>
+                                <div><div class="candidate-label">Hybrid</div><?= h(strval($recallCandidate['hybrid_score'] ?? '')) ?></div>
+                                <div><div class="candidate-label"><?= !empty($recallCandidate['selected']) ? 'Selected Memory' : 'Memory Preview' ?></div><?= h(strval($recallCandidate['memory_preview'] ?? '')) ?></div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
 
                 <div class="section-label" style="margin-top:10px;">Extracted Topics</div>
                 <div class="trace-box"><?= h($topics !== '' ? $topics : '(none)') ?></div>

--- a/unittests/tests/MemoryRankingTest.php
+++ b/unittests/tests/MemoryRankingTest.php
@@ -95,6 +95,22 @@ final class MemoryRankingTest extends TestCase
         $this->assertSame(2, $selected['rowid']);
     }
 
+    public function testRecallAuditUsesTheSameNewerMemoryTieBreakAsSelection(): void
+    {
+        $candidates = [
+            ['rowid' => 10, 'distance' => 0.25, 'mixed_distance' => 0.10, 'gamets_truncated' => 100],
+            ['rowid' => 5, 'distance' => 0.25, 'mixed_distance' => 0.10, 'gamets_truncated' => 200],
+        ];
+        $selected = chimSelectBestHybridMemoryCandidate($candidates);
+
+        $audit = chimBuildMemoryRecallAuditCandidates($candidates, $selected, 1);
+
+        $this->assertCount(1, $audit);
+        $this->assertSame('5', $audit[0]['rowid']);
+        $this->assertTrue($audit[0]['selected']);
+        $this->assertSame(200.0, $audit[0]['game_time']);
+    }
+
     public function testFallbackComputesMixedDistanceFromKeywordRank(): void
     {
         $selected = chimSelectBestHybridMemoryCandidate([

--- a/unittests/tests/MemoryRankingTest.php
+++ b/unittests/tests/MemoryRankingTest.php
@@ -6,6 +6,53 @@ require_once __DIR__ . '/../../lib/memory_ranking.php';
 
 final class MemoryRankingTest extends TestCase
 {
+    public function testBuildsBoundedRecallAuditInHybridRankOrder(): void
+    {
+        $candidates = [
+            [
+                'rowid' => 10,
+                'distance' => 0.20,
+                'rank_fts' => 0.01,
+                'mixed_distance' => 0.19,
+                'summary' => 'Semantic-only candidate',
+            ],
+            [
+                'rowid' => 11,
+                'distance' => 0.30,
+                'rank_fts' => 0.25,
+                'mixed_distance' => 0.05,
+                'summary' => 'Hybrid winner',
+            ],
+        ];
+        $selected = chimSelectBestHybridMemoryCandidate($candidates);
+
+        $audit = chimBuildMemoryRecallAuditCandidates($candidates, $selected, 1);
+
+        $this->assertCount(1, $audit);
+        $this->assertSame('11', $audit[0]['rowid']);
+        $this->assertTrue($audit[0]['selected']);
+        $this->assertEqualsWithDelta(0.30, $audit[0]['semantic_distance'], 0.00001);
+        $this->assertEqualsWithDelta(0.25, $audit[0]['keyword_score'], 0.00001);
+        $this->assertEqualsWithDelta(1.35, $audit[0]['hybrid_score'], 0.00001);
+        $this->assertSame('Hybrid winner', $audit[0]['memory_preview']);
+    }
+
+    public function testRecallAuditSkipsInvalidCandidatesAndTruncatesMemoryText(): void
+    {
+        $audit = chimBuildMemoryRecallAuditCandidates([
+            ['rowid' => 1, 'summary' => 'missing distance'],
+            [
+                'rowid' => 2,
+                'distance' => 0.4,
+                'rank_fts' => 0.0,
+                'summary' => str_repeat('x', 400),
+            ],
+        ], ['rowid' => 2]);
+
+        $this->assertCount(1, $audit);
+        $this->assertSame(300, strlen($audit[0]['memory_preview']));
+    }
+
     public function testCombinedDistanceSelectsBalancedSemanticAndKeywordMatch(): void
     {
         $selected = chimSelectBestHybridMemoryCandidate([

--- a/unittests/tests/OghmaAuditPageTest.php
+++ b/unittests/tests/OghmaAuditPageTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class OghmaAuditPageTest extends TestCase
+{
+    public function testProfileSessionBootstrapRunsBeforePageOutputAndNavbar(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../ui/oghma_audit.php');
+
+        $this->assertIsString($source);
+        $profileLoaderPosition = strpos($source, 'profile_loader.php');
+        $documentPosition = strpos($source, '<!DOCTYPE html>');
+        $navbarPosition = strpos($source, 'navbar.php');
+
+        $this->assertNotFalse($profileLoaderPosition);
+        $this->assertNotFalse($documentPosition);
+        $this->assertNotFalse($navbarPosition);
+        $this->assertLessThan($documentPosition, $profileLoaderPosition);
+        $this->assertLessThan($navbarPosition, $documentPosition);
+    }
+}


### PR DESCRIPTION
## Summary
- record the top ten hybrid-memory candidates in existing audit rows
- show semantic distance, keyword score, hybrid score, selected state, and a bounded memory preview
- render candidate ranking in the existing Oghma and Memory Audit page
- keep old audit rows and installations without the new column readable

## Database
- add nullable `audit_memory.recall_candidates jsonb`
- use an idempotent `ADD COLUMN IF NOT EXISTS` upgrade migration
- include the same nullable column in the fresh-install schema
- do not rewrite existing audit data

## Runtime impact
- no additional embedding, network, or LLM calls
- store at most ten candidates with a 300-character preview each
- reuse the existing audit insert performed by vector-memory recall

## Dependency
- stacked on #612
- merge #612 first, then retarget this PR to `unstable`

## Validation
- PHP syntax checks passed for all changed PHP files
- focused memory-audit PHPUnit coverage passed
- combined integration suite passed: **43 tests, 258 assertions**
- fresh/upgrade migration applied successfully to the local PostgreSQL database
- standalone and Config Hub audit views returned HTTP 200 and rendered candidate details without console errors
- page bootstrap was repaired so direct access does not emit a session warning
- temporary audit test data was removed
- `git diff --check` passed

## Deployment
- deployed and exercised locally together with #612
