### PR TITLE
Add server-owned Player2 health heartbeat

### DIFF
--- a/connector/player2json.php
+++ b/connector/player2json.php
@@ -234,6 +234,9 @@ class player2json
         }
         $this->_is_streaming = false; 
 
+        require_once(__DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "lib" . DIRECTORY_SEPARATOR . "player2_health.php");
+        chimPlayer2HealthMarkUsed($this->_url);
+
     }
     
     public function open($contextData, $customParms)

--- a/lib/player2_health.php
+++ b/lib/player2_health.php
@@ -1,0 +1,214 @@
+<?php
+
+const CHIM_PLAYER2_HEALTH_ACTIVITY_TTL = 180;
+const CHIM_PLAYER2_HEALTH_ACTIVITY_WRITE_INTERVAL = 15;
+const CHIM_PLAYER2_HEALTH_USE_TTL = 300;
+const CHIM_PLAYER2_HEALTH_INTERVAL = 60;
+const CHIM_PLAYER2_HEALTH_LOCK_ID = 873421;
+
+function chimPlayer2HealthNormalizeUrl(string $url): string
+{
+    $url = trim($url);
+    if ($url === '') {
+        $url = 'http://127.0.0.1:4315';
+    }
+
+    if (!preg_match('#^https?://#i', $url)) {
+        $url = 'http://' . ltrim($url, '/');
+    }
+
+    $parts = parse_url($url);
+    if (!is_array($parts) || empty($parts['host'])) {
+        return 'http://127.0.0.1:4315/v1/health';
+    }
+
+    $scheme = strtolower(strval($parts['scheme'] ?? 'http')) === 'https' ? 'https' : 'http';
+    $healthUrl = $scheme . '://' . $parts['host'];
+    if (!empty($parts['port'])) {
+        $healthUrl .= ':' . intval($parts['port']);
+    }
+
+    return $healthUrl . '/v1/health';
+}
+
+function chimPlayer2HealthGetOption(string $id, string $default = ''): string
+{
+    $db = $GLOBALS['db'] ?? null;
+    if (!$db) {
+        return $default;
+    }
+
+    $escapedId = $db->escape($id);
+    $row = $db->fetchOne("SELECT value FROM conf_opts WHERE id='{$escapedId}' LIMIT 1");
+    return is_array($row) && array_key_exists('value', $row) ? strval($row['value']) : $default;
+}
+
+function chimPlayer2HealthSetOption(string $id, string $value): bool
+{
+    $db = $GLOBALS['db'] ?? null;
+    if (!$db) {
+        return false;
+    }
+
+    return (bool)$db->upsertRowOnConflict('conf_opts', [
+        'id' => $id,
+        'value' => $value,
+    ], 'id');
+}
+
+function chimPlayer2HealthMarkGameActivity(?int $now = null): bool
+{
+    $now = $now ?? time();
+    $lastActivity = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'));
+    $newSession = $lastActivity <= 0 || ($now - $lastActivity) > CHIM_PLAYER2_HEALTH_ACTIVITY_TTL;
+
+    if ($newSession) {
+        chimPlayer2HealthSetOption('PLAYER2_GAME_SESSION_STARTED_TS', strval($now));
+    }
+    if ($newSession || ($now - $lastActivity) >= CHIM_PLAYER2_HEALTH_ACTIVITY_WRITE_INTERVAL) {
+        chimPlayer2HealthSetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', strval($now));
+    }
+    $GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE'] = true;
+
+    return $newSession;
+}
+
+function chimPlayer2HealthMarkUsed(string $connectorUrl, ?int $now = null): bool
+{
+    if (empty($GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE'])) {
+        return false;
+    }
+
+    $now = $now ?? time();
+    $sessionStarted = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_SESSION_STARTED_TS', '0'));
+    $lastActivity = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'));
+    if ($sessionStarted <= 0 || $lastActivity <= 0 || ($now - $lastActivity) > CHIM_PLAYER2_HEALTH_ACTIVITY_TTL) {
+        return false;
+    }
+
+    chimPlayer2HealthSetOption('PLAYER2_HEALTH_ACTIVE_SESSION_TS', strval($sessionStarted));
+    chimPlayer2HealthSetOption('PLAYER2_HEALTH_LAST_USED_TS', strval($now));
+    chimPlayer2HealthSetOption('PLAYER2_HEALTH_URL', chimPlayer2HealthNormalizeUrl($connectorUrl));
+    return true;
+}
+
+function chimPlayer2HealthShouldPing(array $state, int $now): bool
+{
+    $lastActivity = intval($state['last_activity'] ?? 0);
+    $sessionStarted = intval($state['session_started'] ?? 0);
+    $activeSession = intval($state['active_session'] ?? 0);
+    $lastUsed = intval($state['last_used'] ?? 0);
+    $lastAttempt = intval($state['last_attempt'] ?? 0);
+    $healthUrl = trim(strval($state['health_url'] ?? ''));
+
+    return $healthUrl !== ''
+        && $lastActivity > 0
+        && ($now - $lastActivity) <= CHIM_PLAYER2_HEALTH_ACTIVITY_TTL
+        && $sessionStarted > 0
+        && $activeSession === $sessionStarted
+        && $lastUsed > 0
+        && ($now - $lastUsed) <= CHIM_PLAYER2_HEALTH_USE_TTL
+        && ($lastAttempt <= 0 || ($now - $lastAttempt) >= CHIM_PLAYER2_HEALTH_INTERVAL);
+}
+
+function chimPlayer2HealthRequest(string $url): array
+{
+    if (function_exists('curl_init')) {
+        $handle = curl_init($url);
+        curl_setopt_array($handle, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CONNECTTIMEOUT => 2,
+            CURLOPT_TIMEOUT => 5,
+            CURLOPT_HTTPHEADER => ['player2-game-key: CHIM'],
+        ]);
+        $body = curl_exec($handle);
+        $error = curl_error($handle);
+        $status = intval(curl_getinfo($handle, CURLINFO_RESPONSE_CODE));
+        curl_close($handle);
+
+        return [
+            'ok' => $body !== false && $status >= 200 && $status < 300,
+            'http_code' => $status,
+            'error' => $error,
+        ];
+    }
+
+    $context = stream_context_create([
+        'http' => [
+            'method' => 'GET',
+            'header' => "player2-game-key: CHIM\r\n",
+            'timeout' => 5,
+            'ignore_errors' => true,
+        ],
+    ]);
+    $body = @file_get_contents($url, false, $context);
+    $status = 0;
+    foreach (($http_response_header ?? []) as $header) {
+        if (preg_match('#^HTTP/\S+\s+(\d{3})#i', $header, $matches)) {
+            $status = intval($matches[1]);
+            break;
+        }
+    }
+
+    return [
+        'ok' => $body !== false && $status >= 200 && $status < 300,
+        'http_code' => $status,
+        'error' => $body === false ? 'Player2 health request failed' : '',
+    ];
+}
+
+function chimPlayer2HealthTick(?int $now = null, ?callable $transport = null): bool
+{
+    $db = $GLOBALS['db'] ?? null;
+    if (!$db) {
+        return false;
+    }
+
+    $now = $now ?? time();
+    $state = [
+        'last_activity' => chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'),
+        'session_started' => chimPlayer2HealthGetOption('PLAYER2_GAME_SESSION_STARTED_TS', '0'),
+        'active_session' => chimPlayer2HealthGetOption('PLAYER2_HEALTH_ACTIVE_SESSION_TS', '0'),
+        'last_used' => chimPlayer2HealthGetOption('PLAYER2_HEALTH_LAST_USED_TS', '0'),
+        'last_attempt' => chimPlayer2HealthGetOption('PLAYER2_HEALTH_LAST_ATTEMPT_TS', '0'),
+        'health_url' => chimPlayer2HealthGetOption('PLAYER2_HEALTH_URL', ''),
+    ];
+    if (!chimPlayer2HealthShouldPing($state, $now)) {
+        return false;
+    }
+
+    $lockRow = $db->fetchOne('SELECT pg_try_advisory_lock(' . CHIM_PLAYER2_HEALTH_LOCK_ID . ') AS locked');
+    $locked = in_array(strtolower(strval($lockRow['locked'] ?? '')), ['1', 't', 'true'], true);
+    if (!$locked) {
+        return false;
+    }
+
+    try {
+        $lastAttempt = intval(chimPlayer2HealthGetOption('PLAYER2_HEALTH_LAST_ATTEMPT_TS', '0'));
+        if ($lastAttempt > 0 && ($now - $lastAttempt) < CHIM_PLAYER2_HEALTH_INTERVAL) {
+            return false;
+        }
+
+        chimPlayer2HealthSetOption('PLAYER2_HEALTH_LAST_ATTEMPT_TS', strval($now));
+        $result = $transport
+            ? $transport(strval($state['health_url']))
+            : chimPlayer2HealthRequest(strval($state['health_url']));
+        $httpCode = intval($result['http_code'] ?? 0);
+        $error = trim(strval($result['error'] ?? ''));
+
+        chimPlayer2HealthSetOption('PLAYER2_HEALTH_LAST_HTTP_CODE', strval($httpCode));
+        chimPlayer2HealthSetOption('PLAYER2_HEALTH_LAST_ERROR', substr($error, 0, 500));
+        if (!empty($result['ok'])) {
+            chimPlayer2HealthSetOption('PLAYER2_HEALTH_LAST_SUCCESS_TS', strval($now));
+            if (class_exists('Logger')) {
+                Logger::info("[Player2 Health] Heartbeat succeeded ({$httpCode})");
+            }
+        } elseif (class_exists('Logger')) {
+            Logger::warn("[Player2 Health] Heartbeat failed ({$httpCode}) {$error}");
+        }
+
+        return !empty($result['ok']);
+    } finally {
+        $db->fetchOne('SELECT pg_advisory_unlock(' . CHIM_PLAYER2_HEALTH_LOCK_ID . ') AS unlocked');
+    }
+}

--- a/main.php
+++ b/main.php
@@ -33,6 +33,8 @@ chimRuntimeBootstrap($path, [
     'load_player_name' => true,
     'load_narrator' => true,
 ]);
+require_once($path . "lib/player2_health.php");
+require_once($path . "lib/background_processor.php");
 if (!headers_sent() && function_exists('chimGetNarratorDisplayNameHeaderValue')) {
     header('X-Narrator-Display-Name: ' . chimGetNarratorDisplayNameHeaderValue());
 }
@@ -153,6 +155,13 @@ if (in_array($gameRequest[0], ['updateequipment', 'updateinventory', 'updateskil
 // Database Connection
 $db = $GLOBALS["db"] ?? new sql();
 $GLOBALS["db"] = $db;
+
+if (PHP_SAPI !== 'cli' && !getenv('PHPUNIT_TEST') && $gameRequest[0] !== 'request') {
+    $player2NewGameSession = chimPlayer2HealthMarkGameActivity();
+    if ($player2NewGameSession && function_exists('herikaEnsureBackgroundProcessorRunning')) {
+        herikaEnsureBackgroundProcessorRunning(false);
+    }
+}
 
 require_once($path . "processor" .DIRECTORY_SEPARATOR."chim_modes.php");
 

--- a/service/processors/player2health/entrypoint.php
+++ b/service/processors/player2health/entrypoint.php
@@ -1,0 +1,12 @@
+<?php
+
+$GLOBALS['TASKS']['player2health'] = [];
+$GLOBALS['TASKS']['player2health']['fn'] = function () {
+    $enginePath = $GLOBALS['ENGINE_ROOT'];
+    if (!isset($GLOBALS['db'])) {
+        $GLOBALS['db'] = new sql();
+    }
+
+    require_once $enginePath . 'lib/player2_health.php';
+    chimPlayer2HealthTick();
+};

--- a/unittests/tests/Player2HealthTest.php
+++ b/unittests/tests/Player2HealthTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/player2_health.php';
+
+final class Player2HealthTest extends TestCase
+{
+    public function testNormalizesSupportedConnectorUrls(): void
+    {
+        self::assertSame(
+            'http://127.0.0.1:4315/v1/health',
+            chimPlayer2HealthNormalizeUrl('http://127.0.0.1:4315/v1/chat/completions')
+        );
+        self::assertSame(
+            'https://player2.example:443/v1/health',
+            chimPlayer2HealthNormalizeUrl('https://player2.example:443/docs')
+        );
+    }
+
+    public function testRequiresFreshGameActivityAndCurrentArmedSession(): void
+    {
+        $state = [
+            'last_activity' => 950,
+            'session_started' => 900,
+            'active_session' => 900,
+            'last_used' => 940,
+            'last_attempt' => 900,
+            'health_url' => 'http://127.0.0.1:4315/v1/health',
+        ];
+
+        self::assertTrue(chimPlayer2HealthShouldPing($state, 1000));
+        self::assertFalse(chimPlayer2HealthShouldPing($state, 959));
+
+        $state['last_activity'] = 700;
+        self::assertFalse(chimPlayer2HealthShouldPing($state, 1000));
+
+        $state['last_activity'] = 950;
+        $state['active_session'] = 800;
+        self::assertFalse(chimPlayer2HealthShouldPing($state, 1000));
+
+        $state['active_session'] = 900;
+        $state['last_used'] = 699;
+        self::assertFalse(chimPlayer2HealthShouldPing($state, 1000));
+    }
+}


### PR DESCRIPTION
## Summary
- track fresh Skyrim game traffic without relying on plugin-side health requests
- arm Player2 health checks only after a real Player2 LLM request in the active game session
- send `GET /v1/health` from the background manager at most once per minute with the `CHIM` game key
- stop checks after game traffic or Player2 use becomes stale, ignore response polling, and coalesce activity writes

## Database
- no migration or new table
- runtime heartbeat state is stored in existing `conf_opts` rows

## Validation
- PHP lint passed for all changed PHP files
- `Player2HealthTest`: 2 tests, 7 assertions
- deployed server-only files to local WSL runtime with matching SHA-256 hashes
- verified unarmed background manager produced zero health attempts
- verified live Player2 0.10.67 returned HTTP 200 through the background task
- verified HerikaServer UI returned HTTP 200 on local port 8081

## Notes
- no CHIM plugin files or binaries changed
- draft for manual review because the required unstable guard flagged sensitive runtime paths and open-PR overlap in `main.php`