### PR TITLE
Fix Background Life first-run reliability

### DIFF
--- a/debug/background_action_handler.php
+++ b/debug/background_action_handler.php
@@ -139,7 +139,7 @@ function claimBglInventorySettlement(string $npcName, int $idleGamets, $db): boo
         "UPDATE core_npc_master
          SET extended_data = jsonb_set(
              COALESCE(extended_data, '{}'::jsonb),
-             '{$markerKey}',
+             ARRAY['{$markerKey}']::text[],
              to_jsonb({$idleGamets}::bigint),
              true
          )

--- a/debug/background_action_handler.php
+++ b/debug/background_action_handler.php
@@ -120,6 +120,37 @@ function normalizeBglInventoryActions($actions): array
 }
 
 /**
+ * Claim the inventory settlement for one idle action.
+ *
+ * The conditional UPDATE makes the claim atomic across worker processes. The
+ * marker is written before any game inventory command, favoring a missed
+ * settlement over applying a destructive consume/produce action twice.
+ */
+function claimBglInventorySettlement(string $npcName, int $idleGamets, $db): bool
+{
+    if ($idleGamets <= 0) {
+        return false;
+    }
+
+    $npcNameEsc = $db->escape($npcName);
+    $markerKey = 'background_life_inventory_last_processed_idle_gamets';
+    $claimed = $db->fetchOne(
+        "UPDATE core_npc_master
+         SET extended_data = jsonb_set(
+             COALESCE(extended_data, '{}'::jsonb),
+             '{$markerKey}',
+             to_jsonb({$idleGamets}::bigint),
+             true
+         )
+         WHERE npc_name='{$npcNameEsc}'
+           AND COALESCE(NULLIF(extended_data->>'{$markerKey}', '')::bigint, 0) < {$idleGamets}
+         RETURNING id"
+    );
+
+    return is_array($claimed) && !empty($claimed['id']);
+}
+
+/**
  * Resolve a TravelTo location using exact + fuzzy matching and optional coord distance.
  *
  * @param string $location

--- a/debug/background_action_handler.php
+++ b/debug/background_action_handler.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/../lib/background_life_tracking.php';
 
 /**
  * Force-trigger an NPC background life update on the next mid-term BGL check.
@@ -428,25 +429,10 @@ function handleStayAtPlaceAction($location, $currentNpcData, $npcName, $last_ts,
     return true;
 }
 
-//sends a track signal, NPC should report coords
-function handleTrack($currentNpcData, $db)
+// Sends one track signal so the NPC reports its current coordinates.
+function handleTrack($currentNpcData, $db, string $tag = '')
 {
-    $refHexString = convertSignedToUnsignedHex(hexdec($currentNpcData["refid"]));
-
-    // Insert response log entry with return home command
-    $db->insert(
-        'responselog',
-        [
-            'localts' => time(),
-            'sent' => 0,
-            'actor' => "rolemaster",
-            'text' => "",
-            'action' => "rolecommand|BackgroundCmd@$refHexString@Track/",
-            'tag' => '',
-        ]
-    );
-
-    return true;
+    return chimQueueBackgroundTrack($currentNpcData, $db, $tag);
 }
 
 /**

--- a/debug/background_action_handler.php
+++ b/debug/background_action_handler.php
@@ -56,6 +56,70 @@ function getNpcLastCoordsPoint($currentNpcData)
 }
 
 /**
+ * Resolve the NPC's latest reported location marker.
+ */
+function resolveNpcCurrentLocation($currentNpcData, $db)
+{
+    $metadata = $currentNpcData['metadata'] ?? null;
+    if (is_string($metadata)) {
+        $metadata = json_decode($metadata, true);
+    }
+
+    $locationFormId = is_array($metadata)
+        ? ($metadata['last_coords']['location_formid'] ?? null)
+        : null;
+    if (!is_numeric($locationFormId)) {
+        return null;
+    }
+
+    $formId = $db->escape((string) $locationFormId);
+    $location = $db->fetchOne(
+        "SELECT name, region, hold, formid, coords, 1::float AS sim, 4 AS exact_rank
+         FROM locations
+         WHERE formid='$formId'
+         LIMIT 1"
+    );
+
+    return is_array($location) ? $location : null;
+}
+
+function isResolvedTravelLocationConfident($location): bool
+{
+    if (!is_array($location) || empty($location['formid'])) {
+        return false;
+    }
+
+    return (int) ($location['exact_rank'] ?? 0) > 0
+        || (float) ($location['sim'] ?? 0) >= 0.8;
+}
+
+/**
+ * Keep only inventory actions that can be safely translated into game commands.
+ */
+function normalizeBglInventoryActions($actions): array
+{
+    if (!is_array($actions)) {
+        return [];
+    }
+
+    $normalized = [];
+    foreach ($actions as $action) {
+        if (!is_string($action)) {
+            continue;
+        }
+
+        $action = trim($action);
+        if (preg_match('/^(Consume|Produced):(?:0x)?[0-9a-fA-F]{1,8}:[1-9][0-9]*$/', $action) !== 1) {
+            continue;
+        }
+
+        $normalized[] = $action;
+    }
+
+    return $normalized;
+}
+
+/**
  * Resolve a TravelTo location using exact + fuzzy matching and optional coord distance.
  *
  * @param string $location
@@ -105,7 +169,7 @@ function resolveTravelLocation($location, $currentNpcData, $db)
                 END AS exact_rank
          FROM locations
          WHERE formid IS NOT NULL
-         ORDER BY exact_rank DESC$orderByDistanceSql, sim DESC
+         ORDER BY exact_rank DESC, sim DESC$orderByDistanceSql
          LIMIT 1"
     );
 
@@ -140,7 +204,10 @@ function handleTravelToAction($location, $currentNpcData, $npcName, $last_ts, $l
         error_log("[handleTravelToAction] requested='$requestedLocation' resolved='{$resolvedLocation}' formid='{$locId['formid']}'$sim$dist");
     }
 
-    if (!isset($locId["formid"]) || (isset($locId['sim']) && $locId['sim'] < 0.8)) {
+    if (
+        strcasecmp($requestedLocation, 'random') !== 0
+        && !isResolvedTravelLocationConfident($locId)
+    ) {
         $db->insert('eventlog', [
             'ts' => $last_ts,
             'gamets' => $last_gamets + 10,
@@ -234,12 +301,13 @@ function handleStayAtPlaceAction($location, $currentNpcData, $npcName, $last_ts,
 {
     $locId = resolveTravelLocation($location, $currentNpcData, $db);
     $requestedLocation = $db->escape($location);
-    $resolvedLocation = $locId['name'] ?? $requestedLocation;
     $intent = trim((string) $intent);
     $intentSuffix = $intent !== '' ? ":$intent" : '';
     $intentText = $intent !== '' ? " with intent '$intent'" : '';
+    $isRandomLocation = strcasecmp($requestedLocation, 'random') === 0;
+    $resolvedLocation = $locId['name'] ?? $requestedLocation;
 
-    if (strcasecmp($requestedLocation, 'random') === 0) {
+    if ($isRandomLocation) {
         error_log("[handleStayAtPlaceAction] random picked: " . print_r($locId, true));
     }
 
@@ -249,10 +317,24 @@ function handleStayAtPlaceAction($location, $currentNpcData, $npcName, $last_ts,
         error_log("[handleStayAtPlaceAction] requested='$requestedLocation' resolved='{$resolvedLocation}' formid='{$locId['formid']}'$sim$dist");
     }
 
+    if (!$isRandomLocation && !isResolvedTravelLocationConfident($locId)) {
+        $fallbackLocation = resolveNpcCurrentLocation($currentNpcData, $db);
+        if (is_array($fallbackLocation)) {
+            error_log(
+                "[handleStayAtPlaceAction] requested='$requestedLocation' was not a confident match; "
+                . "using current location '{$fallbackLocation['name']}'."
+            );
+            $locId = $fallbackLocation;
+        } else {
+            $locId = null;
+        }
+    }
+
     if (!isset($locId["formid"])) {
         return false;
     }
 
+    $resolvedLocation = $locId['name'] ?? $requestedLocation;
     $refHexString = convertSignedToUnsignedHex(hexdec($currentNpcData["refid"]));
     $locHexString = (convertHex($locId["formid"]));
 

--- a/debug/simple_llm_request_with_context_life.php
+++ b/debug/simple_llm_request_with_context_life.php
@@ -33,6 +33,7 @@ chimRuntimeBootstrap($enginePath, [
 require_once $enginePath . 'lib/model_dynmodel.php';
 require_once $enginePath . 'lib/chat_helper_functions.php';
 require_once $enginePath . 'lib/data_functions.php';
+require_once $enginePath . 'lib/background_life_connector.php';
 require_once $enginePath . 'lib/logger.php';
 require_once $enginePath . 'lib/utils_game_timestamp.php';
 require_once $enginePath . 'lib/rolemaster_helpers.php';
@@ -126,11 +127,39 @@ function loadBGLStylePrompt($promptKey, $replacements = [])
 $npcMaster = new NpcMaster();
 
 $connector = new LLMConnector();
-$currentConnectorData = $connector->getById($GLOBALS["CORE_CONNECTOR_BGL"]);
 $currentNpcData = $npcMaster->getByName($argv[1]);
 
 $profile = new CoreProfile();
-$currentProfileData = $profile->getById($currentNpcData["profile_id"]);
+$currentProfileData = is_array($currentNpcData)
+    ? $profile->getById($currentNpcData["profile_id"] ?? 0)
+    : false;
+$defaultProfileData = $profile->getDefaultNpc();
+
+if (!is_array($currentNpcData)) {
+    error_log("[BGL RUN] {$argv[1]} - NPC profile data was not found.");
+    exit(1);
+}
+
+if (!is_array($currentProfileData)) {
+    $currentProfileData = is_array($defaultProfileData) ? $defaultProfileData : [];
+}
+
+try {
+    $resolvedConnector = chimResolveBackgroundLifeConnector(
+        $GLOBALS["CORE_CONNECTOR_BGL"] ?? null,
+        $currentProfileData,
+        is_array($defaultProfileData) ? $defaultProfileData : [],
+        static fn(int $id) => $connector->getById($id)
+    );
+} catch (RuntimeException $e) {
+    error_log("[BGL RUN] {$argv[1]} - {$e->getMessage()}");
+    exit(1);
+}
+
+$currentConnectorData = $resolvedConnector['data'];
+error_log(
+    "[BGL RUN] {$argv[1]} - using connector {$currentConnectorData['id']} from {$resolvedConnector['source']}."
+);
 $connector->setOldGlobals($currentConnectorData);
 $npcMaster->setOldGlobalsFromCurrentNpcData($currentNpcData);
 
@@ -481,8 +510,10 @@ this location and its current task
 - intent can be: Work, Rest, Relax, Socialize, Sleep, Study, Guard.
 - Remain at the current location to work, rest, relax, socialize, or perform ongoing activities.
 - This is the default action when the NPC should remain where they are.
-- At an inn: rest, relax, socialize with patrons. E.G StayAtPlace:Inn:Relax
-- At home: rest, relax, socialize with companions,sleep. e.g StayAtPlace:Breezehome:Sleep
+- <Place> must be the exact current location name from context, never a generic label such as Home or Inn.
+- At an inn: rest, relax, or socialize with patrons. E.G StayAtPlace:Sleeping Giant Inn:Relax
+- At home: rest, relax, socialize with companions, or sleep. E.G StayAtPlace:Alvor and Sigrid's House:Sleep
+- Use TravelTo when the character should go somewhere other than the exact current location.
 
 TravelTo:<Place>
 - Travel to another location.
@@ -504,8 +535,9 @@ this location and its current task
 - intent can be: Work, Rest, Relax, Socialize, Sleep, Study, Guard.
 - Remain at the current location to work, rest, relax, socialize, or perform ongoing activities.
 - This is the default action when the NPC should remain where they are.
-- At an inn: rest, relax, socialize with patrons. E.G StayAtPlace:Inn:Relax
-- At home: rest, relax, socialize with companions,sleep. e.g StayAtPlace:Breezehome:Sleep
+- <Place> must be the exact current location name from context, never a generic label such as Home or Inn.
+- At an inn: rest, relax, or socialize with patrons. E.G StayAtPlace:Sleeping Giant Inn:Relax
+- At home: rest, relax, socialize with companions, or sleep. E.G StayAtPlace:Alvor and Sigrid's House:Sleep
 
 SpreadRumor - Character activities generate rumors, also, character can explictly create a rumor. 
 E.G. If character's goal or activity is to enforce local trade, create a rumor about local trading being enhanced.

--- a/debug/simple_llm_request_with_context_life_command.php
+++ b/debug/simple_llm_request_with_context_life_command.php
@@ -91,9 +91,8 @@ if ($cmds[0] == "TrackAll") {
 
     // Check if NPC is around using DataBeingsInRange
 
-    $npcsInRange = DataBeingsInRange();
-    if (strpos($npcsInRange, $GLOBALS["HERIKA_NAME"]) !== false) {
-        logger::info("[BGL] NPC {$argv[1]} is in range, skipping background life processing.");
+    if (chimIsBackgroundNpcInRange((string) $GLOBALS["HERIKA_NAME"])) {
+        logger::debug("[BGL] NPC {$argv[1]} is in range, skipping background life processing.");
         return;
     }
     

--- a/debug/simple_llm_request_with_context_life_command.php
+++ b/debug/simple_llm_request_with_context_life_command.php
@@ -123,20 +123,10 @@ if ($cmds[0] == "TravelTo") {
 } else if ($cmds[0] == "ReturnHome") {
     handleReturnHome($cmds[1], $currentNpcData, $GLOBALS["HERIKA_NAME"], $last_ts, $last_gamets, $momentum, $db);
 } else if ($cmds[0] == "Track") {
-    $metadata = $npcMaster->getMetadata($currentNpcData);
-    $metadata["last_coords"]["pending"] = true;
-    $npcMaster->updateByArray($npcMaster->setMetadata($currentNpcData, $metadata));
     handleTrack($currentNpcData, $db);
 } else if ($cmds[0] == "TrackAll") {
     $allBglNPC = $db->fetchAll("select * from public.core_npc_master WHERE (extended_data ->> 'background_life_enabled')::boolean = true");
     foreach ($allBglNPC as $npc) {
-        
-        // handleTrack only needs refid
-        $currentNpcData = $npcMaster->getByName($npc["npc_name"]);
-        $metadata = $npcMaster->getMetadata($currentNpcData);
-        $metadata["last_coords"]["pending"] = true;
-        $npcMaster->updateByArray($npcMaster->setMetadata($currentNpcData, $metadata));
-
         handleTrack($npc, $db);
     }
 }

--- a/debug/simple_llm_request_with_context_life_v2.php
+++ b/debug/simple_llm_request_with_context_life_v2.php
@@ -494,6 +494,7 @@ foreach (array_reverse($actionsRows) as $row) {
 
 $bgEvents = [];
 $lastEventParsed = [];   // Tracks the most recent valid background event for location context
+$lastEventGamets = 0;
 
 $lastLocRow['location'] = $lastLocRow['location'] ?? '';
 
@@ -524,6 +525,7 @@ foreach ($backgroundEventRows as $event) {
         'type' => 'event',
     ];
     $lastEventParsed = $eventParsed;   // Keep last matching event for location reference
+    $lastEventGamets = (float) $event['gamets'];
 
     // Update daysPassed to reflect the latest background event if it's older than the last interactions
     $daysPassed = round(($last_gamets - $event['gamets']) * GAMETS_TO_HOURS / 24, 2);
@@ -563,6 +565,12 @@ if (isset($metadata['last_coords']) && !empty($metadata['last_coords'][3])) {
     }
 }
 
+$LAST_REPORTED_LOCATION = chimSelectCurrentBackgroundLocation(
+    $LAST_REPORTED_LOCATION,
+    $metadata['last_coords']['last_updated'] ?? 0,
+    (string) ($lastEventParsed['location'] ?? ''),
+    $lastEventGamets
+);
 
 if (isset($metadata['low_process_actors'])) {
 

--- a/debug/simple_llm_request_with_context_life_v2.php
+++ b/debug/simple_llm_request_with_context_life_v2.php
@@ -1626,9 +1626,9 @@ if ($innerThoughtBuffer && $recordInnerThoughts) {
             'sess' => $momentum,
             'localts' => time(),
         ]);
-    }
 
-    logMemory($GLOBALS['HERIKA_NAME'], $GLOBALS['HERIKA_NAME'], trim($innerThoughtBuffer), $momentum, $last_gamets, 'backgroundlife_diary', $last_ts);
+        logMemory($GLOBALS['HERIKA_NAME'], $GLOBALS['HERIKA_NAME'], trim($innerThoughtBuffer), $momentum, $last_gamets, 'backgroundlife_diary', $last_ts);
+    }
 
 }
 // ─── Mark NPC as Background-Life Enabled ─────────────────────────────────────

--- a/debug/simple_llm_request_with_context_life_v2.php
+++ b/debug/simple_llm_request_with_context_life_v2.php
@@ -45,6 +45,7 @@ chimRuntimeBootstrap($enginePath, [
 require_once $enginePath . 'lib/model_dynmodel.php';
 require_once $enginePath . 'lib/chat_helper_functions.php';
 require_once $enginePath . 'lib/data_functions.php';
+require_once $enginePath . 'lib/background_life_connector.php';
 require_once $enginePath . 'lib/logger.php';
 require_once $enginePath . 'lib/utils_game_timestamp.php';
 require_once $enginePath . 'lib/rolemaster_helpers.php';
@@ -184,10 +185,38 @@ $npcMaster = new NpcMaster();
 $connector = new LLMConnector();
 
 $currentNpcData = $npcMaster->getByName($npcName);
-$currentConnectorData = $connector->getById($GLOBALS['CORE_CONNECTOR_BGL']);
 
 $profile = new CoreProfile();
-$currentProfileData = $profile->getById($currentNpcData['profile_id']);
+$currentProfileData = is_array($currentNpcData)
+    ? $profile->getById($currentNpcData['profile_id'] ?? 0)
+    : false;
+$defaultProfileData = $profile->getDefaultNpc();
+
+if (!is_array($currentNpcData)) {
+    error_log("[BGL RUN] $npcName - NPC profile data was not found.");
+    exit(1);
+}
+
+if (!is_array($currentProfileData)) {
+    $currentProfileData = is_array($defaultProfileData) ? $defaultProfileData : [];
+}
+
+try {
+    $resolvedConnector = chimResolveBackgroundLifeConnector(
+        $GLOBALS['CORE_CONNECTOR_BGL'] ?? null,
+        $currentProfileData,
+        is_array($defaultProfileData) ? $defaultProfileData : [],
+        static fn(int $id) => $connector->getById($id)
+    );
+} catch (RuntimeException $e) {
+    error_log("[BGL RUN] $npcName - {$e->getMessage()}");
+    exit(1);
+}
+
+$currentConnectorData = $resolvedConnector['data'];
+error_log(
+    "[BGL RUN] $npcName - using connector {$currentConnectorData['id']} from {$resolvedConnector['source']}."
+);
 
 $connector->setOldGlobals($currentConnectorData);
 $npcMaster->setOldGlobalsFromCurrentNpcData($currentNpcData);
@@ -225,9 +254,16 @@ $lastIssuedAction = $db->fetchOne(
      ORDER BY gamets DESC, ts ASC"
 );
 
-if ($lastIssuedAction["gamets"] && ($lastIssuedAction["action"] == "TravelTo" || $lastIssuedAction["action"] == "MoveTo")) {
+if (!is_array($lastIssuedAction)) {
+    $lastIssuedAction = [];
+}
+
+if (
+    !empty($lastIssuedAction['gamets'])
+    && in_array((string) ($lastIssuedAction['action'] ?? ''), ['TravelTo', 'MoveTo'], true)
+) {
     $npcIsTravelling = true;
-    $npcIsTravellingStarted = $lastIssuedAction["gamets"];
+    $npcIsTravellingStarted = $lastIssuedAction['gamets'];
 } else {
     $npcIsTravelling = false;
     $npcIsTravellingStarted = 0;
@@ -243,7 +279,7 @@ $lastInteractionRow = $db->fetchOne(
 );
 
 if (empty($lastInteractionRow['gamets'])) {
-    if ($extdata["background_life_player_unattached"]) {
+    if (!empty($extdata['background_life_player_unattached'])) {
         error_log('[BGL RUN] No prior interaction found but background_life_player_unattached is true');
     } else {
         error_log('[BGL RUN] No prior interaction found, but background_life_player_unattached is false — skipping.');
@@ -796,7 +832,7 @@ Rules:
    - Produced goods will be added to the character's inventory in the future, so they will not be present in the current inventory.
 
 3. No activity
-   - If neither is a working or relaxing scenario (e.g. {$GLOBALS["HERIKA_NAME"]} was sleeping), return the `DoNothing` action.
+   - If neither is a working nor relaxing scenario (e.g. {$GLOBALS["HERIKA_NAME"]} was sleeping), return an empty action array.
 
 Requirements
 
@@ -819,8 +855,7 @@ Format:
 {
   \"action\": [
     \"Consume:itemid:qty\",
-    \"Produced:itemid:qty\",
-    \"DoNothing\"
+    \"Produced:itemid:qty\"
   ],
   \"reasoning\": \"optional one-sentence explanation\"
 }
@@ -830,7 +865,6 @@ Rules:
 - Only include valid actions in this exact string format:
   Consume:itemid:qty
   Produced:itemid:qty
-  DoNothing
 - itemid must match in-game inventory identifiers.
 - qty must be an integer.
 - You may include multiple actions if needed.
@@ -853,9 +887,9 @@ Rules:
     }
 
     if (isset($parsedResponse['action']) && is_array($parsedResponse['action'])) {
-        $action = ($parsedResponse['action']);
+        $action = normalizeBglInventoryActions($parsedResponse['action']);
     } else {
-        $action = '';
+        $action = [];
     }
     if (isset($parsedResponse['reasoning'])) {
         $reasoning = $parsedResponse['reasoning'];
@@ -865,6 +899,7 @@ Rules:
 
 
     if ($action) {
+        $actionText = [];
         $actionTextDescription = [];
         foreach ($action as $singleAction) {
             error_log("[BGL RUN] $npcNameEsc — Idle production/consumption detected: $singleAction. Reasoning: $reasoning");
@@ -872,7 +907,7 @@ Rules:
             $skyrimCmd = new SkyrimCommandBuilder();
             $sourceRefHexString = strtolower(convertSignedToUnsignedHex(hexdec($currentNpcData['refid'])));
             // Parse action string
-            list($actionType, $itemId, $count) = explode(':', $singleAction);
+            list($actionType, $itemId, $count) = explode(':', $singleAction, 3);
             $itemId = strtr(strtolower($itemId), ["0x" => ""]); // Remove 0x prefix if present
 
             $count = (int) $count;
@@ -967,6 +1002,10 @@ $lastBackgroundAction = $db->fetchOne(
      LIMIT 1"
 );
 
+if (!is_array($lastBackgroundAction)) {
+    $lastBackgroundAction = [];
+}
+
 $isSpeakAction = !empty($lastBackgroundAction)
     && (
         strcasecmp((string) ($lastBackgroundAction['action'] ?? ''), 'SpeakTo') === 0
@@ -981,10 +1020,13 @@ $lang = (($npcMetadata['CORE_LANG'] ?? '') === 'es' || ($profileMetadata['CORE_L
 
 
 // Hinter
-error_log(date("YMd H:i:s") . " [BGL RUN] HINT $npcNameEsc — last action: {$lastBackgroundAction['action']}, last event: <{$lastIssuedBgEvent['name']}> <{$lastIssuedBgEvent['event']}>, npcIsTravelling: " . ($npcIsTravelling ? 'true' : 'false'));
+$lastBackgroundActionName = (string) ($lastBackgroundAction['action'] ?? '');
+$lastIssuedBgEventName = strtolower((string) ($lastIssuedBgEvent['name'] ?? ''));
+$lastIssuedBgEventState = strtolower((string) ($lastIssuedBgEvent['event'] ?? ''));
+error_log(date("YMd H:i:s") . " [BGL RUN] HINT $npcNameEsc — last action: $lastBackgroundActionName, last event: <$lastIssuedBgEventName> <$lastIssuedBgEventState>, npcIsTravelling: " . ($npcIsTravelling ? 'true' : 'false'));
 if (
-    strtolower($lastIssuedBgEvent["name"]) == "sandbox" && $lastIssuedBgEvent["event"] == "start" && $npcIsTravelling
-    || strtolower($lastIssuedBgEvent["name"]) == "travelto" && $lastIssuedBgEvent["event"] == "end" && $npcIsTravelling
+    $lastIssuedBgEventName === "sandbox" && $lastIssuedBgEventState === "start" && $npcIsTravelling
+    || $lastIssuedBgEventName === "travelto" && $lastIssuedBgEventState === "end" && $npcIsTravelling
 ) {
     // Last action was MoveTo or TravelTo.
     // Last event was a Sandbox event. This means the NPC reached destination
@@ -998,7 +1040,7 @@ if (
 // Avoid too much transactions.
 
 $byspassTradingActions = false;
-if ($lastBackgroundAction['action'] === 'BuyItem' || $lastBackgroundAction['action'] === 'SellItem') {
+if ($lastBackgroundActionName === 'BuyItem' || $lastBackgroundActionName === 'SellItem') {
     // Last action was BuyItem or SellItem.
     // Avoid repeated trading actions in the same turn, as it can lead to infinite loops of buying/selling items.
     // 
@@ -1049,8 +1091,10 @@ if (
 
 // IF last action was less than half an hour ago, skip inner thoughts and go directly to action decision suggestion.
 $action_parts = explode(":", $lastBackgroundAction['fullcall'] ?? '');
-$localHoursPassed = round(($last_gamets - $lastBackgroundAction['gamets']) * GAMETS_TO_HOURS, 2);
-if ($localHoursPassed < 0.5 && !$wasSocializeIntentAction) {
+$localHoursPassed = isset($lastBackgroundAction['gamets'])
+    ? round(($last_gamets - (float) $lastBackgroundAction['gamets']) * GAMETS_TO_HOURS, 2)
+    : null;
+if ($localHoursPassed !== null && $localHoursPassed < 0.5 && !$wasSocializeIntentAction) {
 
     $bypassInnerThoughts = true;
     $innerThoughtBufferForced = "{$GLOBALS['HERIKA_NAME']}'s inner thought: Let’s see where this takes us";
@@ -1218,8 +1262,10 @@ StayAtPlace:<Place>:<intent>
 - intent can be: Work, Rest, Relax, Socialize, Sleep, Study, Guard.
 - Remain at the current location to work, rest, relax, socialize, or perform ongoing activities.
 - This is the default action when the NPC should remain where they are.
-- At an inn: rest, relax, socialize with patrons. E.G StayAtPlace:Inn:Relax, StayAtPlace:Inn:Socialize (Socialize is preferred if there are other NPCs present)
-- At home: rest, relax, socialize with companions,sleep. e.g StayAtPlace:Breezehome:Sleep
+- <Place> must be the exact current location name from context, never a generic label such as Home or Inn.
+- At an inn: rest, relax, or socialize with patrons. E.G StayAtPlace:Sleeping Giant Inn:Relax, StayAtPlace:Sleeping Giant Inn:Socialize (Socialize is preferred if there are other NPCs present)
+- At home: rest, relax, socialize with companions, or sleep. E.G StayAtPlace:Alvor and Sigrid's House:Sleep
+- Use TravelTo when the NPC should go somewhere other than the exact current location.
 - If gathering information or spreading rumors, remain for at least 24 hours.
 - After arriving somewhere, prefer interacting (SpeakTo, BuyItem, SellItem) before choosing StayAtPlace again, unless there is no meaningful interaction available.
 
@@ -1312,8 +1358,8 @@ PROMPT3;
 // Hinter
 
 if (
-    (strtolower($lastIssuedBgEvent["name"]) == "sandbox" && $lastIssuedBgEvent["event"] == "start" && $npcIsTravelling)
-    || (strtolower($lastIssuedBgEvent["name"]) == "travelto" && $lastIssuedBgEvent["event"] == "end" && $npcIsTravelling)
+    ($lastIssuedBgEventName === "sandbox" && $lastIssuedBgEventState === "start" && $npcIsTravelling)
+    || ($lastIssuedBgEventName === "travelto" && $lastIssuedBgEventState === "end" && $npcIsTravelling)
 ) {
 
     // Last action was MoveTo or TravelTo.
@@ -1376,9 +1422,9 @@ For example:
 * To Sell/Buy Item to a trader that maybe is not present: MoveTo:<NPC/Actor name> ->(next iteration) SpeakTo:<NPC/Actor name> ->(next iteration) SellItem:.. 
 * To gift items without taking money: SpeakTo:<NPC/Actor name> ->(next iteration) GiveItemTo:<NPC/Actor name>:<itemid>:<count>
 * To give money without trading items: SpeakTo:<NPC/Actor name> ->(next iteration) GiveGoldTo:<NPC/Actor name>:<amount>
-* Buy food at an inn: SpeakTo:<NPC innkeeper> ->(next iteration),BuyItem:<NPC/Actor name> ->(next iteration) StayAtPlace:Inn 
-* Relax/Socialize at an inn: SpeakTo:<NPC/Actor name> ->(next iteration) ->(next iteration) StayAtPlace:Inn 
-* Relax at home: SpeakTo:<NPC/Actor name> ->(next iteration) StayAtPlace:Home:Sleep
+* Buy food at an inn: SpeakTo:<NPC innkeeper> ->(next iteration),BuyItem:<NPC/Actor name> ->(next iteration) StayAtPlace:<exact current inn name>:Relax
+* Relax/Socialize at an inn: SpeakTo:<NPC/Actor name> ->(next iteration) StayAtPlace:<exact current inn name>:Socialize
+* Relax at home: SpeakTo:<NPC/Actor name> ->(next iteration) StayAtPlace:<exact current home name>:Sleep
 * Generally speaking, try to Speak to an NPC before trading with him/her, unless the NPC is not present. If the NPC is not present, use MoveTo:<NPC name> to reach him/her first.
 
 
@@ -1549,8 +1595,10 @@ if ($innerThoughtBuffer && $recordInnerThoughts) {
     ]);
     $cnName = $db->escape($GLOBALS['HERIKA_NAME']);
     $checkLatestDiaryEntry = $db->fetchOne("SELECT * FROM diarylog WHERE topic='Journal Note' AND people='$cnName' ORDER BY gamets DESC, ts DESC LIMIT 1");
-    $latestDiaryGamets = (float) $checkLatestDiaryEntry['gamets'];
-    if ($last_gamets - $latestDiaryGamets < (1 / GAMETS_TO_HOURS) * 4) {
+    $latestDiaryGamets = is_array($checkLatestDiaryEntry)
+        ? (float) ($checkLatestDiaryEntry['gamets'] ?? 0)
+        : 0;
+    if ($latestDiaryGamets > 0 && $last_gamets - $latestDiaryGamets < (1 / GAMETS_TO_HOURS) * 4) {
         // If the last diary entry was less than 4 hours ago, we skip adding a new diary entry to avoid cluttering the diary with too many entries in a short time.
         $recordDiaryEntry = false;
     }

--- a/debug/simple_llm_request_with_context_life_v2.php
+++ b/debug/simple_llm_request_with_context_life_v2.php
@@ -771,8 +771,19 @@ $isIdleAction = !empty($lastBackgroundAction)
 
 $idleGamets = (int) ($lastBackgroundAction['gamets'] ?? 0);
 $idleHours = max(0, round(($last_gamets - $idleGamets) * GAMETS_TO_HOURS, 2));
+$inventorySettlementClaimed = false;
 
-if ($isIdleAction && $idleHours > 1) {// If last Idle was Socialize, there a chance of a follow up.
+if ($isIdleAction && $idleHours > 1) {
+    $inventorySettlementClaimed = claimBglInventorySettlement($npcName, $idleGamets, $db);
+    if (!$inventorySettlementClaimed) {
+        error_log(
+            "[BGL RUN] $npcNameEscBg - inventory settlement for idle action $idleGamets "
+            . 'was already claimed; skipping duplicate inventory processing.'
+        );
+    }
+}
+
+if ($inventorySettlementClaimed) {// If last Idle was Socialize, there a chance of a follow up.
     $intent = explode(':', (string) ($lastBackgroundAction['fullcall'] ?? ''));
     $lastIntent = $intent[2] ?? '';
     $lastIntentBasedHint = "";

--- a/lib/background_life_connector.php
+++ b/lib/background_life_connector.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Resolve the connector used by Background Life without requiring the optional
+ * global override to be configured.
+ *
+ * @return array{data: array, source: string}
+ */
+function chimResolveBackgroundLifeConnector(
+    $configuredConnectorId,
+    array $currentProfile,
+    array $defaultProfile,
+    callable $fetchConnector
+): array {
+    $candidates = [
+        'Background Life setting' => $configuredConnectorId,
+        'NPC profile primary LLM' => $currentProfile['llm_primary_id'] ?? null,
+        'default profile primary LLM' => $defaultProfile['llm_primary_id'] ?? null,
+    ];
+
+    $seen = [];
+    foreach ($candidates as $source => $candidateId) {
+        $connectorId = (int) $candidateId;
+        if ($connectorId <= 0 || isset($seen[$connectorId])) {
+            continue;
+        }
+
+        $seen[$connectorId] = true;
+        $connectorData = $fetchConnector($connectorId);
+        if (!is_array($connectorData) || trim((string) ($connectorData['driver'] ?? '')) === '') {
+            continue;
+        }
+
+        return [
+            'data' => $connectorData,
+            'source' => $source,
+        ];
+    }
+
+    throw new RuntimeException(
+        'Background Life has no usable LLM connector. Configure its connector or assign a primary LLM to the NPC/default profile.'
+    );
+}

--- a/lib/background_life_tracking.php
+++ b/lib/background_life_tracking.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Normalize a stored actor reference ID for a BackgroundCmd command.
+ */
+function chimNormalizeBackgroundTrackRefId($refId): ?string
+{
+    $refId = trim((string) $refId);
+    if (!preg_match('/^(?:0x)?([0-9a-f]{1,8})$/i', $refId, $matches)) {
+        return null;
+    }
+
+    return '0x' . strtoupper(str_pad($matches[1], 8, '0', STR_PAD_LEFT));
+}
+
+/**
+ * Atomically claim and queue a coordinate update for one Background Life NPC.
+ *
+ * The pending flag and response command are written in one statement. Competing
+ * workers therefore cannot enqueue duplicate Track commands for the same NPC.
+ */
+function chimQueueBackgroundTrack(array $npcData, $db, string $tag = ''): bool
+{
+    $npcId = (int) ($npcData['id'] ?? 0);
+    $refId = chimNormalizeBackgroundTrackRefId($npcData['refid'] ?? '');
+    if ($npcId <= 0 || $refId === null) {
+        return false;
+    }
+
+    $action = $db->escape("rolecommand|BackgroundCmd@{$refId}@Track/");
+    $tag = $db->escape($tag);
+    $localTs = time();
+
+    $queued = $db->fetchOne(
+        "WITH claimed AS (
+            UPDATE core_npc_master
+            SET metadata = jsonb_set(
+                COALESCE(metadata, '{}'::jsonb),
+                '{last_coords}',
+                COALESCE(metadata->'last_coords', '{}'::jsonb) || '{\"pending\":true}'::jsonb,
+                true
+            )
+            WHERE id={$npcId}
+              AND COALESCE(metadata->'last_coords'->>'pending', 'false') <> 'true'
+            RETURNING id
+        )
+        INSERT INTO responselog (localts, sent, actor, text, action, tag)
+        SELECT {$localTs}, 0, 'rolemaster', '', '{$action}', '{$tag}'
+        FROM claimed
+        RETURNING rowid"
+    );
+
+    return is_array($queued) && !empty($queued['rowid']);
+}

--- a/lib/background_life_tracking.php
+++ b/lib/background_life_tracking.php
@@ -31,6 +31,35 @@ function chimIsBackgroundNpcInRange(string $npcName): bool
 }
 
 /**
+ * Prefer the newest reliable location source for a Background Life decision.
+ *
+ * Coordinate tracking can lag immediately after travel completes. A newer
+ * background-action event reflects the actor's current package location and
+ * must win over stale coordinates from before the journey.
+ */
+function chimSelectCurrentBackgroundLocation(
+    string $coordinateLocation,
+    $coordinateGamets,
+    string $eventLocation,
+    $eventGamets
+): string {
+    $coordinateLocation = trim($coordinateLocation);
+    $eventLocation = trim($eventLocation);
+
+    if ($eventLocation === '') {
+        return $coordinateLocation;
+    }
+    if ($coordinateLocation === '') {
+        return $eventLocation;
+    }
+
+    $coordinateGamets = is_numeric($coordinateGamets) ? (float) $coordinateGamets : 0.0;
+    $eventGamets = is_numeric($eventGamets) ? (float) $eventGamets : 0.0;
+
+    return $eventGamets >= $coordinateGamets ? $eventLocation : $coordinateLocation;
+}
+
+/**
  * Atomically claim and queue a coordinate update for one Background Life NPC.
  *
  * The pending flag and response command are written in one statement. Competing

--- a/lib/background_life_tracking.php
+++ b/lib/background_life_tracking.php
@@ -14,6 +14,23 @@ function chimNormalizeBackgroundTrackRefId($refId): ?string
 }
 
 /**
+ * Check the exact pipe-delimited presence list before requesting coordinates.
+ *
+ * Nearby NPC coordinates are already refreshed by normal game presence data,
+ * so sending an additional BackgroundCmd Track request only creates redundant
+ * server and plugin work.
+ */
+function chimIsBackgroundNpcInRange(string $npcName): bool
+{
+    $npcName = trim($npcName);
+    if ($npcName === '' || !function_exists('DataBeingsInRange')) {
+        return false;
+    }
+
+    return str_contains((string) DataBeingsInRange(), '|' . $npcName . '|');
+}
+
+/**
  * Atomically claim and queue a coordinate update for one Background Life NPC.
  *
  * The pending flag and response command are written in one statement. Competing

--- a/lib/middleterm_worker_lock.php
+++ b/lib/middleterm_worker_lock.php
@@ -1,0 +1,26 @@
+<?php
+
+const CHIM_MIDDLETERM_WORKER_LOCK = 'chim_middleterm_worker';
+
+function chimPostgresLockValue($value): bool
+{
+    return $value === true
+        || $value === 1
+        || in_array(strtolower((string) $value), ['1', 't', 'true'], true);
+}
+
+function chimTryAcquireMiddletermWorkerLock($db): bool
+{
+    $row = $db->fetchOne(
+        "SELECT pg_try_advisory_lock(hashtext('" . CHIM_MIDDLETERM_WORKER_LOCK . "')) AS acquired"
+    );
+
+    return chimPostgresLockValue($row['acquired'] ?? false);
+}
+
+function chimReleaseMiddletermWorkerLock($db): void
+{
+    $db->fetchOne(
+        "SELECT pg_advisory_unlock(hashtext('" . CHIM_MIDDLETERM_WORKER_LOCK . "')) AS released"
+    );
+}

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -179,6 +179,18 @@ if (!function_exists('chimGetBackgroundLifeTriggerHours')) {
     }
 }
 
+if (!function_exists('chimIsBackgroundLifeDue')) {
+    function chimIsBackgroundLifeDue($lastUpdated, float $thresholdGamets): bool
+    {
+        if (!is_numeric($lastUpdated)) {
+            return true;
+        }
+
+        $lastUpdatedGamets = floatval($lastUpdated);
+        return $lastUpdatedGamets <= 0 || $lastUpdatedGamets < $thresholdGamets;
+    }
+}
+
 if (!function_exists('chimGetManagedGeneralSettingIds')) {
     function chimGetManagedGeneralSettingIds(): array
     {

--- a/processor/background_event.php
+++ b/processor/background_event.php
@@ -173,7 +173,7 @@ if (is_array($bgevent)) {
                 $npcManager->updateByArray($npcData);
 
                 // Also, lets track coords.
-                if ($npcData["refid"]) {
+                if ($npcData["refid"] && !chimIsBackgroundNpcInRange((string) $npcData["npc_name"])) {
                     chimQueueBackgroundTrack(
                         $npcData,
                         $GLOBALS["db"],

--- a/processor/background_event.php
+++ b/processor/background_event.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/../lib/background_life_tracking.php';
 
 
 function convertSignedToUnsignedHexTrunc($signedInt)
@@ -173,16 +174,10 @@ if (is_array($bgevent)) {
 
                 // Also, lets track coords.
                 if ($npcData["refid"]) {
-                    $GLOBALS["db"]->insert(
-                        'responselog',
-                        [
-                            'localts' => time(),
-                            'sent' => 0,
-                            'actor' => "rolemaster",
-                            'text' => "",
-                            'action' => "rolecommand|BackgroundCmd@0x{$npcData['refid']}@Track/",
-                            'tag' => "requested after background event {$bgevent["name"]}",
-                        ]
+                    chimQueueBackgroundTrack(
+                        $npcData,
+                        $GLOBALS["db"],
+                        "requested after background event {$bgevent["name"]}"
                     );
                 }
             }

--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -205,17 +205,6 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         if (chimIsBackgroundLifeDue($mwdata["background_life_last_updated"] ?? null, $bglTriggerHoursAgoGamets)) {
             error_log("[BGL]  Passive event for {$npc["npc_name"]}");
 
-
-            if (isset($mwdata["background_life_last_updated"]))  {
-                if ($mwdata["background_life_last_updated"] > ($oneDayAgoGamets)) {
-                    
-                    $delta = ($mwdata["background_life_last_updated"] - $oneDayAgoGamets) * 0.0000024;
-                    error_log("[BGL]  {$npc["npc_name"]} Avoiding by 1-day HARDCODED RULE. Last updated: {$mwdata["background_life_last_updated"]}, threshold: {$oneDayAgoGamets }, BGL_TRIGGER_DAYS: {$GLOBALS['BGL_TRIGGER_DAYS']}, delta: {$delta}");
-                    continue;
-                
-                }
-            }
-
             $shellResult = shell_exec("php $enginePath/debug/simple_llm_request_with_context_life.php \"{$npc["npc_name"]}\" ");
             if (!empty($GLOBALS["CUSTOM_LOG_FILE"])) {
                 Logger::info($shellResult, $GLOBALS["CUSTOM_LOG_FILE"]);

--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -16,6 +16,7 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
     require_once($enginePath . "lib/data_functions.php");
     require_once($enginePath . "lib/rolemaster_helpers.php");
     require_once($enginePath . "lib/utils_game_timestamp.php");
+    require_once($enginePath . "lib/background_life_tracking.php");
     require_once($enginePath . "lib/middleterm_worker_lock.php");
 
     require_once $enginePath . "lib/core/npc_master.class.php";
@@ -133,6 +134,10 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
 
     $allEnabledBgLNpc = $GLOBALS["db"]->fetchAll("SELECT * FROM core_npc_master WHERE extended_data->>'background_life_enabled' = 'true' AND metadata->>'last_coords' IS NOT NULL AND metadata->'last_coords'->>'pending' IS NULL ");
     foreach ($allEnabledBgLNpc as $npc) {
+        if (chimIsBackgroundNpcInRange((string) $npc["npc_name"])) {
+            continue;
+        }
+
         $mwdata = json_decode($npc["metadata"], true);
         if (!isset($mwdata["last_coords"]["last_updated"]) || !$mwdata["last_coords"]["last_updated"] || $mwdata["last_coords"]["last_updated"] < ($oneDayAgoGamets)) {
             logger::info("[BGL] Daily Tracking {$npc["npc_name"]}");
@@ -157,6 +162,10 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
     $allEnabledBgLNpc = $GLOBALS["db"]->fetchAll("SELECT * FROM core_npc_master WHERE extended_data->>'background_life_enabled' = 'true' AND metadata->'gps_track' = 'true' AND metadata->'last_coords'->>'pending' IS NULL AND (metadata->'last_coords'->>'last_updated')::numeric < $oneHourAgoGamets ");
 
     foreach ($allEnabledBgLNpc as $npc) {
+        if (chimIsBackgroundNpcInRange((string) $npc["npc_name"])) {
+            continue;
+        }
+
         $mwdata = json_decode($npc["metadata"], true);
         if (
             !isset($mwdata["last_coords"]["last_updated"]) || !$mwdata["last_coords"]["last_updated"]

--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -180,7 +180,7 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         $mwdata = json_decode($npc["extended_data"], true);
         // Trigger if never updated, or if last update is older than configured threshold
         $mustInstructBypassBgl=false;
-        if (!isset($mwdata["background_life_last_updated"]) || $mwdata["background_life_last_updated"] < ($bglTriggerDaysAgoGamets)) {
+        if (chimIsBackgroundLifeDue($mwdata["background_life_last_updated"] ?? null, $bglTriggerDaysAgoGamets)) {
             error_log("[BGL]  Passive event for {$npc["npc_name"]}");
 
 
@@ -254,9 +254,11 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         }
 
         // Trigger if never updated, or if last update is older than configured threshold
-        if (!isset($mwdata["background_life_last_updated"]) || $mwdata["background_life_last_updated"] < ($bglTriggerDaysAgoGamets)) {
-            $delta = ($mwdata["background_life_last_updated"] - $bglTriggerDaysAgoGamets) * 0.0000024;
-            error_log("[BGL] Event for {$npc["npc_name"]}, last updated: {$mwdata["background_life_last_updated"]}, threshold: {$bglTriggerDaysAgoGamets}, BGL_TRIGGER_DAYS: {$GLOBALS['BGL_TRIGGER_DAYS']}, delta: {$delta}, presence delta: {$mwdata["background_life_last_updated_presence_delta"]}");
+        if (chimIsBackgroundLifeDue($mwdata["background_life_last_updated"] ?? null, $bglTriggerDaysAgoGamets)) {
+            $lastUpdated = (float) ($mwdata["background_life_last_updated"] ?? 0);
+            $presenceDelta = (int) ($mwdata["background_life_last_updated_presence_delta"] ?? 0);
+            $delta = ($lastUpdated - $bglTriggerDaysAgoGamets) * 0.0000024;
+            error_log("[BGL] Event for {$npc["npc_name"]}, last updated: {$lastUpdated}, threshold: {$bglTriggerDaysAgoGamets}, BGL_TRIGGER_DAYS: {$GLOBALS['BGL_TRIGGER_DAYS']}, delta: {$delta}, presence delta: {$presenceDelta}");
 
             if ($mustInstructBypassBgl){
                 error_log("[BGL] {$npc["npc_name"]} has been near a player for more than 10 checks. Issuing INSTRUCTION");

--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -157,8 +157,6 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         $oneHourAgoGamets = $maxRow;
     }
 
-    error_log("[BGL] Checking tracked NPCs");
-
     $allEnabledBgLNpc = $GLOBALS["db"]->fetchAll("SELECT * FROM core_npc_master WHERE extended_data->>'background_life_enabled' = 'true' AND metadata->'gps_track' = 'true' AND metadata->'last_coords'->>'pending' IS NULL AND (metadata->'last_coords'->>'last_updated')::numeric < $oneHourAgoGamets ");
 
     foreach ($allEnabledBgLNpc as $npc) {
@@ -184,7 +182,6 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
     // BgL content
     // In-game based on the configured hours
 
-    error_log("[BGL] Checking passive events NPCs");
     $allEnabledBgLNpc = $GLOBALS["db"]->fetchAll("SELECT * FROM core_npc_master WHERE extended_data->>'background_life_enabled' = 'true' AND (extended_data->>'background_life_commands' = 'false' or extended_data->>'background_life_commands'  IS NULL)");
     foreach ($allEnabledBgLNpc as $npc) {
 
@@ -193,8 +190,6 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
 
 
         if (isset($npcIsNearToPlayer) && $npcIsNearToPlayer["n"] > 0) {
-            $localDelta = ($npcIsNearToPlayer["n"] - $oneHourAgoGamets) * 0.0000024;
-            error_log("[BGL] Skipping Passive event for {$npc["npc_name"]}, is NEAR TO PLAYER, delta: {$localDelta}");
             continue;
            
         }
@@ -215,17 +210,12 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
             $npcMaster->updateExtendedKeysByName($npc["npc_name"], $extdata);
 
             break;  // One per iteration - break after processing
-        } else {
-            $delta = ($mwdata["background_life_last_updated"] - $bglTriggerHoursAgoGamets) * 0.0000024;
-            error_log("[BGL] (Passive) Skipping {$npc["npc_name"]}, last updated: {$mwdata["background_life_last_updated"]}, threshold: {$bglTriggerHoursAgoGamets}, BGL_TRIGGER_HOURS: {$bglTriggerHours},delta: {$delta}");
         }
     }
 
     // Process delayed events for BgL NPCs
     processDelayedEvents($GLOBALS["db"], $enginePath);
 
-    error_log("[BGL] Checking active events NPCs");
-    
     // BgL commands
     $allEnabledBgLNpc = $GLOBALS["db"]->fetchAll("SELECT * FROM core_npc_master WHERE extended_data->>'background_life_enabled' = 'true' AND extended_data->>'background_life_commands' = 'true' ");
     foreach ($allEnabledBgLNpc as $npc) {
@@ -235,8 +225,6 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
             type='infonpc' and data like '%" . ($GLOBALS["db"]->escape($npc["npc_name"])) . "%' and gamets > $oneHourAgoGamets");
 
         if (isset($npcIsNearToPlayer) && $npcIsNearToPlayer["n"] > 0) {
-            $localDelta = ($npcIsNearToPlayer["n"] - $oneHourAgoGamets) * 0.0000024;
-
             $npcManager = new NpcMaster();
             $npcData = $npcManager->getByName($npc["npc_name"]);
             $extended = json_decode($npcData["extended_data"], true);
@@ -248,8 +236,6 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
             $npcData = $npcManager->setExtendedData($npcData, $extended);
 
             if ($extended["background_life_last_updated_presence_delta"] > 10) {
-                error_log("[BGL] {$npc["npc_name"]} has been near a player for more than 10 checks. Issuing instructions if needed");
-                
                 // $extended["background_life_last_updated"] = $maxRow;
                 $mustInstructBypassBgl=true;
                 $npcData = $npcManager->setExtendedData($npcData, $extended);
@@ -258,7 +244,6 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
             } else {
                 $npcData = $npcManager->setExtendedData($npcData, $extended);
                 $npcManager->updateByArray($npcData);
-                error_log("[BGL] Skipping Passive event for {$npc["npc_name"]}, is NEAR TO PLAYER, delta: {$localDelta}, Presence retries: {$extended["background_life_last_updated_presence_delta"]}");
                 continue;
             }
 
@@ -302,14 +287,11 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
                 Logger::info($shellResult, $GLOBALS["CUSTOM_LOG_FILE"]);
             }
             break;  // One per iteration - break after processing
-        } else {
-            $delta = ($mwdata["background_life_last_updated"] - $bglTriggerHoursAgoGamets) * 0.0000024;
-            error_log("[BGL] Skipping {$npc["npc_name"]}, last updated: {$mwdata["background_life_last_updated"]}, threshold: {$bglTriggerHoursAgoGamets}, BGL_TRIGGER_HOURS: {$bglTriggerHours}, delta: {$delta}");
         }
     }
 
     if (sizeof($allEnabledBgLNpc) === 0) {
-        error_log("[BGL] No NPCs with background life enabled");
+        Logger::debug("[BGL] No NPCs with background life enabled");
     }
 
 

--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -16,11 +16,29 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
     require_once($enginePath . "lib/data_functions.php");
     require_once($enginePath . "lib/rolemaster_helpers.php");
     require_once($enginePath . "lib/utils_game_timestamp.php");
+    require_once($enginePath . "lib/middleterm_worker_lock.php");
 
     require_once $enginePath . "lib/core/npc_master.class.php";
     require_once $enginePath . "lib/core/api_badge.class.php";
     require_once $enginePath . "lib/core/core_profiles.class.php";
     require_once $enginePath . "lib/core/llm_connector.class.php";
+
+    if (!chimTryAcquireMiddletermWorkerLock($GLOBALS["db"])) {
+        Logger::debug("[MIDDLETERM] Another worker is active; skipping overlapping run");
+        return;
+    }
+
+    $middletermLockHeld = true;
+    register_shutdown_function(
+        static function () use (&$middletermLockHeld) {
+            if (!$middletermLockHeld || !isset($GLOBALS["db"])) {
+                return;
+            }
+
+            chimReleaseMiddletermWorkerLock($GLOBALS["db"]);
+            $middletermLockHeld = false;
+        }
+    );
 
     /**
      * Process delayed events waiting for TTS to finish
@@ -309,7 +327,8 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         $shellResult = shell_exec("php {$GLOBALS["ENGINE_PATH"]}/debug/util_memory_subsystem.php compact embed 1 2>/dev/null");
     }
 
-    //unset($GLOBALS["db"]);
+    chimReleaseMiddletermWorkerLock($GLOBALS["db"]);
+    $middletermLockHeld = false;
 
 }
     ?>

--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -129,11 +129,6 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
     $bglTriggerHours = chimGetBackgroundLifeTriggerHours();
     $bglTriggerHoursAgoGamets = $maxRow - ($bglTriggerHours / 0.0000024);
 
-    $bglTriggerHours = chimGetBackgroundLifeTriggerHours();
-    $bglTriggerDays = $bglTriggerHours/24;
-    $bglTriggerDaysAgoGamets=$maxRow - ( (24 * $bglTriggerDays) / 0.0000024);
-
-
     // BgL tracking coords, in-game daily
 
     $allEnabledBgLNpc = $GLOBALS["db"]->fetchAll("SELECT * FROM core_npc_master WHERE extended_data->>'background_life_enabled' = 'true' AND metadata->>'last_coords' IS NOT NULL AND metadata->'last_coords'->>'pending' IS NULL ");
@@ -178,7 +173,7 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
 
 
     // BgL content
-    // In-game based on configured days
+    // In-game based on the configured hours
 
     error_log("[BGL] Checking passive events NPCs");
     $allEnabledBgLNpc = $GLOBALS["db"]->fetchAll("SELECT * FROM core_npc_master WHERE extended_data->>'background_life_enabled' = 'true' AND (extended_data->>'background_life_commands' = 'false' or extended_data->>'background_life_commands'  IS NULL)");
@@ -198,7 +193,7 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         $mwdata = json_decode($npc["extended_data"], true);
         // Trigger if never updated, or if last update is older than configured threshold
         $mustInstructBypassBgl=false;
-        if (chimIsBackgroundLifeDue($mwdata["background_life_last_updated"] ?? null, $bglTriggerDaysAgoGamets)) {
+        if (chimIsBackgroundLifeDue($mwdata["background_life_last_updated"] ?? null, $bglTriggerHoursAgoGamets)) {
             error_log("[BGL]  Passive event for {$npc["npc_name"]}");
 
 
@@ -272,11 +267,11 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         }
 
         // Trigger if never updated, or if last update is older than configured threshold
-        if (chimIsBackgroundLifeDue($mwdata["background_life_last_updated"] ?? null, $bglTriggerDaysAgoGamets)) {
+        if (chimIsBackgroundLifeDue($mwdata["background_life_last_updated"] ?? null, $bglTriggerHoursAgoGamets)) {
             $lastUpdated = (float) ($mwdata["background_life_last_updated"] ?? 0);
             $presenceDelta = (int) ($mwdata["background_life_last_updated_presence_delta"] ?? 0);
-            $delta = ($lastUpdated - $bglTriggerDaysAgoGamets) * 0.0000024;
-            error_log("[BGL] Event for {$npc["npc_name"]}, last updated: {$lastUpdated}, threshold: {$bglTriggerDaysAgoGamets}, BGL_TRIGGER_DAYS: {$GLOBALS['BGL_TRIGGER_DAYS']}, delta: {$delta}, presence delta: {$presenceDelta}");
+            $delta = ($lastUpdated - $bglTriggerHoursAgoGamets) * 0.0000024;
+            error_log("[BGL] Event for {$npc["npc_name"]}, last updated: {$lastUpdated}, threshold: {$bglTriggerHoursAgoGamets}, BGL_TRIGGER_HOURS: {$bglTriggerHours}, delta: {$delta}, presence delta: {$presenceDelta}");
 
             if ($mustInstructBypassBgl){
                 error_log("[BGL] {$npc["npc_name"]} has been near a player for more than 10 checks. Issuing INSTRUCTION");

--- a/unittests/tests/BackgroundActionLocationTest.php
+++ b/unittests/tests/BackgroundActionLocationTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../debug/background_action_handler.php';
+
+final class BackgroundActionLocationDb
+{
+    public string $lastQuery = '';
+    public $nextResult = null;
+
+    public function escape($value): string
+    {
+        return str_replace("'", "''", (string) $value);
+    }
+
+    public function fetchOne(string $query)
+    {
+        $this->lastQuery = $query;
+        return $this->nextResult;
+    }
+}
+
+final class BackgroundActionLocationTest extends TestCase
+{
+    public function testFuzzyResolutionRanksSimilarityBeforeDistance(): void
+    {
+        $db = new BackgroundActionLocationDb();
+        $npc = [
+            'metadata' => [
+                'last_coords' => [100, 200],
+            ],
+        ];
+
+        resolveTravelLocation("Lucan's Dry Goods", $npc, $db);
+
+        self::assertStringContainsString(
+            'ORDER BY exact_rank DESC, sim DESC, dist ASC',
+            preg_replace('/\s+/', ' ', $db->lastQuery)
+        );
+    }
+
+    public function testCurrentLocationUsesReportedLocationFormId(): void
+    {
+        $db = new BackgroundActionLocationDb();
+        $db->nextResult = [
+            'name' => "Alvor and Sigrid's House",
+            'formid' => '117640',
+            'sim' => 1,
+            'exact_rank' => 4,
+        ];
+        $npc = [
+            'metadata' => json_encode([
+                'last_coords' => [
+                    'location_formid' => 117640,
+                ],
+            ]),
+        ];
+
+        $result = resolveNpcCurrentLocation($npc, $db);
+
+        self::assertSame("Alvor and Sigrid's House", $result['name']);
+        self::assertStringContainsString("formid='117640'", $db->lastQuery);
+    }
+
+    public function testLowSimilarityLocationIsNotConfident(): void
+    {
+        self::assertFalse(isResolvedTravelLocationConfident([
+            'formid' => '117642',
+            'sim' => 0.083333336,
+            'exact_rank' => 0,
+        ]));
+    }
+
+    public function testExactOrStrongFuzzyLocationIsConfident(): void
+    {
+        self::assertTrue(isResolvedTravelLocationConfident([
+            'formid' => '117640',
+            'sim' => 0.60,
+            'exact_rank' => 3,
+        ]));
+        self::assertTrue(isResolvedTravelLocationConfident([
+            'formid' => '117641',
+            'sim' => 0.80,
+            'exact_rank' => 0,
+        ]));
+    }
+}

--- a/unittests/tests/BackgroundInventoryActionTest.php
+++ b/unittests/tests/BackgroundInventoryActionTest.php
@@ -64,6 +64,10 @@ final class BackgroundInventoryActionTest extends TestCase
             "background_life_inventory_last_processed_idle_gamets",
             $db->lastQuery
         );
+        self::assertStringContainsString(
+            "ARRAY['background_life_inventory_last_processed_idle_gamets']::text[]",
+            $db->lastQuery
+        );
         self::assertStringContainsString('< 37136115', $db->lastQuery);
     }
 

--- a/unittests/tests/BackgroundInventoryActionTest.php
+++ b/unittests/tests/BackgroundInventoryActionTest.php
@@ -4,6 +4,23 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../debug/background_action_handler.php';
 
+final class BackgroundInventoryClaimDb
+{
+    public string $lastQuery = '';
+    public $nextResult = null;
+
+    public function escape($value): string
+    {
+        return str_replace("'", "''", (string) $value);
+    }
+
+    public function fetchOne(string $query)
+    {
+        $this->lastQuery = $query;
+        return $this->nextResult;
+    }
+}
+
 final class BackgroundInventoryActionTest extends TestCase
 {
     public function testKeepsValidProducedAndConsumeActions(): void
@@ -34,5 +51,28 @@ final class BackgroundInventoryActionTest extends TestCase
                 ['Produced:00034CDF:1'],
             ])
         );
+    }
+
+    public function testClaimsEachIdleActionWithAtomicConditionalUpdate(): void
+    {
+        $db = new BackgroundInventoryClaimDb();
+        $db->nextResult = ['id' => 2190];
+
+        self::assertTrue(claimBglInventorySettlement("Camilla Valerius", 37136115, $db));
+        self::assertStringContainsString('UPDATE core_npc_master', $db->lastQuery);
+        self::assertStringContainsString(
+            "background_life_inventory_last_processed_idle_gamets",
+            $db->lastQuery
+        );
+        self::assertStringContainsString('< 37136115', $db->lastQuery);
+    }
+
+    public function testRejectsDuplicateOrInvalidIdleActionClaims(): void
+    {
+        $db = new BackgroundInventoryClaimDb();
+        $db->nextResult = null;
+
+        self::assertFalse(claimBglInventorySettlement('Camilla Valerius', 37136115, $db));
+        self::assertFalse(claimBglInventorySettlement('Camilla Valerius', 0, $db));
     }
 }

--- a/unittests/tests/BackgroundInventoryActionTest.php
+++ b/unittests/tests/BackgroundInventoryActionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../debug/background_action_handler.php';
+
+final class BackgroundInventoryActionTest extends TestCase
+{
+    public function testKeepsValidProducedAndConsumeActions(): void
+    {
+        self::assertSame(
+            ['Produced:0x00064B3F:2', 'Consume:00034CDF:1'],
+            normalizeBglInventoryActions([
+                'Produced:0x00064B3F:2',
+                'Consume:00034CDF:1',
+            ])
+        );
+    }
+
+    public function testTreatsDoNothingAsNoInventoryAction(): void
+    {
+        self::assertSame([], normalizeBglInventoryActions(['DoNothing']));
+    }
+
+    public function testRejectsMalformedOrUnsafeActions(): void
+    {
+        self::assertSame(
+            [],
+            normalizeBglInventoryActions([
+                'Produced',
+                'Produced:not-a-form-id:1',
+                'Consume:00034CDF:0',
+                'DeleteEverything:00034CDF:99',
+                ['Produced:00034CDF:1'],
+            ])
+        );
+    }
+}

--- a/unittests/tests/BackgroundLifeConcurrencyTest.php
+++ b/unittests/tests/BackgroundLifeConcurrencyTest.php
@@ -82,6 +82,17 @@ final class BackgroundLifeConcurrencyTest extends TestCase
         self::assertFalse(chimIsBackgroundNpcInRange(''));
     }
 
+    public function testSchedulerSkipsNearbyActorsBeforeLaunchingTrackCommands(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../service/processors/middleterm/entrypoint.php');
+
+        self::assertIsString($source);
+        self::assertGreaterThanOrEqual(
+            2,
+            substr_count($source, 'if (chimIsBackgroundNpcInRange((string) $npc["npc_name"]))')
+        );
+    }
+
     public function testMiddletermLockUsesDedicatedAdvisoryLock(): void
     {
         $db = new BackgroundLifeConcurrencyDb();

--- a/unittests/tests/BackgroundLifeConcurrencyTest.php
+++ b/unittests/tests/BackgroundLifeConcurrencyTest.php
@@ -5,6 +5,14 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../lib/background_life_tracking.php';
 require_once __DIR__ . '/../../lib/middleterm_worker_lock.php';
 
+$GLOBALS['BACKGROUND_LIFE_TEST_BEINGS_IN_RANGE'] = '';
+if (!function_exists('DataBeingsInRange')) {
+    function DataBeingsInRange(): string
+    {
+        return (string) ($GLOBALS['BACKGROUND_LIFE_TEST_BEINGS_IN_RANGE'] ?? '');
+    }
+}
+
 final class BackgroundLifeConcurrencyDb
 {
     public array $queries = [];
@@ -62,6 +70,16 @@ final class BackgroundLifeConcurrencyTest extends TestCase
         self::assertFalse(chimQueueBackgroundTrack(['id' => 0, 'refid' => '1347A'], $db));
         self::assertFalse(chimQueueBackgroundTrack(['id' => 1, 'refid' => 'not-a-ref'], $db));
         self::assertSame([], $db->queries);
+    }
+
+    public function testNearbyCheckMatchesWholeActorNamesOnly(): void
+    {
+        $GLOBALS['BACKGROUND_LIFE_TEST_BEINGS_IN_RANGE'] = '|RANGROO|Sven|Sigrid|';
+
+        self::assertTrue(chimIsBackgroundNpcInRange('Sven'));
+        self::assertTrue(chimIsBackgroundNpcInRange('Sigrid'));
+        self::assertFalse(chimIsBackgroundNpcInRange('Sven the Bard'));
+        self::assertFalse(chimIsBackgroundNpcInRange(''));
     }
 
     public function testMiddletermLockUsesDedicatedAdvisoryLock(): void

--- a/unittests/tests/BackgroundLifeConcurrencyTest.php
+++ b/unittests/tests/BackgroundLifeConcurrencyTest.php
@@ -32,6 +32,44 @@ final class BackgroundLifeConcurrencyDb
 
 final class BackgroundLifeConcurrencyTest extends TestCase
 {
+    public function testNewerBackgroundEventLocationOverridesStaleCoordinates(): void
+    {
+        self::assertSame(
+            'Riverwood',
+            chimSelectCurrentBackgroundLocation(
+                'Sleeping Giant Inn (Interior)',
+                77000000,
+                'Riverwood',
+                77088888
+            )
+        );
+    }
+
+    public function testNewerCoordinatesRemainAuthoritative(): void
+    {
+        self::assertSame(
+            'Sleeping Giant Inn (Interior)',
+            chimSelectCurrentBackgroundLocation(
+                'Sleeping Giant Inn (Interior)',
+                77100000,
+                'Riverwood',
+                77088888
+            )
+        );
+    }
+
+    public function testLocationSelectionFallsBackWhenEitherSourceIsMissing(): void
+    {
+        self::assertSame(
+            'Riverwood',
+            chimSelectCurrentBackgroundLocation('', 0, 'Riverwood', 77088888)
+        );
+        self::assertSame(
+            'Sleeping Giant Inn',
+            chimSelectCurrentBackgroundLocation('Sleeping Giant Inn', 77000000, '', 0)
+        );
+    }
+
     public function testTrackClaimAndQueueUseOneAtomicStatement(): void
     {
         $db = new BackgroundLifeConcurrencyDb();

--- a/unittests/tests/BackgroundLifeConcurrencyTest.php
+++ b/unittests/tests/BackgroundLifeConcurrencyTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/background_life_tracking.php';
+require_once __DIR__ . '/../../lib/middleterm_worker_lock.php';
+
+final class BackgroundLifeConcurrencyDb
+{
+    public array $queries = [];
+    public $nextResult = null;
+
+    public function escape($value): string
+    {
+        return str_replace("'", "''", (string) $value);
+    }
+
+    public function fetchOne(string $query)
+    {
+        $this->queries[] = $query;
+        return $this->nextResult;
+    }
+}
+
+final class BackgroundLifeConcurrencyTest extends TestCase
+{
+    public function testTrackClaimAndQueueUseOneAtomicStatement(): void
+    {
+        $db = new BackgroundLifeConcurrencyDb();
+        $db->nextResult = ['rowid' => 1234];
+
+        self::assertTrue(chimQueueBackgroundTrack([
+            'id' => 2190,
+            'refid' => '1347A',
+        ], $db, 'scheduled'));
+
+        self::assertCount(1, $db->queries);
+        $query = preg_replace('/\s+/', ' ', $db->queries[0]);
+        self::assertStringContainsString('WITH claimed AS ( UPDATE core_npc_master', $query);
+        self::assertStringContainsString("\"pending\":true", $query);
+        self::assertStringContainsString("metadata->'last_coords'->>'pending'", $query);
+        self::assertStringContainsString('INSERT INTO responselog', $query);
+        self::assertStringContainsString('BackgroundCmd@0x0001347A@Track/', $query);
+        self::assertStringContainsString("'scheduled'", $query);
+    }
+
+    public function testTrackQueueReturnsFalseWhenAnotherWorkerAlreadyClaimedNpc(): void
+    {
+        $db = new BackgroundLifeConcurrencyDb();
+        $db->nextResult = [];
+
+        self::assertFalse(chimQueueBackgroundTrack([
+            'id' => 2190,
+            'refid' => '0001347A',
+        ], $db));
+    }
+
+    public function testTrackQueueRejectsInvalidNpcIdentity(): void
+    {
+        $db = new BackgroundLifeConcurrencyDb();
+
+        self::assertFalse(chimQueueBackgroundTrack(['id' => 0, 'refid' => '1347A'], $db));
+        self::assertFalse(chimQueueBackgroundTrack(['id' => 1, 'refid' => 'not-a-ref'], $db));
+        self::assertSame([], $db->queries);
+    }
+
+    public function testMiddletermLockUsesDedicatedAdvisoryLock(): void
+    {
+        $db = new BackgroundLifeConcurrencyDb();
+        $db->nextResult = ['acquired' => 't'];
+
+        self::assertTrue(chimTryAcquireMiddletermWorkerLock($db));
+        self::assertStringContainsString('pg_try_advisory_lock', $db->queries[0]);
+        self::assertStringContainsString(CHIM_MIDDLETERM_WORKER_LOCK, $db->queries[0]);
+
+        $db->nextResult = ['released' => 't'];
+        chimReleaseMiddletermWorkerLock($db);
+        self::assertStringContainsString('pg_advisory_unlock', $db->queries[1]);
+    }
+
+    public function testMiddletermLockFailsClosedWhenAlreadyOwned(): void
+    {
+        $db = new BackgroundLifeConcurrencyDb();
+        $db->nextResult = ['acquired' => 'f'];
+
+        self::assertFalse(chimTryAcquireMiddletermWorkerLock($db));
+    }
+}

--- a/unittests/tests/BackgroundLifeConnectorTest.php
+++ b/unittests/tests/BackgroundLifeConnectorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/background_life_connector.php';
+
+final class BackgroundLifeConnectorTest extends TestCase
+{
+    public function testConfiguredConnectorTakesPriority(): void
+    {
+        $result = chimResolveBackgroundLifeConnector(
+            7,
+            ['llm_primary_id' => 8],
+            ['llm_primary_id' => 9],
+            static fn(int $id): array => ['id' => $id, 'driver' => 'openrouterjson']
+        );
+
+        self::assertSame(7, $result['data']['id']);
+        self::assertSame('Background Life setting', $result['source']);
+    }
+
+    public function testFallsBackToNpcProfileWhenSettingIsEmpty(): void
+    {
+        $result = chimResolveBackgroundLifeConnector(
+            '',
+            ['llm_primary_id' => 8],
+            ['llm_primary_id' => 9],
+            static fn(int $id): array => ['id' => $id, 'driver' => 'openrouterjson']
+        );
+
+        self::assertSame(8, $result['data']['id']);
+        self::assertSame('NPC profile primary LLM', $result['source']);
+    }
+
+    public function testFallsBackToDefaultProfileWhenNpcConnectorIsInvalid(): void
+    {
+        $result = chimResolveBackgroundLifeConnector(
+            null,
+            ['llm_primary_id' => 8],
+            ['llm_primary_id' => 9],
+            static fn(int $id): array => $id === 8
+                ? ['id' => 8, 'driver' => '']
+                : ['id' => 9, 'driver' => 'openrouterjson']
+        );
+
+        self::assertSame(9, $result['data']['id']);
+        self::assertSame('default profile primary LLM', $result['source']);
+    }
+
+    public function testFailsCleanlyWithoutAnyUsableConnector(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Background Life has no usable LLM connector');
+
+        chimResolveBackgroundLifeConnector(
+            null,
+            [],
+            [],
+            static fn(int $id): array => []
+        );
+    }
+}

--- a/unittests/tests/BackgroundLifeCooldownTest.php
+++ b/unittests/tests/BackgroundLifeCooldownTest.php
@@ -92,4 +92,18 @@ final class BackgroundLifeCooldownTest extends TestCase
         $this->assertStringNotContainsString('1-day HARDCODED RULE', $source);
         $this->assertStringNotContainsString("\$GLOBALS['BGL_TRIGGER_DAYS']", $source);
     }
+
+    public function testSchedulerDoesNotWriteRoutineSkipDiagnosticsToServiceLog(): void
+    {
+        $source = file_get_contents(
+            __DIR__ . '/../../service/processors/middleterm/entrypoint.php'
+        );
+
+        $this->assertIsString($source);
+        $this->assertStringNotContainsString('error_log("[BGL] Checking', $source);
+        $this->assertStringNotContainsString('error_log("[BGL] Skipping', $source);
+        $this->assertStringNotContainsString('error_log("[BGL] (Passive) Skipping', $source);
+        $this->assertStringContainsString('error_log("[BGL] Event for', $source);
+        $this->assertStringContainsString('error_log("[BGL] {$npc["npc_name"]} has been near a player for more than 10 checks. Issuing INSTRUCTION")', $source);
+    }
 }

--- a/unittests/tests/BackgroundLifeCooldownTest.php
+++ b/unittests/tests/BackgroundLifeCooldownTest.php
@@ -77,4 +77,19 @@ final class BackgroundLifeCooldownTest extends TestCase
         $this->assertFalse(chimIsBackgroundLifeDue(1000, 1000.0));
         $this->assertFalse(chimIsBackgroundLifeDue(1500, 1000.0));
     }
+
+    public function testSchedulerUsesConfiguredHoursWithoutLegacyOneDayMinimum(): void
+    {
+        $source = file_get_contents(
+            __DIR__ . '/../../service/processors/middleterm/entrypoint.php'
+        );
+
+        $this->assertIsString($source);
+        $this->assertGreaterThanOrEqual(
+            2,
+            substr_count($source, 'chimIsBackgroundLifeDue($mwdata["background_life_last_updated"] ?? null, $bglTriggerHoursAgoGamets)')
+        );
+        $this->assertStringNotContainsString('1-day HARDCODED RULE', $source);
+        $this->assertStringNotContainsString("\$GLOBALS['BGL_TRIGGER_DAYS']", $source);
+    }
 }

--- a/unittests/tests/BackgroundLifeCooldownTest.php
+++ b/unittests/tests/BackgroundLifeCooldownTest.php
@@ -62,4 +62,19 @@ final class BackgroundLifeCooldownTest extends TestCase
         $this->assertSame(1.0, chimNormalizeBackgroundLifeTriggerHours(0));
         $this->assertSame(720.0, chimNormalizeBackgroundLifeTriggerHours(1000));
     }
+
+    public function testMissingOrNonPositiveTimestampIsDueImmediately(): void
+    {
+        $this->assertTrue(chimIsBackgroundLifeDue(null, -1000.0));
+        $this->assertTrue(chimIsBackgroundLifeDue('', -1000.0));
+        $this->assertTrue(chimIsBackgroundLifeDue(0, -1000.0));
+        $this->assertTrue(chimIsBackgroundLifeDue(-1, -1000.0));
+    }
+
+    public function testPositiveTimestampUsesConfiguredThreshold(): void
+    {
+        $this->assertTrue(chimIsBackgroundLifeDue(500, 1000.0));
+        $this->assertFalse(chimIsBackgroundLifeDue(1000, 1000.0));
+        $this->assertFalse(chimIsBackgroundLifeDue(1500, 1000.0));
+    }
 }

--- a/unittests/tests/BackgroundLifeDiaryPersistenceTest.php
+++ b/unittests/tests/BackgroundLifeDiaryPersistenceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class BackgroundLifeDiaryPersistenceTest extends TestCase
+{
+    public function testMemoryUsesTheSameDiaryCooldownGuardAsDiaryLog(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../debug/simple_llm_request_with_context_life_v2.php');
+
+        self::assertIsString($source);
+
+        $guardStart = strrpos($source, 'if ($recordDiaryEntry) {');
+        $nextSection = strpos(
+            $source,
+            '$currentNpcData = $npcMaster->getByName($npcName);',
+            $guardStart
+        );
+
+        self::assertNotFalse($guardStart);
+        self::assertNotFalse($nextSection);
+
+        $guardedPersistence = substr($source, $guardStart, $nextSection - $guardStart);
+
+        self::assertStringContainsString("'topic' => 'Journal Note'", $guardedPersistence);
+        self::assertStringContainsString("logMemory(\$GLOBALS['HERIKA_NAME']", $guardedPersistence);
+    }
+}


### PR DESCRIPTION
﻿## Summary

- Treat missing and non-positive Background Life timestamps as immediately due.
- Fall back from the optional Background Life connector to the NPC or default profile LLM.
- Guard empty action, event, diary, and presence history on first-run cycles.
- Reject malformed inventory side effects and represent no inventory activity as an empty action list.
- Atomically claim each idle-action inventory settlement so retries cannot consume or produce the same items twice.
- Require confident travel-location matches and keep weak `StayAtPlace` requests at the NPC's reported current location.
- Prefer a newer background-event location over older coordinate metadata after travel.
- Serialize the middle-term scheduler and atomically enqueue coordinate tracking.
- Keep diary-memory persistence under the same retry throttle as diarylog persistence.
- Honor the configured hours cooldown for active and passive NPCs.
- Remove high-volume per-tick Background Life scheduler diagnostics while retaining actual due-event logs.

## Root causes

Fresh or reset NPC metadata could contain a zero timestamp, while the old comparison only handled missing or sufficiently old positive values. Background Life also assumed its optional connector and several history rows always existed.

The live soak exposed additional independent faults:

- retries could apply the same idle inventory mutation more than once
- overlapping middle-term workers could enqueue duplicate `Track` commands
- rejected weak-location retries could persist near-identical diary memories
- passive scheduling retained a separate hardcoded one-day minimum
- an inventory settlement marker passed a scalar instead of a PostgreSQL `text[]` path
- stale coordinate metadata could override a newer post-travel event location
- routine scheduler checks produced excessive service-log volume

## Validation

- PHP lint passed for all changed runtime files.
- Focused PHPUnit suite: **33 tests, 81 assertions**.
- Rollback-only PostgreSQL integration verified atomic inventory and tracking claims.
- Two-session advisory-lock test denied the competing scheduler connection.
- Hot-deployed exact tested files with matching SHA-256 hashes and correct ownership without restarting Skyrim.
- Completed an eight-hour live harness soak with six existing NPCs.
- Observed natural travel, arrival, work, sleep, nearby dialogue, inventory consumption, diary memory, summary, and Oghma paths.
- Sven's post-travel cycle correctly used `Riverwood` rather than stale `Sleeping Giant Inn` coordinates after the location fix.
- Final memory audit: **39 rows, 39 unique, 0 blank, 0 exact duplicates**.
- Oghma audit recorded 80 context-injection decisions across 30 unique memories.
- No sustained response backlog, PHP/server error, LLM timeout, or Skyrim hang occurred during the soak.
- Skyrim remained responsive at completion.
- Harness restoration completed for all six NPCs; `BGL_TRIGGER_HOURS` returned to `120` and MoveTo confirmation returned to enabled.

## Known observations

- Nearby actors use recent game-presence context rather than the stricter audio path check. The plugin correctly suppresses playback when the actor is no longer spatially audible.
- Some generated stories can repeat an NPC's intention across days, such as Lucan repeatedly deciding to return to his shop. This is narrative/model behavior rather than a scheduler or persistence failure.


## Seven-hour follow-up soak

- Run 4 completed the full **420 minutes** with 12 selected NPCs; Skyrim remained responsive and all temporary harness settings were restored.
- The deployed baseline reproduced the blank optional Background Life connector path and the associated missing-key warnings covered by this PR.
- Current PR head validation passed PHP lint for 16 changed PHP files and **22 tests / 48 assertions**.
- A clean merge simulation with current unstable, including the merged service singleton fix, passed **24 tests / 56 assertions**.
- Six identical role commands and 63 duplicate request/result pairs were traced to concurrent background service daemons. That separate root cause is already fixed by merged PR #627 and is intentionally not duplicated here.
- The soak generated no new `memory` rows while normal connector-backed Background Life was blocked, so Background Life memory coverage remains pending a post-merge re-soak.
