### PR TITLE
Ground bored events in nearby NPC context

### DIFF
--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -7531,6 +7531,34 @@ if ($checkVersion("prompts") < 20260719001) {
     Logger::info("Applied patch prompts 20260719001 - improved book reading prompt");
 }
 
+if ($checkVersion("prompts") < 20260727001) {
+    Logger::debug("Applying prompts 20260727001 - add bored event director rules");
+
+    require_once(__DIR__ . "/../lib/rolemaster_bored.php");
+    $boredEventRules = $db->escape(chimRolemasterDefaultBoredEventRules());
+    $description = $db->escape(
+        "Additional Rolemaster rules used only for autonomous bored events. "
+        . "Supports {SEED_ACTOR_RULE}, {SEED_ACTOR}, {NEARBY_ACTORS}, and {PLAYER_NAME} placeholders. "
+        . "Used in: service/processors/rolemaster/cmd/instruction.php"
+    );
+
+    $migrationOk = $db->execQuery("
+        INSERT INTO public.prompts (prompt_key, default_prompt, description)
+        VALUES ('director_bored_event_rules', '{$boredEventRules}', '{$description}')
+        ON CONFLICT (prompt_key) DO UPDATE SET
+            default_prompt = EXCLUDED.default_prompt,
+            description = EXCLUDED.description,
+            updated_at = CURRENT_TIMESTAMP
+    ") !== false;
+
+    if ($migrationOk) {
+        $updateVersion("prompts", 20260727001);
+        Logger::info("Applied patch prompts 20260727001 - added bored event director rules");
+    } else {
+        Logger::error("Failed to apply patch prompts 20260727001");
+    }
+}
+
 if ($checkVersion("memory_summary") < 20260721001) {
     Logger::debug("Applying memory_summary 20260721001 - normalize diary memory owners");
 

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -2820,6 +2820,41 @@ function chimMergePeoplePipeLists()
     return normalizePeoplePipeList($names);
 }
 
+function chimBuildDirectivePeoplePipe($nearbyPeople, $speakerName, $instructionText)
+{
+    $speakerPeople = normalizePeoplePipeList([(string)$speakerName]);
+    $listenerPeople = "";
+    $listenerName = "";
+
+    if (preg_match(
+        '/\bThe dialogue listener must be\s+([^\r\n.]+)\.(?:\s|$)/iu',
+        (string)$instructionText,
+        $matches
+    )) {
+        $listenerName = html_entity_decode(
+            trim((string)($matches[1] ?? "")),
+            ENT_QUOTES | ENT_HTML5,
+            "UTF-8"
+        );
+    } elseif (preg_match(
+        '/\(must use ACTION\s+(?:JustTalk|Talk)\s+([^)]+)\)/iu',
+        (string)$instructionText,
+        $matches
+    )) {
+        $listenerName = html_entity_decode(
+            trim((string)($matches[1] ?? "")),
+            ENT_QUOTES | ENT_HTML5,
+            "UTF-8"
+        );
+    }
+
+    if ($listenerName !== "" && strcasecmp($listenerName, "everyone") !== 0) {
+        $listenerPeople = normalizePeoplePipeList([$listenerName]);
+    }
+
+    return chimMergePeoplePipeLists($nearbyPeople, $speakerPeople, $listenerPeople);
+}
+
 function chimSetCurrentTurnPresentActorsSnapshot($actors)
 {
     $normalized = chimNormalizePresentActors($actors);

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -1753,7 +1753,12 @@ function returnLines($lines,$writeOutput=true)
                 $addonlistener="";
             }
             $originalRequest[3]="{$outBuffer["actor"]}: $responseForContext $addonlistener";
-            logEvent($originalRequest);
+            $dialogueEventPeople = chimBuildDialogueEventPeoplePipe(
+                chimGetCurrentTurnPeopleSnapshot(),
+                $outBuffer["actor"] ?? "",
+                $GLOBALS["SCRIPTLINE_LISTENER_ATOMIC"] ?? ""
+            );
+            logEvent($originalRequest, $dialogueEventPeople);
             
             // Log chat here, because  function return comes back out of sync.
             $originalRequest[0]="chat";
@@ -1778,7 +1783,7 @@ function returnLines($lines,$writeOutput=true)
                 'utterance_id' => $GLOBALS["SCRIPTLINE_UTTERANCE_ID"] ?? chimGenerateUtteranceId(),
                 'delivery_state' => 'emitted'
             ];
-            logEvent($originalRequest);
+            logEvent($originalRequest, $dialogueEventPeople);
         }
         
     }
@@ -2853,6 +2858,14 @@ function chimBuildDirectivePeoplePipe($nearbyPeople, $speakerName, $instructionT
     }
 
     return chimMergePeoplePipeLists($nearbyPeople, $speakerPeople, $listenerPeople);
+}
+
+function chimBuildDialogueEventPeoplePipe($turnPeople, $speakerName, $listenerName)
+{
+    return chimMergePeoplePipeLists(
+        $turnPeople,
+        normalizePeoplePipeList([(string)$speakerName, (string)$listenerName])
+    );
 }
 
 function chimSetCurrentTurnPresentActorsSnapshot($actors)

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -962,12 +962,12 @@ function DataLastDataFor($actor, $lastNelements = -10)
 /**
  * Get context for actor to send to llm
  */
-function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescriptions=false,$excludeBusy=false)
+function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescriptions=false,$excludeBusy=false,$excludeFarAway=false)
 {
     
     $lastDialog = array(); // Initialize the return array
     $followers=[];
-    $actorsInRangeList=DataBeingsInCloseRange();
+    $actorsInRangeList=DataBeingsInCloseRange($excludeFarAway);
     $actorsInRange=strtr($actorsInRangeList,["|"=>"\n* "]);
     $actorDetailedList=explode("|",$actorsInRangeList);
     // Not always the same order
@@ -1549,7 +1549,7 @@ function DataLastInfoFor($actorBeingCalled, $lastNelements = -2,$addNPCDescripti
         
     // This is intended to give info about nearby actors, ALL actors (dead ones included).
 
-    $nearbyActors=DataBeingsOrDeathsInRangeExcluding("",true);
+    $nearbyActors=$excludeFarAway ? trim($actorsInRangeList, "|") : DataBeingsOrDeathsInRangeExcluding("",true);
     $nearbyActorsList=[];
     if ($nearbyActors) {
         foreach (explode("|",$nearbyActors) as $k=>$v) {

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -4530,7 +4530,7 @@ function chimDataStripActorStateSuffix($name)
     return trim((string)$name);
 }
 
-function chimDataActorStatusBlocksCloseRange($token)
+function chimDataActorStatusBlocksCloseRange($token, $includeBusy = false)
 {
     if (!preg_match('/\s*\(([^()]*)\)\s*$/u', (string)$token, $matches)) {
         return false;
@@ -4545,10 +4545,14 @@ function chimDataActorStatusBlocksCloseRange($token)
         return false;
     }
 
+    if ($includeBusy && $status === "busy") {
+        return false;
+    }
+
     return preg_match('/^(?:busy|hostile|in combat|far away|too far away|restrained|dead|disabled|unavailable|checking|can[\'"]?t hear you|no target|no crosshair target)/i', $status) === 1;
 }
 
-function DataBeingsInCloseRange($excludeFarAway=false)
+function DataBeingsInCloseRange($excludeFarAway=false, $includeBusy=false)
 {
 
     global $db;
@@ -4572,7 +4576,7 @@ function DataBeingsInCloseRange($excludeFarAway=false)
         $beingsArrayNew=[];
         foreach ($beingsArray as $k=>$v) {
             $v = trim((string)$v);
-            if ($excludeFarAway && chimDataActorStatusBlocksCloseRange($v))
+            if ($excludeFarAway && chimDataActorStatusBlocksCloseRange($v, $includeBusy))
                 continue;
             if (preg_match('/\((?:dead|disabled)\)\s*$/i', $v)) //??
                 continue;

--- a/lib/rolemaster_bored.php
+++ b/lib/rolemaster_bored.php
@@ -79,3 +79,41 @@ function chimRolemasterBoredListenerRequirement(string $target, array $actorMap)
 
     return " The dialogue listener must be {$canonicalTarget}.";
 }
+
+function chimRolemasterDefaultBoredEventRules(): string
+{
+    return <<<'PROMPT'
+# Bored event rules
+{SEED_ACTOR_RULE}
+* Only use speakers from this nearby eligible actor list: {NEARBY_ACTORS}.
+* Do not invent distant or off-scene actors.
+* Do not target or comment on {PLAYER_NAME} merely because time passed or the player is idle.
+* Prefer a natural NPC-to-NPC interaction or scene action. Involve the player only when recent player activity clearly requires a response.
+* When an instruction targets another nearby actor, direct the dialogue to that actor.
+PROMPT;
+}
+
+function chimRolemasterRenderBoredEventRules(
+    string $template,
+    string $seedActor,
+    string $playerName,
+    array $actorMap
+): string {
+    if (trim($template) === '') {
+        $template = chimRolemasterDefaultBoredEventRules();
+    }
+
+    $seedActor = trim($seedActor);
+    $seedActorRule = $seedActor === ''
+        ? ''
+        : "* The first instruction must use the selected initiating actor: {$seedActor}.";
+    $nearbyActors = implode(', ', array_values($actorMap));
+
+    $rendered = str_replace(
+        ['{SEED_ACTOR_RULE}', '{SEED_ACTOR}', '{NEARBY_ACTORS}', '{PLAYER_NAME}'],
+        [$seedActorRule, $seedActor, $nearbyActors, $playerName],
+        $template
+    );
+
+    return trim((string)preg_replace("/\n{3,}/", "\n\n", $rendered));
+}

--- a/lib/rolemaster_bored.php
+++ b/lib/rolemaster_bored.php
@@ -1,0 +1,81 @@
+<?php
+
+function chimRolemasterBoredActorKey(string $actorName): string
+{
+    return function_exists('mb_strtolower')
+        ? mb_strtolower($actorName, 'UTF-8')
+        : strtolower($actorName);
+}
+
+function chimRolemasterBoredActorMap(string $actorsInRange, string $playerName = '', string $seedActor = ''): array
+{
+    $actors = [];
+    foreach (preg_split('/[|\/]/', $actorsInRange) ?: [] as $actor) {
+        $actor = trim($actor);
+        if ($actor === '' || ($playerName !== '' && strcasecmp($actor, $playerName) === 0)) {
+            continue;
+        }
+        $actors[chimRolemasterBoredActorKey($actor)] = $actor;
+    }
+
+    $seedActor = trim($seedActor);
+    if ($seedActor !== '' && ($playerName === '' || strcasecmp($seedActor, $playerName) !== 0)) {
+        $actors[chimRolemasterBoredActorKey($seedActor)] = $seedActor;
+    }
+
+    return $actors;
+}
+
+function chimRolemasterBoredCanonicalActor(string $actorName, array $actorMap): ?string
+{
+    $actorName = trim($actorName);
+    if ($actorName === '') {
+        return null;
+    }
+
+    return $actorMap[chimRolemasterBoredActorKey($actorName)] ?? null;
+}
+
+function chimRolemasterFilterBoredInstructions(array $instructions, array $actorMap, string $seedActor): array
+{
+    $valid = [];
+    $seedInstruction = null;
+
+    foreach ($instructions as $instruction) {
+        if (!is_array($instruction)) {
+            continue;
+        }
+
+        $canonicalActor = chimRolemasterBoredCanonicalActor((string)($instruction['character'] ?? ''), $actorMap);
+        if ($canonicalActor === null) {
+            continue;
+        }
+
+        $instruction['character'] = $canonicalActor;
+        if ($seedActor !== '' && strcasecmp($canonicalActor, $seedActor) === 0) {
+            $seedInstruction = $instruction;
+        } else {
+            $valid[] = $instruction;
+        }
+    }
+
+    if ($seedActor !== '' && $seedInstruction === null) {
+        return [];
+    }
+
+    if ($seedInstruction !== null) {
+        array_unshift($valid, $seedInstruction);
+    }
+
+    return $valid;
+}
+
+function chimRolemasterBoredListenerRequirement(string $target, array $actorMap): string
+{
+    $canonicalTarget = chimRolemasterBoredCanonicalActor($target, $actorMap);
+    if ($canonicalTarget === null) {
+        return '';
+    }
+
+    return " The dialogue listener must be {$canonicalTarget}.";
+}

--- a/main.php
+++ b/main.php
@@ -996,8 +996,18 @@ if (in_array($gameRequest[0],["bored"])) {
     if (!empty($GLOBALS["NARRATOR_BORED_EVENT_ACTIVE"])) {
         Logger::info("[NARRATOR_BORED] Using narrator bored flow");
     } elseif ((isset($GLOBALS["BORED_EVENT_SERVERSIDE"])&&($GLOBALS["BORED_EVENT_SERVERSIDE"]))) {
-        Logger::info("Redirecting bored event to rolemaster");
-        `php service/manager.php rolemaster instruction ""`;
+        $boredSeedActor = trim((string)($gameRequest[4] ?? $GLOBALS["HERIKA_NAME"] ?? ""));
+        Logger::info("Redirecting bored event to rolemaster with seed actor '{$boredSeedActor}'");
+        $phpCli = PHP_BINDIR . DIRECTORY_SEPARATOR . "php";
+        $managerPath = __DIR__ . DIRECTORY_SEPARATOR . "service" . DIRECTORY_SEPARATOR . "manager.php";
+        $command = escapeshellarg($phpCli)
+            . " " . escapeshellarg($managerPath)
+            . " rolemaster instruction " . escapeshellarg("")
+            . " bored " . escapeshellarg($boredSeedActor);
+        exec($command, $output, $returnCode);
+        if ($returnCode !== 0) {
+            Logger::warn("Failed to start bored rolemaster request (exit code {$returnCode})");
+        }
         terminate();
 
     }

--- a/main.php
+++ b/main.php
@@ -1739,7 +1739,18 @@ if (($gameRequest[0] ?? "") === "rechat" && isset($GLOBALS["RECHAT_RESOLVED_TARG
 $authoritativePeople = $hasAuthoritativeRequestAudience ? $requestAudienceSnapshot : $resolvedRechatPeople;
 $directiveFallbackPeople = "";
 if ($authoritativePeople === "" && in_array($gameRequest[0] ?? "", $directiveDialogueEventTypes, true)) {
-    $directiveFallbackPeople = DataBeingsInCloseRange(true);
+    // Busy actors remain physically present even though Rolemaster must not
+    // select them as new speakers.
+    $directiveSpeakerName = trim((string)(
+        $GLOBALS["CHIM_CORE_CURRENT_NPC_DATA"]["npc_name"]
+        ?? $GLOBALS["HERIKA_NAME"]
+        ?? ""
+    ));
+    $directiveFallbackPeople = chimBuildDirectivePeoplePipe(
+        DataBeingsInCloseRange(true, true),
+        $directiveSpeakerName,
+        $gameRequest[3] ?? ""
+    );
 }
 
 if (isWhisperExecutionMode() && in_array($gameRequest[0] ?? "", $playerInputEventTypes, true)) {

--- a/service/processors/rolemaster/cmd/instruction.php
+++ b/service/processors/rolemaster/cmd/instruction.php
@@ -218,15 +218,29 @@ user request: actor \"a\" leaves the place
             $directorInstructionRules
         );
         if ($isBoredInstruction) {
-            $directorInstructionRules .= "\n\n# Bored event rules";
-            if ($boredSeedActor !== "") {
-                $directorInstructionRules .= "\n* The first instruction must use the selected initiating actor: {$boredSeedActor}.";
+            $boredEventRules = null;
+            try {
+                $promptData = $GLOBALS["db"]->fetchOne(
+                    "SELECT custom_prompt, default_prompt FROM prompts WHERE prompt_key = 'director_bored_event_rules'"
+                );
+                if ($promptData) {
+                    $boredEventRules = !empty($promptData['custom_prompt'])
+                        ? $promptData['custom_prompt']
+                        : $promptData['default_prompt'];
+                }
+            } catch (Exception $e) {
+                Logger::warn(
+                    "Failed to load director_bored_event_rules from database, using hardcoded fallback: "
+                    . $e->getMessage()
+                );
             }
-            $directorInstructionRules .= "\n* Only use speakers from the Nearby eligible actors list."
-                . "\n* Do not invent distant or off-scene actors."
-                . "\n* Do not target or comment on {$GLOBALS["PLAYER_NAME"]} merely because time passed or the player is idle."
-                . "\n* Prefer a natural NPC-to-NPC interaction or scene action. Involve the player only when recent player activity clearly requires a response."
-                . "\n* When an instruction targets another nearby actor, direct the dialogue to that actor.";
+
+            $directorInstructionRules .= "\n\n" . chimRolemasterRenderBoredEventRules(
+                (string)$boredEventRules,
+                $boredSeedActor,
+                (string)$GLOBALS["PLAYER_NAME"],
+                $GLOBALS["ROLEMASTER_BORED_ALLOWED_ACTORS"] ?? []
+            );
         }
         
         // Database Prompt (Director)

--- a/service/processors/rolemaster/cmd/instruction.php
+++ b/service/processors/rolemaster/cmd/instruction.php
@@ -25,6 +25,11 @@ $GLOBALS["CURRENT_CONNECTOR"]=$currentConnectorData["driver"];
 
 $connector->setOldGlobals($currentConnectorData);
 
+$isBoredInstruction = (($GLOBALS["argv"][4] ?? "") === "bored");
+$boredSeedActor = trim((string)($GLOBALS["argv"][5] ?? ""));
+$GLOBALS["ROLEMASTER_BORED_MODE"] = $isBoredInstruction;
+$GLOBALS["ROLEMASTER_BORED_SEED"] = $boredSeedActor;
+$GLOBALS["ROLEMASTER_BORED_ALLOWED_ACTORS"] = [];
 
 if (!isset($GLOBALS["CHIM_CORE_CURRENT_CONNECTOR_DATA"]) ) {
         logMsg("Choose a LLM model and connector. Used connector: '{$GLOBALS["CORE_CONNECTOR_DIRECTOR"]}'",S_LOG_CRITICAL);
@@ -34,7 +39,8 @@ if (!isset($GLOBALS["CHIM_CORE_CURRENT_CONNECTOR_DATA"]) ) {
     
         $sqlfilter=" and type not in ('prechat','backgroundaction','addnpc','addbgnpc','travelcancel','innerchat') ";
 
-        $contextDataHistoric = DataLastDataExpandedFor($GLOBALS["PLAYER_NAME"], -50,$sqlfilter);    // Full context
+        $historyActor = ($isBoredInstruction && $boredSeedActor !== "") ? $boredSeedActor : $GLOBALS["PLAYER_NAME"];
+        $contextDataHistoric = DataLastDataExpandedFor($historyActor, -50,$sqlfilter);    // Full context
         
         foreach ($contextDataHistoric as $element) {
             // We should clean here background events entries
@@ -42,7 +48,15 @@ if (!isset($GLOBALS["CHIM_CORE_CURRENT_CONNECTOR_DATA"]) ) {
         
         $contextDataHistoric =array_merge([["role"=>"user","content"=>"# HISTORIC DIALOGUE AND EVENTS IN CHRONOLOGICAL ORDER"]], $contextDataHistoric);
 
-        $contextDataWorld = DataLastInfoFor("", -2,$addNPCDescriptions=true,$excludeBusy=true)??[];
+        $GLOBALS["PROMPT_NEARBY_SECTIONS"] = "";
+        $contextDataWorld = DataLastInfoFor(
+            "",
+            -2,
+            $addNPCDescriptions=true,
+            $excludeBusy=true,
+            $excludeFarAway=$isBoredInstruction
+        )??[];
+        $nearbySceneContext = trim((string)($GLOBALS["PROMPT_NEARBY_SECTIONS"] ?? ""));
         $contextDataFull = array_merge($contextDataWorld, $contextDataHistoric);
         $historyData="";
 
@@ -51,6 +65,9 @@ if (!isset($GLOBALS["CHIM_CORE_CURRENT_CONNECTOR_DATA"]) ) {
         
             $historyData.=trim("{$element["content"]}").PHP_EOL.PHP_EOL;
             
+        }
+        if ($nearbySceneContext !== "") {
+            $historyData .= $nearbySceneContext . PHP_EOL.PHP_EOL;
         }
         
         $recap=$GLOBALS["db"]->fetchOne("SELECT * FROM rolemaster where type='story_summary' ORDER BY rowid DESC LIMIT 1");
@@ -61,8 +78,19 @@ if (!isset($GLOBALS["CHIM_CORE_CURRENT_CONNECTOR_DATA"]) ) {
 
         // Inject relationship context for director awareness
         // Get nearby NPCs from DataBeingsInCloseRange (same source as DataLastInfoFor uses)
-        $nearbyNpcsRaw = DataBeingsInCloseRange();
+        $nearbyNpcsRaw = DataBeingsInCloseRange($isBoredInstruction);
         $nearbyNpcsList = array_filter(array_map('trim', explode('|', $nearbyNpcsRaw)));
+        if ($isBoredInstruction) {
+            $allowedActorMap = chimRolemasterBoredActorMap(
+                $nearbyNpcsRaw,
+                (string)$GLOBALS["PLAYER_NAME"],
+                $boredSeedActor
+            );
+            $GLOBALS["ROLEMASTER_BORED_ALLOWED_ACTORS"] = $allowedActorMap;
+            $historyData .= "# BORED EVENT SCENE\n";
+            $historyData .= "Selected initiating actor: " . ($boredSeedActor !== "" ? $boredSeedActor : "not provided") . "\n";
+            $historyData .= "Nearby eligible actors: " . implode(", ", array_values($allowedActorMap)) . "\n\n";
+        }
 
         // Build relationship context for these NPCs
         $relContext = RelationshipManager::buildDirectorContext($nearbyNpcsList);
@@ -189,6 +217,17 @@ user request: actor \"a\" leaves the place
             [$GLOBALS["PLAYER_NAME"], $functionList],
             $directorInstructionRules
         );
+        if ($isBoredInstruction) {
+            $directorInstructionRules .= "\n\n# Bored event rules";
+            if ($boredSeedActor !== "") {
+                $directorInstructionRules .= "\n* The first instruction must use the selected initiating actor: {$boredSeedActor}.";
+            }
+            $directorInstructionRules .= "\n* Only use speakers from the Nearby eligible actors list."
+                . "\n* Do not invent distant or off-scene actors."
+                . "\n* Do not target or comment on {$GLOBALS["PLAYER_NAME"]} merely because time passed or the player is idle."
+                . "\n* Prefer a natural NPC-to-NPC interaction or scene action. Involve the player only when recent player activity clearly requires a response."
+                . "\n* When an instruction targets another nearby actor, direct the dialogue to that actor.";
+        }
         
         // Database Prompt (Director)
         $prompt[] = array('role' => 'user', 'content' => "$sysprompt\n$directorInstructionRules\n$userprompt");
@@ -246,6 +285,12 @@ user request: actor \"a\" leaves the place
             $characterName = trim($response["character"] ?? 'Unknown');
             $instructionText = trim($response["instruction"] ?? 'No instruction text');
             $action = !empty($response["action"]) ? "{$response["action"]} " . ($response["target"] ?? "") : "";
+            if (!empty($GLOBALS["ROLEMASTER_BORED_MODE"])) {
+                $instructionText .= chimRolemasterBoredListenerRequirement(
+                    (string)($response["target"] ?? ""),
+                    $GLOBALS["ROLEMASTER_BORED_ALLOWED_ACTORS"] ?? []
+                );
+            }
         
             if (!$characterName || !$instructionText) {
                 return false;
@@ -310,7 +355,20 @@ user request: actor \"a\" leaves the place
             $response=$response[0];
 
         if (isset($response["instructions"]) && is_array($response["instructions"])) {
-            $allOk=true;
+            if ($isBoredInstruction) {
+                $originalInstructionCount = count($response["instructions"]);
+                $response["instructions"] = chimRolemasterFilterBoredInstructions(
+                    $response["instructions"],
+                    $GLOBALS["ROLEMASTER_BORED_ALLOWED_ACTORS"] ?? [],
+                    $boredSeedActor
+                );
+                if (empty($response["instructions"])) {
+                    Logger::warn("Discarded bored rolemaster response because it omitted the selected actor or used no eligible nearby actors");
+                } elseif (count($response["instructions"]) !== $originalInstructionCount) {
+                    Logger::warn("Removed invalid or off-scene actors from bored rolemaster response");
+                }
+            }
+            $allOk=!empty($response["instructions"]);
             foreach ($response["instructions"] as $r) {
                 $allOk=$allOk && parseInstruction($r);
                 parseSceneNote($r);

--- a/service/processors/rolemaster/entrypoint.php
+++ b/service/processors/rolemaster/entrypoint.php
@@ -26,6 +26,7 @@ $GLOBALS["TASKS"]["rolemaster"]["fn"]=function() {
     require_once($enginePath . "lib/chat_helper_functions.php");
     require_once($enginePath . "lib/data_functions.php");
     require_once($enginePath . "lib/rolemaster_helpers.php");
+    require_once($enginePath . "lib/rolemaster_bored.php");
 
     
     SaveOriginalHerikaName(); 

--- a/unittests/tests/DataBeingsInCloseRangeTest.php
+++ b/unittests/tests/DataBeingsInCloseRangeTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/data_functions.php';
+
+final class DataBeingsInCloseRangeTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['db']);
+    }
+
+    public function testBusyActorsCanRemainPresentWithoutIncludingFarAwayActors(): void
+    {
+        $GLOBALS['db'] = new class {
+            public function fetchAll(string $query): array
+            {
+                return [[
+                    'data' => 'beings in range:Corpulus Vinius (busy)/Gulum-Ei (busy)/RANGROO/Noster Eagle-Eye (far away)'
+                ]];
+            }
+        };
+
+        $this->assertSame(
+            '|RANGROO|',
+            DataBeingsInCloseRange(true)
+        );
+        $this->assertSame(
+            '|Corpulus Vinius|Gulum-Ei|RANGROO|',
+            DataBeingsInCloseRange(true, true)
+        );
+    }
+}

--- a/unittests/tests/PlayerPresenceSnapshotTest.php
+++ b/unittests/tests/PlayerPresenceSnapshotTest.php
@@ -137,4 +137,18 @@ final class PlayerPresenceSnapshotTest extends TestCase
 
         $this->assertSame('|Lisette|RANGROO|Eris|', $people);
     }
+
+    public function testDialogueEventPeopleAlwaysIncludeActualSpeakerAndListener(): void
+    {
+        $people = chimBuildDialogueEventPeoplePipe(
+            '|Octieve San|Lisette|RANGROO|',
+            'Octieve San',
+            'Minette Vinius'
+        );
+
+        $this->assertSame(
+            '|Octieve San|Lisette|RANGROO|Minette Vinius|',
+            $people
+        );
+    }
 }

--- a/unittests/tests/PlayerPresenceSnapshotTest.php
+++ b/unittests/tests/PlayerPresenceSnapshotTest.php
@@ -87,4 +87,54 @@ final class PlayerPresenceSnapshotTest extends TestCase
         $this->assertSame('|Lydia|RANGROO|', $snapshot['audience']);
         $this->assertSame([], $snapshot['present_actors']);
     }
+
+    public function testDirectivePeopleIncludeSelectedSpeakerAndExplicitListener(): void
+    {
+        $people = chimBuildDirectivePeoplePipe(
+            '|Lisette|Vivienne Onis|RANGROO|',
+            'Dorian',
+            'Dorian should ask about a remedy. The dialogue listener must be Vivienne Onis. (must use ACTION JustTalk Vivienne Onis)'
+        );
+
+        $this->assertSame(
+            '|Lisette|Vivienne Onis|RANGROO|Dorian|',
+            $people
+        );
+    }
+
+    public function testDirectivePeopleStillIncludeSpeakerWithoutExplicitListener(): void
+    {
+        $people = chimBuildDirectivePeoplePipe(
+            '|Lisette|RANGROO|',
+            'Jorn',
+            'Jorn should inspect the room. (must use ACTION Inspect_Surroundings)'
+        );
+
+        $this->assertSame('|Lisette|RANGROO|Jorn|', $people);
+    }
+
+    public function testDirectivePeopleUseTalkActionTargetWhenListenerRequirementIsAbsent(): void
+    {
+        $people = chimBuildDirectivePeoplePipe(
+            '|Lisette|RANGROO|',
+            'Belrand',
+            'Belrand should ask about work. (must use ACTION JustTalk Vivienne Onis)'
+        );
+
+        $this->assertSame(
+            '|Lisette|RANGROO|Belrand|Vivienne Onis|',
+            $people
+        );
+    }
+
+    public function testDirectivePeopleDoNotAddEveryoneAsAnActor(): void
+    {
+        $people = chimBuildDirectivePeoplePipe(
+            '|Lisette|RANGROO|',
+            'Eris',
+            'Eris should address the room. (must use ACTION JustTalk everyone)'
+        );
+
+        $this->assertSame('|Lisette|RANGROO|Eris|', $people);
+    }
 }

--- a/unittests/tests/RolemasterBoredRoutingTest.php
+++ b/unittests/tests/RolemasterBoredRoutingTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../lib/rolemaster_bored.php';
+
+final class RolemasterBoredRoutingTest extends TestCase
+{
+    public function testActorMapExcludesPlayerAndKeepsSeed(): void
+    {
+        $actors = chimRolemasterBoredActorMap(
+            '|Camilla Valerius|RANGROO|Lucan Valerius|',
+            'RANGROO',
+            'Camilla Valerius'
+        );
+
+        $this->assertSame([
+            'camilla valerius' => 'Camilla Valerius',
+            'lucan valerius' => 'Lucan Valerius',
+        ], $actors);
+    }
+
+    public function testInstructionsRejectInventedActorsAndRequireSeed(): void
+    {
+        $actors = chimRolemasterBoredActorMap('|Camilla Valerius|Lucan Valerius|', 'RANGROO', 'Camilla Valerius');
+        $instructions = [
+            ['character' => 'Siddgeir', 'instruction' => 'Appear from nowhere'],
+            ['character' => 'lucan valerius', 'instruction' => 'Ask about the shop'],
+            ['character' => 'camilla valerius', 'instruction' => 'Answer Lucan'],
+        ];
+
+        $filtered = chimRolemasterFilterBoredInstructions($instructions, $actors, 'Camilla Valerius');
+
+        $this->assertCount(2, $filtered);
+        $this->assertSame('Camilla Valerius', $filtered[0]['character']);
+        $this->assertSame('Lucan Valerius', $filtered[1]['character']);
+        $this->assertSame(
+            [],
+            chimRolemasterFilterBoredInstructions(
+                [['character' => 'Lucan Valerius', 'instruction' => 'Speak alone']],
+                $actors,
+                'Camilla Valerius'
+            )
+        );
+    }
+
+    public function testListenerRequirementOnlyUsesKnownNearbyActor(): void
+    {
+        $actors = chimRolemasterBoredActorMap('|Camilla Valerius|Lucan Valerius|', 'RANGROO', 'Camilla Valerius');
+
+        $this->assertSame(
+            ' The dialogue listener must be Lucan Valerius.',
+            chimRolemasterBoredListenerRequirement('lucan valerius', $actors)
+        );
+        $this->assertSame('', chimRolemasterBoredListenerRequirement('RANGROO', $actors));
+        $this->assertSame('', chimRolemasterBoredListenerRequirement('everyone', $actors));
+    }
+}
+

--- a/unittests/tests/RolemasterBoredRoutingTest.php
+++ b/unittests/tests/RolemasterBoredRoutingTest.php
@@ -56,4 +56,3 @@ final class RolemasterBoredRoutingTest extends TestCase
         $this->assertSame('', chimRolemasterBoredListenerRequirement('everyone', $actors));
     }
 }
-

--- a/unittests/tests/RolemasterBoredRoutingTest.php
+++ b/unittests/tests/RolemasterBoredRoutingTest.php
@@ -55,4 +55,48 @@ final class RolemasterBoredRoutingTest extends TestCase
         $this->assertSame('', chimRolemasterBoredListenerRequirement('RANGROO', $actors));
         $this->assertSame('', chimRolemasterBoredListenerRequirement('everyone', $actors));
     }
+
+    public function testBoredEventRulesRenderPromptManagerPlaceholders(): void
+    {
+        $actors = chimRolemasterBoredActorMap(
+            '|Camilla Valerius|Lucan Valerius|',
+            'RANGROO',
+            'Camilla Valerius'
+        );
+
+        $rules = chimRolemasterRenderBoredEventRules(
+            chimRolemasterDefaultBoredEventRules(),
+            'Camilla Valerius',
+            'RANGROO',
+            $actors
+        );
+
+        $this->assertStringContainsString(
+            'The first instruction must use the selected initiating actor: Camilla Valerius.',
+            $rules
+        );
+        $this->assertStringContainsString(
+            'Camilla Valerius, Lucan Valerius',
+            $rules
+        );
+        $this->assertStringContainsString(
+            'Do not target or comment on RANGROO',
+            $rules
+        );
+        $this->assertStringNotContainsString('{SEED_ACTOR_RULE}', $rules);
+        $this->assertStringNotContainsString('{NEARBY_ACTORS}', $rules);
+        $this->assertStringNotContainsString('{PLAYER_NAME}', $rules);
+    }
+
+    public function testBoredEventRulesAllowCustomPromptWithoutSeed(): void
+    {
+        $rules = chimRolemasterRenderBoredEventRules(
+            "Actors: {NEARBY_ACTORS}\n{SEED_ACTOR_RULE}\nPlayer: {PLAYER_NAME}",
+            '',
+            'RANGROO',
+            ['lucan valerius' => 'Lucan Valerius']
+        );
+
+        $this->assertSame("Actors: Lucan Valerius\n\nPlayer: RANGROO", $rules);
+    }
 }


### PR DESCRIPTION
## Summary
- consume the bored-event NPC selected by the CHIM plugin as the routing seed
- build autonomous scenes from that NPC's recent history and the actual nearby scene
- reject invented or off-scene speakers while preserving explicit NPC-to-NPC listeners
- retain busy actors as physically present without making them eligible as new Rolemaster speakers
- preserve the selected speaker and explicit listener in instruction and follow-up chat snapshots
- expose autonomous bored-event rules as `director_bored_event_rules` in Prompt Manager
- retain backward compatibility when an older plugin sends no actor seed

## Root cause
Generated instruction requests rebuilt `People Present` from the strict close-range list. That list intentionally excludes busy actors and can also mark the currently routed speaker or listener as far away, so valid turn participants disappeared. Follow-up chat rows then reused that incomplete snapshot without unioning the LLM's actual output speaker and listener. Bored-specific prompt constraints were also hardcoded and could not be tuned through Prompt Manager.

## Implementation
- directive audience composition unions strict nearby actors with the authoritative routed speaker and explicit listener/action target
- emitted prechat/chat rows additionally union the actual output speaker and atomic listener
- Rolemaster speaker eligibility and bystander distance filtering remain unchanged
- migration `20260727001` adds `director_bored_event_rules` idempotently
- runtime prefers the Prompt Manager custom override, falls back to its maintained default, and still enforces the routing filter after generation
- prompt placeholders: `{SEED_ACTOR_RULE}`, `{SEED_ACTOR}`, `{NEARBY_ACTORS}`, and `{PLAYER_NAME}`

## Related
- CHIM plugin transport: https://github.com/Dwemer-Dynamics/CHIM/pull/94

## Validation
- PHP lint passed for every changed PHP file
- focused PHPUnit regression passed: 14 tests, 33 assertions
- 30-minute in-game soak completed with Skyrim running and responsive throughout
- all 6 autonomous seeds produced fresh grounded Rolemaster chains
- authoritative eventlog window contained 15 instructions, including 12 dialogue instructions
- zero false player prefixes, missing explicit listeners, LLM timeouts, invalid JSON responses, PHP warnings, or fatal errors were found in the soak window
- full actor names were preserved in structured output, including `Corpulus Vinius`
- migration applied locally and logged prompts version `20260727001`
- Prompt Manager database row and rendered UI entry verified; custom override remained unset and available for editing
- local Prompt Manager returned HTTP 200 and passed visual inspection

## Deployment
- HerikaServer source from commit `ceaa2eab` deployed to `/var/www/html/HerikaServer`
- deployed runtime file hashes matched the feature branch
- Apache restarted successfully and is running
- CHIM was not rebuilt for the Prompt Manager-only update; the paired plugin PR had already been deployed for the soak

## Review notes
- `lib/data_functions.php` is also touched by open PRs #594 and #568; this PR only adds the optional busy-presence behavior used by directive audience composition
- PocketTTS was unavailable at `127.0.0.1:8086` during the soak, producing TTS-only connection noise unrelated to routing and prompt validation

## Scope
- targets `unstable`
- one idempotent prompts migration that preserves existing `custom_prompt` overrides
- source only; no binaries, file moves, renames, or deletions
- PR remains draft for manual review