### PR TITLE
Deduplicate identical Oghma lore payloads

### DIFF
--- a/lib/oghma_forced_context.php
+++ b/lib/oghma_forced_context.php
@@ -320,6 +320,32 @@ if (!function_exists('chimOghmaMarkTopicInjected')) {
     }
 }
 
+if (!function_exists('chimOghmaPayloadFingerprint')) {
+    function chimOghmaPayloadFingerprint($description): string
+    {
+        $normalized = trim((string) preg_replace('/\s+/u', ' ', trim((string) $description)));
+        return $normalized === '' ? '' : hash('sha256', strtolower($normalized));
+    }
+}
+
+if (!function_exists('chimOghmaPayloadWasInjected')) {
+    function chimOghmaPayloadWasInjected($description): bool
+    {
+        $fingerprint = chimOghmaPayloadFingerprint($description);
+        return $fingerprint !== '' && !empty($GLOBALS['OGHMA_INJECTED_PAYLOADS'][$fingerprint]);
+    }
+}
+
+if (!function_exists('chimOghmaMarkPayloadInjected')) {
+    function chimOghmaMarkPayloadInjected($description): void
+    {
+        $fingerprint = chimOghmaPayloadFingerprint($description);
+        if ($fingerprint !== '') {
+            $GLOBALS['OGHMA_INJECTED_PAYLOADS'][$fingerprint] = true;
+        }
+    }
+}
+
 if (!function_exists('chimOghmaAppendForcedRows')) {
     function chimOghmaAppendForcedRows(array $rows, array $knowledgeTags, string $source, int $limit): int
     {
@@ -334,10 +360,19 @@ if (!function_exists('chimOghmaAppendForcedRows')) {
             }
 
             $topic = trim((string) ($row['topic'] ?? ''));
+            if (chimOghmaPayloadWasInjected($payload['description'])) {
+                chimOghmaMarkTopicInjected($topic);
+                if (class_exists('Logger')) {
+                    Logger::info("[OGHMA] Skipped duplicate {$source} article content: {$topic}");
+                }
+                continue;
+            }
+
             $levelText = $payload['level'] === 'advanced'
                 ? 'You have advanced knowledge on this subject, you can use it in your dialogue'
                 : 'You only have basic knowledge on this subject, you can use it in your dialogue';
             $GLOBALS['OGHMA_HINT'] .= " \n#Lore Information ({$levelText}): {$topic}\n\"{$payload['description']}\"";
+            chimOghmaMarkPayloadInjected($payload['description']);
             chimOghmaMarkTopicInjected($topic);
             $added++;
             if (class_exists('Logger')) {

--- a/processor/oghma.php
+++ b/processor/oghma.php
@@ -2,6 +2,7 @@
 
 $GLOBALS["OGHMA_HINT"] = "";
 $GLOBALS["OGHMA_INJECTED_TOPICS"] = [];
+$GLOBALS["OGHMA_INJECTED_PAYLOADS"] = [];
 
 // Helper function to properly check boolean values (handles string "false" from form submissions)
 // Guard against redeclaration when oghma.php is included multiple times (e.g., during rechat)
@@ -268,7 +269,14 @@ if ($minimeEnabled || $oghmaCustomEnabled) {
 
                                 if ($advancedAllowed) {
                                     // The user can access advanced lore
-                                    $GLOBALS["OGHMA_HINT"] .= " \n#Lore Information (You have advanced knowledge on this subject, you can use it in your dialogue):{$topTopic["topic"]}\n\"".trim($topTopic["topic_desc"])."\"";
+                                    $description = trim((string) ($topTopic["topic_desc"] ?? ''));
+                                    if (!chimOghmaPayloadWasInjected($description)) {
+                                        $GLOBALS["OGHMA_HINT"] .= " \n#Lore Information (You have advanced knowledge on this subject, you can use it in your dialogue):{$topTopic["topic"]}\n\"{$description}\"";
+                                        chimOghmaMarkPayloadInjected($description);
+                                    } else {
+                                        $msg = "oghma keyword duplicate content already injected";
+                                        chimOghmaMarkTopicInjected($topTopic["topic"] ?? '');
+                                    }
                                 } else {
                                     // -----------------------------
                                     // 2) Check basic article
@@ -303,7 +311,14 @@ if ($minimeEnabled || $oghmaCustomEnabled) {
                                     }
 
                                     if ($basicAllowed) {
-                                        $GLOBALS["OGHMA_HINT"] .= " \n#Lore Information (You only have basic knowledge on this subject, you can use it in your dialogue): {$topTopic["topic"]}\n\"".trim($topTopic["topic_desc_basic"])."\"";
+                                        $description = trim((string) ($topTopic["topic_desc_basic"] ?? ''));
+                                        if (!chimOghmaPayloadWasInjected($description)) {
+                                            $GLOBALS["OGHMA_HINT"] .= " \n#Lore Information (You only have basic knowledge on this subject, you can use it in your dialogue): {$topTopic["topic"]}\n\"{$description}\"";
+                                            chimOghmaMarkPayloadInjected($description);
+                                        } else {
+                                            $msg = "oghma keyword duplicate content already injected";
+                                            chimOghmaMarkTopicInjected($topTopic["topic"] ?? '');
+                                        }
                                     } else {
                                         $GLOBALS["OGHMA_HINT"] .= " \n#Lore Information\nYou do not know ANYTHING about {$topTopic["topic"]}";
                                     }

--- a/unittests/tests/OghmaForcedContextTest.php
+++ b/unittests/tests/OghmaForcedContextTest.php
@@ -42,6 +42,30 @@ final class OghmaForcedContextTest extends TestCase
         $this->assertFalse(chimOghmaTopicWasInjected('bosmer'));
     }
 
+    public function testDifferentTopicsWithIdenticalLoreAreInjectedOnlyOnce(): void
+    {
+        $GLOBALS['OGHMA_HINT'] = '';
+        $GLOBALS['OGHMA_INJECTED_TOPICS'] = [];
+        $GLOBALS['OGHMA_INJECTED_PAYLOADS'] = [];
+        $rows = [
+            [
+                'topic' => 'bosmer',
+                'topic_desc' => 'Wood Elves are native to Valenwood.',
+                'knowledge_class' => '',
+            ],
+            [
+                'topic' => 'wood_elf',
+                'topic_desc' => "  Wood Elves are native\n to Valenwood.  ",
+                'knowledge_class' => '',
+            ],
+        ];
+
+        $this->assertSame(1, chimOghmaAppendForcedRows($rows, [], 'racial', 4));
+        $this->assertSame(1, substr_count($GLOBALS['OGHMA_HINT'], 'Wood Elves are native'));
+        $this->assertTrue(chimOghmaTopicWasInjected('bosmer'));
+        $this->assertTrue(chimOghmaTopicWasInjected('wood elf'));
+    }
+
     public function testCanonicalHoldSignalsIncludeTheLoreTopicAlias(): void
     {
         $this->assertSame(


### PR DESCRIPTION
﻿## Summary

- Deduplicate Oghma articles by normalized lore payload, not only by topic alias.
- Mark duplicate topics as handled so later scene-context searches do not reinsert the same lore.
- Apply the same payload registry to forced race/location context and normal Oghma keyword results.

## Evidence

A seven-hour Background Life soak injected both `bosmer` and `wood_elf` rows for Faendal even though their basic and advanced lore payloads were identical. Topic-alias deduplication could not catch separate database rows with the same content.

## Validation

- PHP lint passed for all 3 changed files.
- Focused Oghma suite: **17 tests, 47 assertions**.
- New regression test verifies differently named articles with whitespace-equivalent lore are injected once.
- The broader `--filter Oghma` run reached 17 passing tests before the existing database-backed `OghmaTest` bootstrap failed on missing `sql::escapeLiteral()`.
- Not deployed during the soak because changing the live runtime would invalidate the baseline.

## Scope

No schema changes, generated assets, harness files, logs, databases, or binaries are included.



## Related soak follow-up

- CHIM log-volume fix: https://github.com/Dwemer-Dynamics/CHIM/pull/93

