### PR TITLE
Normalize generic action target parameters

### DIFF
--- a/functions/functions.php
+++ b/functions/functions.php
@@ -2,6 +2,7 @@
 
 // Functions to be provided to OpenAI
 $startTime=$GLOBALS["startTime"] ?? microtime(true);
+require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'function_parameter_normalization.php';
 
 if (!function_exists('chimTraceFunctionsIncludePhase')) {
     function chimTraceFunctionsIncludePhase($line, $label, $startTime)
@@ -2418,6 +2419,8 @@ function functionExecutionParameterValueIsEmpty($parameterValue)
 function buildFunctionParameterValueFromResponse($functionDef, $parsedResponse)
 {
     $properties = $functionDef["parameters"]["properties"] ?? [];
+    $normalizedResponse = herikaNormalizeFunctionResponseArguments($properties, $parsedResponse);
+
     $requiredParameters = [];
     foreach (($functionDef["parameters"]["required"] ?? []) as $requiredParameter) {
         $requiredParameter = trim(strval($requiredParameter));
@@ -2428,7 +2431,7 @@ function buildFunctionParameterValueFromResponse($functionDef, $parsedResponse)
 
     $missingRequiredParameters = [];
     foreach ($requiredParameters as $requiredParameter) {
-        if (!array_key_exists($requiredParameter, $parsedResponse) || $parsedResponse[$requiredParameter] === "" || $parsedResponse[$requiredParameter] === null) {
+        if (!array_key_exists($requiredParameter, $normalizedResponse) || $normalizedResponse[$requiredParameter] === "" || $normalizedResponse[$requiredParameter] === null) {
             $missingRequiredParameters[] = $requiredParameter;
         }
     }
@@ -2436,8 +2439,8 @@ function buildFunctionParameterValueFromResponse($functionDef, $parsedResponse)
     if (count($properties) > 1) {
         $parameters = [];
         foreach ($properties as $parameterName => $parameterSchema) {
-            if (array_key_exists($parameterName, $parsedResponse)) {
-                $parameters[$parameterName] = normalizeFunctionParameterValueFromSchema($parameterSchema, $parsedResponse[$parameterName]);
+            if (array_key_exists($parameterName, $normalizedResponse)) {
+                $parameters[$parameterName] = normalizeFunctionParameterValueFromSchema($parameterSchema, $normalizedResponse[$parameterName]);
             }
         }
 
@@ -2448,7 +2451,7 @@ function buildFunctionParameterValueFromResponse($functionDef, $parsedResponse)
     }
 
     return [
-        "parameter_value" => getSingleFunctionParameterValue($functionDef, $parsedResponse),
+        "parameter_value" => getSingleFunctionParameterValue($functionDef, $normalizedResponse),
         "missing_required" => $missingRequiredParameters,
     ];
 }

--- a/lib/function_parameter_normalization.php
+++ b/lib/function_parameter_normalization.php
@@ -1,0 +1,25 @@
+<?php
+
+if (!function_exists('herikaNormalizeFunctionResponseArguments')) {
+    function herikaNormalizeFunctionResponseArguments(array $properties, array $parsedResponse): array
+    {
+        if (count($properties) !== 1) {
+            return $parsedResponse;
+        }
+
+        $parameterName = array_key_first($properties);
+        if (
+            !is_string($parameterName)
+            || $parameterName === 'target'
+            || array_key_exists($parameterName, $parsedResponse)
+            || !array_key_exists('target', $parsedResponse)
+        ) {
+            return $parsedResponse;
+        }
+
+        // Dialogue JSON exposes one generic target field even when the action
+        // schema gives its sole argument a more specific name.
+        $parsedResponse[$parameterName] = $parsedResponse['target'];
+        return $parsedResponse;
+    }
+}

--- a/unittests/tests/FunctionParameterAliasTest.php
+++ b/unittests/tests/FunctionParameterAliasTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__
+    .DIRECTORY_SEPARATOR.'..'
+    .DIRECTORY_SEPARATOR.'..'
+    .DIRECTORY_SEPARATOR.'lib'
+    .DIRECTORY_SEPARATOR.'function_parameter_normalization.php';
+
+final class FunctionParameterAliasTest extends TestCase
+{
+    private array $travelProperties = [
+        'location' => [
+            'type' => 'string',
+        ],
+    ];
+
+    public function testGenericTargetMapsToSingleNamedLocationParameter(): void
+    {
+        $normalized = herikaNormalizeFunctionResponseArguments(
+            $this->travelProperties,
+            ['action' => 'Travel_To', 'target' => 'Riverwood']
+        );
+
+        $this->assertSame('Riverwood', $normalized['location']);
+        $this->assertSame('Riverwood', $normalized['target']);
+    }
+
+    public function testEmptyGenericTargetRemainsEmptyAfterMapping(): void
+    {
+        $normalized = herikaNormalizeFunctionResponseArguments(
+            $this->travelProperties,
+            ['action' => 'Travel_To', 'target' => '']
+        );
+
+        $this->assertSame('', $normalized['location']);
+    }
+
+    public function testExplicitNamedParameterIsNotOverwritten(): void
+    {
+        $normalized = herikaNormalizeFunctionResponseArguments(
+            $this->travelProperties,
+            ['target' => 'Riverwood', 'location' => 'Whiterun']
+        );
+
+        $this->assertSame('Whiterun', $normalized['location']);
+    }
+
+    public function testMultiParameterSchemaKeepsGenericResponseUnchanged(): void
+    {
+        $response = ['target' => 'RANGROO', 'amount' => 50];
+        $normalized = herikaNormalizeFunctionResponseArguments(
+            [
+                'target' => ['type' => 'string'],
+                'amount' => ['type' => 'integer'],
+            ],
+            $response
+        );
+
+        $this->assertSame($response, $normalized);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize the generic structured-response `target` into an action schema's sole named parameter
- keep explicit named parameters authoritative
- preserve rejection when the destination is actually empty

## Reproduction
The unattended Background Life soak produced a valid `Travel_To` response with `target: Riverwood`. It dispatched successfully through fallback handling but logged `Missing required parameter(s) for TravelTo: location`. A second response with an empty target was correctly rejected.

## Validation
- PHP lint: changed source, helper, and test files
- PHPUnit: `FunctionParameterAliasTest` (4 tests, 5 assertions)
- `git diff --check`
- hot-deployed to the local HerikaServer without restarting Skyrim
- live soak remained healthy after deployment

## Notes
The full PHPUnit bootstrap currently has an unrelated baseline failure because `db_updates.php` calls `sql::escapeLiteral()` while the test SQL shim does not expose it. The new regression test is intentionally database-independent.