### PR TITLE
Fix false warnings in Global Connector tests

### DIFF
--- a/ui/api/profile_connector_tests.php
+++ b/ui/api/profile_connector_tests.php
@@ -420,6 +420,7 @@ function profileConnectorTestsTestLlm(int $connectorId): array
         $GLOBALS["DEBUG_DATA"] = [];
         $GLOBALS["FUNCTIONS_ARE_ENABLED"] = false;
         $GLOBALS["PATCH_PROMPT_ENFORCE_ACTIONS"] = false;
+        $GLOBALS["COMMAND_PROMPT"] = '';
         $GLOBALS["COMMAND_PROMPT_ENFORCE_ACTIONS"] = '';
 
         $llm->setOldGlobals($connector);

--- a/unittests/tests/ProfileConnectorTestsRegressionTest.php
+++ b/unittests/tests/ProfileConnectorTestsRegressionTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ProfileConnectorTestsRegressionTest extends TestCase
+{
+    public function testLlmHealthCheckInitializesCommandPrompt(): void
+    {
+        $source = file_get_contents(
+            dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'ui' . DIRECTORY_SEPARATOR . 'api' .
+            DIRECTORY_SEPARATOR . 'profile_connector_tests.php'
+        );
+
+        $start = strpos($source, 'function profileConnectorTestsTestLlm');
+        $end = strpos($source, 'function profileConnectorTestsTestTts', $start);
+        $llmTestFunction = substr($source, $start, $end - $start);
+
+        $this->assertStringContainsString('$GLOBALS["COMMAND_PROMPT"] = \'\';', $llmTestFunction);
+    }
+}


### PR DESCRIPTION
﻿## Summary

- initialize the test-only command prompt global before exercising LLM connectors
- add a focused regression test for the Global Connector health-check setup

## Root cause

The Global Connector health check initialized the action-prompt global but not `$COMMAND_PROMPT`. Connector drivers still returned successful responses, but PHP emitted an undefined-global warning, so the UI mislabeled every successful LLM check as a warning.

## Validation

- `php -l ui/api/profile_connector_tests.php`
- `php -l unittests/tests/ProfileConnectorTestsRegressionTest.php`
- `php vendor/bin/phpunit --filter ProfileConnectorTestsRegressionTest` ? 1 test, 1 assertion passed
- `git diff --check`

## Deployment

Not deployed locally. The installed Herika deployment workflow is bound to the canonical monorepo checkout and full CHIM deployment, so it cannot safely deploy this isolated feature worktree.

Discord source: [Open Discord thread](https://discord.com/channels/1109612896482246826/1530677104818262048/1530677104818262048)
