### PR TITLE
Handle legacy TTS fallback metadata safely

### DIFF
--- a/lib/core/tts_connector.class.php
+++ b/lib/core/tts_connector.class.php
@@ -407,10 +407,26 @@ class TTSConnector
         );
 
         if ($this->isFemaleGender($gender)) {
-            return trim(strval($metadata['fallback_female'] ?? self::$sharedMetadataDefaultMap['fallback_female']));
+            return $this->resolveFallbackVoiceMetadata(
+                $metadata['fallback_female'] ?? null,
+                self::$sharedMetadataDefaultMap['fallback_female']
+            );
         }
 
-        return trim(strval($metadata['fallback_male'] ?? self::$sharedMetadataDefaultMap['fallback_male']));
+        return $this->resolveFallbackVoiceMetadata(
+            $metadata['fallback_male'] ?? null,
+            self::$sharedMetadataDefaultMap['fallback_male']
+        );
+    }
+
+    private function resolveFallbackVoiceMetadata($value, string $default): string
+    {
+        // Legacy seed rows stored field schemas instead of resolved values.
+        if (is_array($value)) {
+            $value = $value['default'] ?? $default;
+        }
+
+        return is_scalar($value) ? trim(strval($value)) : $default;
     }
 
     public function resolveNpcVoiceForConnector(array $currentNpcData, $connectorData = null): array

--- a/unittests/tests/TtsConnectorFallbackMetadataTest.php
+++ b/unittests/tests/TtsConnectorFallbackMetadataTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'tts_connector.class.php');
+
+final class TtsConnectorFallbackMetadataTest extends TestCase
+{
+    public function testUsesScalarFallbackVoices(): void
+    {
+        $connector = new TTSConnector();
+        $connectorData = [
+            'driver' => 'pockettts',
+            'metadata' => json_encode([
+                'fallback_male' => 'malecustom',
+                'fallback_female' => 'femalecustom',
+            ]),
+        ];
+
+        $this->assertSame('malecustom', $connector->getFallbackVoiceForGender($connectorData, 'male'));
+        $this->assertSame('femalecustom', $connector->getFallbackVoiceForGender($connectorData, 'female'));
+    }
+
+    public function testResolvesLegacyFieldSchemaDefaults(): void
+    {
+        $connector = new TTSConnector();
+        $connectorData = [
+            'driver' => 'pockettts',
+            'metadata' => json_encode([
+                'fallback_male' => ['type' => 'string', 'default' => 'malelegacy'],
+                'fallback_female' => ['type' => 'string', 'default' => 'femalelegacy'],
+            ]),
+        ];
+
+        $this->assertSame('malelegacy', $connector->getFallbackVoiceForGender($connectorData, 'male'));
+        $this->assertSame('femalelegacy', $connector->getFallbackVoiceForGender($connectorData, 'female'));
+    }
+
+    public function testMalformedLegacyFieldSchemasUseSharedDefaults(): void
+    {
+        $connector = new TTSConnector();
+        $connectorData = [
+            'driver' => 'pockettts',
+            'metadata' => json_encode([
+                'fallback_male' => ['type' => 'string'],
+                'fallback_female' => ['type' => 'string'],
+            ]),
+        ];
+
+        $this->assertSame('malenord', $connector->getFallbackVoiceForGender($connectorData, 'male'));
+        $this->assertSame('femalenord', $connector->getFallbackVoiceForGender($connectorData, 'female'));
+    }
+}


### PR DESCRIPTION
﻿## Summary
- resolve legacy TTS fallback field-schema arrays through their `default` value
- retain scalar connector values and shared male/female defaults
- prevent valid legacy connector metadata from producing PHP array-to-string warnings or an `Array` voice ID

## Root cause
Older seeded TTS connector rows can store `fallback_male` and `fallback_female` as schema objects. The runtime cast those arrays directly to strings.

## Validation
- PHP lint passed
- PHPUnit: 3 tests, 6 assertions
- live PocketTTS connector assertion now resolves `femalenord`
- no fresh array-to-string warnings observed after hot deployment during the active soak

This overlaps active connector work, so it is intentionally a focused draft PR for manual review.
