### PR TITLE
Reject invalid MoveTo actor targets

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -1723,6 +1723,33 @@ function DataPosibleMoveToTargets()
     return $GLOBALS["CACHE_POSIBLE_MOVETO_TARGETS"];
 }
 
+function chimResolveMoveToActorTarget($target, array $candidateTargets, $playerName = '', $closestTarget = '')
+{
+    $target = trim((string) $target);
+    if ($target === '') {
+        return '';
+    }
+
+    $playerName = trim((string) $playerName);
+    if ($playerName !== '' && strcasecmp($target, $playerName) === 0) {
+        return $playerName;
+    }
+
+    foreach ($candidateTargets as $candidateTarget) {
+        $candidateTarget = trim((string) $candidateTarget);
+        if ($candidateTarget !== '' && strcasecmp($target, $candidateTarget) === 0) {
+            return $candidateTarget;
+        }
+    }
+
+    $closestTarget = trim((string) $closestTarget);
+    if ($closestTarget !== '' && levenshtein(strtolower($target), strtolower($closestTarget)) <= 3) {
+        return $closestTarget;
+    }
+
+    return '';
+}
+
 function DataPosibleLocationsToGoWide()
 {
     if (isset($GLOBALS["CACHE_POSIBLE_LOCATIONS_TO_GO_WIDE"])) {
@@ -6019,30 +6046,17 @@ function call_llm_internal() {
                             $mang4=explode("--",$mang3[0]);
                             
                             $target=trim($mang4[0]);
-                            $resolvedTarget="";
-
-                            if ($target !== "" && isset($GLOBALS["PLAYER_NAME"]) && strcasecmp($target, $GLOBALS["PLAYER_NAME"]) === 0) {
-                                $resolvedTarget=$GLOBALS["PLAYER_NAME"];
-                            }
-
-                            if ($resolvedTarget === "") {
-                                foreach (DataPosibleMoveToTargets() as $candidateTarget) {
-                                    if (strcasecmp($target, $candidateTarget) === 0) {
-                                        $resolvedTarget=$candidateTarget;
-                                        break;
-                                    }
-                                }
-                            }
+                            $resolvedTarget=chimResolveMoveToActorTarget(
+                                $target,
+                                DataPosibleMoveToTargets(),
+                                $GLOBALS["PLAYER_NAME"] ?? '',
+                                FindClosestActorName($target)
+                            );
 
                             if ($resolvedTarget === "") {
-                                $closestTarget=FindClosestActorName($target);
-                                if ($closestTarget !== "" && levenshtein(strtolower($target), strtolower($closestTarget)) <= 3) {
-                                    $resolvedTarget=$closestTarget;
-                                }
-                            }
-
-                            if ($resolvedTarget === "") {
-                                $resolvedTarget=$target;
+                                error_log("[ACTION POSTFILTER MoveTo] Dropping unresolved actor target: $localtarget");
+                                unset($actions[$n]);
+                                continue;
                             }
 
                             error_log("[ACTION POSTFILTER MoveTo] $localtarget => $target => $resolvedTarget");

--- a/unittests/tests/MoveToTargetGuardTest.php
+++ b/unittests/tests/MoveToTargetGuardTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/data_functions.php';
+
+final class MoveToTargetGuardTest extends TestCase
+{
+    public function testExactVisibleActorIsAccepted(): void
+    {
+        $this->assertSame(
+            'Camilla Valerius',
+            chimResolveMoveToActorTarget(
+                'camilla valerius',
+                ['Alvor', 'Camilla Valerius'],
+                'RANGROO',
+                ''
+            )
+        );
+    }
+
+    public function testPlayerIsAcceptedWithoutNearbyActorEntry(): void
+    {
+        $this->assertSame(
+            'RANGROO',
+            chimResolveMoveToActorTarget('rangroo', [], 'RANGROO', '')
+        );
+    }
+
+    public function testSmallActorNameTypoUsesClosestMatch(): void
+    {
+        $this->assertSame(
+            'Faendal',
+            chimResolveMoveToActorTarget('Faendall', ['Alvor'], 'RANGROO', 'Faendal')
+        );
+    }
+
+    public function testUnresolvedPlaceOrObjectIsRejected(): void
+    {
+        $this->assertSame(
+            '',
+            chimResolveMoveToActorTarget(
+                'Blacksmith Forge',
+                ['Alvor', 'Camilla Valerius'],
+                'RANGROO',
+                'Alvor'
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- reject `MoveTo` actions whose target cannot be resolved to the player or a visible nearby actor
- preserve exact actor targets, explicit RefID targets, and small actor-name typo correction
- prevent unsupported place/object strings from opening confirmation dialogs or reaching the Skyrim plugin

## Evidence
An unattended Background Life soak produced `MoveTo@Blacksmith Forge`. After approval, CHIM logged `target Blacksmith Forge not found`, leaving the requested action ineffective. Current `unstable` passed unresolved strings through unchanged.

## Validation
- `php -l lib/data_functions.php`
- `php -l unittests/tests/MoveToTargetGuardTest.php`
- focused PHPUnit: 6 tests, 8 assertions passed
- full PHPUnit attempted; environment-dependent database fixtures failed to connect and the Windows PHP runtime lacks `ZipArchive`
- hot-deployed to the active local soak: PHP lint passed, event heartbeat remained live, pending responses stayed at zero, and Skyrim remained responsive

## Deployment
Hot-deployed locally for the ongoing no-restart soak. In-game regression monitoring remains active.