### PR TITLE
Increase scene classifier output budget

### DIFF
--- a/processor/postrequest.php
+++ b/processor/postrequest.php
@@ -160,7 +160,7 @@ if ($minimeEnabled) {
             if ($connectionHandler) {
                 $buffer = $connectionHandler->fast_request(
                     $prompt,
-                    ["MAX_TOKENS" => 64],
+                    ["MAX_TOKENS" => 256],
                     "sceneclassifier"
                 );
             }


### PR DESCRIPTION
## Summary
- increase the Scene Classifier completion budget from 64 to 256 tokens
- leave Relationship Management token budgets unchanged

## Why
The classifier expects a short final genre, but reasoning-enabled local models can consume the previous 64-token budget before producing that answer. The larger fixed budget prevents otherwise valid classifier output from being truncated without adding another setting.

## Validation
- `php -l processor/postrequest.php` passed
- `git diff --check` passed
- outgoing diff changes only the Scene Classifier budget
- Relationship Management remains on its existing 512/1024-token budgets
- combined source was deployed locally with the 256-token classifier override present

## Deployment
- deployed as part of the combined local HerikaServer validation build
