### PR TITLE
Fix generated NPC FormIDs in spawn commands

### DIFF
--- a/lib/quest_reference_data.php
+++ b/lib/quest_reference_data.php
@@ -411,6 +411,27 @@ if (!function_exists('quest_reference_normalize_formid')) {
     }
 }
 
+if (!function_exists('quest_reference_formid_for_papyrus')) {
+    function quest_reference_formid_for_papyrus($value): int
+    {
+        $formId = quest_reference_normalize_formid($value);
+        if ($formId === null) {
+            return 0;
+        }
+
+        $unsigned = $formId & 0xFFFFFFFF;
+        return $unsigned > 0x7FFFFFFF ? $unsigned - 0x100000000 : $unsigned;
+    }
+}
+
+if (!function_exists('quest_reference_formid_for_full_plugin_file')) {
+    function quest_reference_formid_for_full_plugin_file($value): int
+    {
+        $formId = quest_reference_normalize_formid($value);
+        return $formId === null ? 0 : $formId & 0x00FFFFFF;
+    }
+}
+
 if (!function_exists('quest_reference_repair_formid_values')) {
     function quest_reference_repair_formid_values(
         $datasetName,

--- a/lib/rolemaster_helpers.php
+++ b/lib/rolemaster_helpers.php
@@ -670,6 +670,7 @@ function npcProfileBase($name, $class, $race, $gender, $location, $taskId, $addi
 
     $humanoidRaces = quest_reference_playable_races();
     $parm1 = quest_reference_pick_safe_spawn_base($masterData, $gender, $race, $dclass);
+    $usesChimOwnedSpawnBase = $parm1 !== 0;
     if ($parm1 === 0) {
         if (in_array($race, $humanoidRaces, true)) {
             Logger::warn("[npcProfileBase] Aborting humanoid spawn: no CHIM-owned base for {$classTemplateKey}");
@@ -766,6 +767,16 @@ function npcProfileBase($name, $class, $race, $gender, $location, $taskId, $addi
 
     }
 
+    // SpawnAgent resolves CHIM-owned humanoid bases with GetFormFromFile,
+    // which requires AIAgent.esp's local FormID rather than its runtime prefix.
+    $wireParm1 = $usesChimOwnedSpawnBase
+        ? quest_reference_formid_for_full_plugin_file($parm1)
+        : quest_reference_formid_for_papyrus($parm1);
+    $wireParm2 = quest_reference_formid_for_papyrus($parm2);
+    $wireParm3 = quest_reference_formid_for_papyrus($parm3);
+    $wireParm4 = quest_reference_formid_for_papyrus($parm4);
+    $wireParm5 = quest_reference_formid_for_papyrus($parm5);
+
     $GLOBALS["db"]->insert(
         'responselog',
         [
@@ -773,7 +784,7 @@ function npcProfileBase($name, $class, $race, $gender, $location, $taskId, $addi
             'sent' => 0,
             'actor' => "rolemaster",
             'text' => "",
-            'action' => "rolecommand|spawnCharacter@{$name}@$parm1@$parm2@$parm3@$parm4@$patchedTaskid@$parm5",
+            'action' => "rolecommand|spawnCharacter@{$name}@$wireParm1@$wireParm2@$wireParm3@$wireParm4@$patchedTaskid@$wireParm5",
             'tag' => "",
         ]
     );

--- a/unittests/tests/QuestAssetLibraryTest.php
+++ b/unittests/tests/QuestAssetLibraryTest.php
@@ -196,6 +196,21 @@ final class QuestAssetLibraryTest extends TestCase
         $this->assertSame([hexdec('01001234')], $weapons['guard']);
     }
 
+    public function testRuntimeFormIdsUseSignedPapyrusWireValues(): void
+    {
+        $this->assertSame(0, quest_reference_formid_for_papyrus(0));
+        $this->assertSame(2147483647, quest_reference_formid_for_papyrus('0x7FFFFFFF'));
+        $this->assertSame(-2147483648, quest_reference_formid_for_papyrus('0x80000000'));
+        $this->assertSame(-1493017151, quest_reference_formid_for_papyrus('0xA7025DC1'));
+        $this->assertSame(-1, quest_reference_formid_for_papyrus('0xFFFFFFFF'));
+    }
+
+    public function testFullPluginRuntimeFormIdsBecomePluginLocalValues(): void
+    {
+        $this->assertSame(0x0025DC1, quest_reference_formid_for_full_plugin_file('0xA7025DC1'));
+        $this->assertSame(0x00013989, quest_reference_formid_for_full_plugin_file('0x00013989'));
+    }
+
     public function testOfficialPackContainsOnlyApprovedOfficialRecords(): void
     {
         $manifest = quest_asset_manifest_validate($this->manifest('skyrim_official.json'))['manifest'];

--- a/unittests/tests/SpawnCommandWireTest.php
+++ b/unittests/tests/SpawnCommandWireTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'rolemaster_helpers.php';
+
+final class SpawnCommandWireTest extends TestCase
+{
+    public function testSpawnCommandUsesPluginLocalAndSignedRuntimeFormIds(): void
+    {
+        $db = new class {
+            public array $inserted = [];
+
+            public function fetchAll(string $query): array
+            {
+                return [];
+            }
+
+            public function fetchOne(string $query): array
+            {
+                return [];
+            }
+
+            public function escape($value): string
+            {
+                return str_replace("'", "''", (string)$value);
+            }
+
+            public function insert(string $table, array $data): void
+            {
+                $this->inserted[] = [$table, $data];
+            }
+        };
+
+        $previousGlobals = [];
+        foreach (['db', 'npc_templates', 'npc_own_templates', 'weapons', 'outfit'] as $key) {
+            $previousGlobals[$key] = $GLOBALS[$key] ?? null;
+        }
+
+        $GLOBALS['db'] = $db;
+        $GLOBALS['npc_templates'] = ['female_nord' => [0x0003DE6E]];
+        $GLOBALS['npc_own_templates'] = ['female_nord_soldier' => [0xA7025DC1]];
+        $GLOBALS['weapons'] = ['soldier' => [0xA7013985], 'default' => [0xA7013989]];
+        $GLOBALS['outfit'] = ['soldier' => [0xA70E108F]];
+
+        try {
+            npcProfileBase('Wire Test', 'soldier', 'Nord', 'female', 'nearby', '0');
+        } finally {
+            foreach ($previousGlobals as $key => $value) {
+                if ($value === null) {
+                    unset($GLOBALS[$key]);
+                } else {
+                    $GLOBALS[$key] = $value;
+                }
+            }
+        }
+
+        $this->assertCount(1, $db->inserted);
+        $this->assertSame('responselog', $db->inserted[0][0]);
+        $this->assertSame(
+            'rolecommand|spawnCharacter@Wire Test@155073@-1492250481@-1493091963@0@0@253550',
+            $db->inserted[0][1]['action']
+        );
+    }
+}


### PR DESCRIPTION
﻿## Summary
- send CHIM-owned spawn bases as AIAgent.esp-local FormIDs for `GetFormFromFile`
- send runtime forms through the signed 32-bit Papyrus wire representation
- add focused command-wire coverage and extend asset-library FormID tests

## Root cause
Generated NPC spawn commands mixed full runtime FormIDs with plugin-local IDs. High-bit runtime IDs could also be serialized as unsupported positive values instead of the signed integer representation Papyrus expects.

## Validation
- PHP lint passed for changed files
- PHPUnit: 23 tests, 1,591 assertions
- focused command test verifies the exact emitted `spawnCharacter` wire payload
- no DLLs or generated deployment artifacts included

This remains draft while generated-NPC provisioning is exercised by the live systems harness.
