### PR TITLE
Prevent duplicate background processor daemons

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+service/start.sh text eol=lf

--- a/service/start.sh
+++ b/service/start.sh
@@ -4,9 +4,30 @@ PORT=12345
 SERVICE_LOG="/var/www/html/HerikaServer/log/service.log"
 FALLBACK_SERVICE_LOG="/tmp/herika_service.log"
 LOG_DIR="$(dirname "$SERVICE_LOG")"
+LOCK_FILE="/tmp/herika_background_processor.lock"
 
 # Ensure new files are group-readable/writable for dwemer + www-data workflows.
 umask 0002
+
+# The TCP probe alone is racy: concurrent auto-start requests can all pass
+# before any listener binds. Hold this lock for the daemon's entire lifetime.
+if ! command -v flock >/dev/null 2>&1; then
+    echo "Cannot start background processor: flock is unavailable."
+    exit 1
+fi
+touch "$LOCK_FILE" 2>/dev/null || {
+    echo "Cannot create background processor lock file: $LOCK_FILE"
+    exit 1
+}
+chmod 0666 "$LOCK_FILE" 2>/dev/null || true
+exec 9>"$LOCK_FILE" || {
+    echo "Cannot open background processor lock file: $LOCK_FILE"
+    exit 1
+}
+if ! flock -n 9; then
+    echo "An instance of the background processor is already running."
+    exit 0
+fi
 
 mkdir -p "$LOG_DIR" 2>/dev/null
 if ! touch "$SERVICE_LOG" 2>/dev/null; then

--- a/unittests/tests/BackgroundProcessorSingletonTest.php
+++ b/unittests/tests/BackgroundProcessorSingletonTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class BackgroundProcessorSingletonTest extends TestCase
+{
+    private string $script;
+
+    protected function setUp(): void
+    {
+        $path = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'service' . DIRECTORY_SEPARATOR . 'start.sh';
+        $script = file_get_contents($path);
+        $this->assertIsString($script);
+        $this->script = $script;
+    }
+
+    public function testAcquiresProcessLifetimeLockBeforePortProbe(): void
+    {
+        $lockPosition = strpos($this->script, 'flock -n 9');
+        $portProbePosition = strpos($this->script, 'nc -z localhost');
+
+        $this->assertNotFalse($lockPosition);
+        $this->assertNotFalse($portProbePosition);
+        $this->assertLessThan($portProbePosition, $lockPosition);
+        $this->assertStringContainsString('exec 9>"$LOCK_FILE"', $this->script);
+    }
+
+    public function testFailsClosedWhenFlockIsUnavailable(): void
+    {
+        $this->assertStringContainsString('command -v flock', $this->script);
+        $this->assertStringContainsString(
+            'Cannot start background processor: flock is unavailable.',
+            $this->script
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add a process-lifetime `flock` guard before the background processor port probe
- prevent concurrent auto-start requests from creating parallel manager loops
- fail closed when the lock primitive or lock file is unavailable
- keep `service/start.sh` checked out with LF line endings on Windows
- add a focused regression test for lock ordering and fail-closed behavior

## Confirmed failure

The live runtime had three independent `service/start.sh` daemon families. The existing `nc -z` check was not atomic, so concurrent startup requests could all pass before a listener bound port 12345. Each daemon then launched the full manager loop, causing repeated Background Life scans and overlapping middle-term work.

## Validation

- `bash -n service/start.sh`
- PHP lint passed for `BackgroundProcessorSingletonTest.php`
- focused PHPUnit: 7 tests, 14 assertions passed
- live deployment reproduced three daemon families before restart
- two concurrent startup contenders now exit cleanly with `already running`
- one daemon family retained the lock and heartbeat port through repeated manager intervals
- manager cadence returned to one pass every 5-6 seconds with no overlap skips during observation
- active CHIM systems harness remained healthy: 6 active actors, 0 failed actors, 0 pending responses
- Skyrim remained running and responsive; no game restart was performed

The repository-wide PHPUnit command exceeded the 120-second command window and was terminated; the focused service and Background Life tests passed.

## Local deployment

Deployed only `service/start.sh` to the local HerikaServer runtime and restarted only the background processor. No plugin binary, game process, database, or user configuration was replaced.