### PR TITLE
Add profile-controlled latest diary context

### DIFF
--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -7633,6 +7633,22 @@ if ($checkVersion("visual_context") < 20260718001) {
     }
 }
 
+if ($checkVersion("latest_diary_context") < 20260727001) {
+    Logger::debug("Applying latest_diary_context 20260727001 - index latest NPC diary lookups");
+
+    $migrationOk = $db->execQuery(
+        "CREATE INDEX IF NOT EXISTS idx_diarylog_people_gamets
+         ON public.diarylog (lower(trim(people)), gamets DESC, localts DESC, rowid DESC)"
+    ) !== false;
+
+    if ($migrationOk) {
+        $updateVersion("latest_diary_context", 20260727001);
+        Logger::info("Applied patch latest_diary_context 20260727001");
+    } else {
+        Logger::error("Failed to apply patch latest_diary_context 20260727001");
+    }
+}
+
 Logger::info(__FILE__." update file processed");
 
 //----------------------------------------------------

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -12,6 +12,54 @@ require_once(__DIR__."/pipeline_status.php");
 require_once(__DIR__."/emote_moods.php");
 require_once(__DIR__."/core/event_type.php");
 
+function chimBuildLatestDiaryContextBlock(string $npcName, array $profileData): string
+{
+    $safeNpcName = trim($npcName);
+    if ($safeNpcName === '' || strcasecmp($safeNpcName, 'The Narrator') === 0) {
+        return '';
+    }
+
+    $metadata = json_decode(strval($profileData['metadata'] ?? '{}'), true);
+    if (!is_array($metadata)
+        || !filter_var($metadata['LATEST_DIARY_CONTEXT_ENABLED'] ?? false, FILTER_VALIDATE_BOOLEAN)) {
+        return '';
+    }
+
+    $db = $GLOBALS['db'] ?? null;
+    if (!is_object($db) || !method_exists($db, 'fetchOne') || !method_exists($db, 'escape')) {
+        return '';
+    }
+
+    try {
+        $escapedName = $db->escape($safeNpcName);
+        $entry = $db->fetchOne(
+            "SELECT topic, content
+             FROM diarylog
+             WHERE lower(trim(people)) = lower('{$escapedName}')
+             ORDER BY gamets DESC, localts DESC, rowid DESC
+             LIMIT 1"
+        );
+    } catch (Throwable $e) {
+        Logger::warn("[LATEST_DIARY_CONTEXT] Unable to load diary context for {$safeNpcName}: " . $e->getMessage());
+        return '';
+    }
+
+    $content = trim(strval($entry['content'] ?? ''));
+    if ($content === '') {
+        return '';
+    }
+
+    $topic = trim(strval($entry['topic'] ?? ''));
+    $diaryText = $topic !== '' ? "Date: {$topic}\n{$content}" : $content;
+    $escapedText = htmlspecialchars(
+        $diaryText,
+        ENT_QUOTES | ENT_XML1 | ENT_SUBSTITUTE,
+        'UTF-8'
+    );
+
+    return "\n<latest_diary_entry>\n{$escapedText}\n</latest_diary_entry>\n";
+}
+
 function callConfiguredTts($textString, $mood, $stringforhash)
 {
     $ttsFunction = strval($GLOBALS["TTSFUNCTION"] ?? '');

--- a/lib/core/core_profiles.class.php
+++ b/lib/core/core_profiles.class.php
@@ -36,6 +36,7 @@ class CoreProfile
                 ],
                 'RPG_COMMENTS_CHANCE'    => 50,
                 'COMBAT_BARK_COOLDOWN'   => 30,
+                'LATEST_DIARY_CONTEXT_ENABLED' => false,
             ];
             $data['metadata'] = json_encode($defaultMeta, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
         }

--- a/main.php
+++ b/main.php
@@ -2461,6 +2461,14 @@ $promptInjectionContext = [
 $characterBottomInjections = function_exists('chimRenderPromptInjections')
     ? chimRenderPromptInjections("character_bottom", $promptInjectionContext)
     : "";
+$latestDiaryContext = function_exists('chimBuildLatestDiaryContextBlock')
+    ? chimBuildLatestDiaryContextBlock(
+        strval($GLOBALS["HERIKA_NAME"] ?? ''),
+        is_array($GLOBALS["CHIM_CORE_CURRENT_PROFILE_DATA"] ?? null)
+            ? $GLOBALS["CHIM_CORE_CURRENT_PROFILE_DATA"]
+            : []
+    )
+    : "";
 $promptBottomInjections = function_exists('chimRenderPromptInjections')
     ? chimRenderPromptInjections("prompt_bottom", $promptInjectionContext)
     : "";
@@ -2480,7 +2488,7 @@ if (!empty($GLOBALS["OGHMA_HINT"])) {
 
 $systemPromptRaw = "<roleplay_instructions>\n" . $GLOBALS["PROMPT_HEAD"] .
     "\n</roleplay_instructions>" . $worldPrompt .
-    "\n\n<character>\n" . $GLOBALS["HERIKA_PERS"] . $dynamicBiography . $characterBottomInjections .
+    "\n\n<character>\n" . $GLOBALS["HERIKA_PERS"] . $dynamicBiography . $latestDiaryContext . $characterBottomInjections .
     "\n</character>" . $knowledgeSection .
     "\n\n<general_instructions>\n" . $GLOBALS["COMMAND_PROMPT"] .
     "\n</general_instructions>" . $actionsList . $nearbySections . $promptBottomInjections . $paralinguisticTagsPrompt .
@@ -2489,7 +2497,7 @@ $systemPromptRaw = "<roleplay_instructions>\n" . $GLOBALS["PROMPT_HEAD"] .
 $promptCompositionSections = [
     'roleplay_instructions' => $GLOBALS["PROMPT_HEAD"] ?? '',
     'world' => $worldPrompt ?? '',
-    'character' => ($GLOBALS["HERIKA_PERS"] ?? '') . ($dynamicBiography ?? '') . ($characterBottomInjections ?? ''),
+    'character' => ($GLOBALS["HERIKA_PERS"] ?? '') . ($dynamicBiography ?? '') . ($latestDiaryContext ?? '') . ($characterBottomInjections ?? ''),
     'knowledge' => $knowledgeSection ?? '',
     'general_instructions' => $GLOBALS["COMMAND_PROMPT"] ?? '',
     'actions' => $actionsList ?? '',

--- a/ui/core/core_profiles.php
+++ b/ui/core/core_profiles.php
@@ -1831,6 +1831,7 @@ $ittById = $byId($ittRows);
         $autoDiaryEnabled = !empty($profileMetadata['AUTO_DIARY_ENABLED']);
         $autoDiaryWaitEnabled = !empty($profileMetadata['AUTO_DIARY_WAIT_ENABLED']);
         $physicalDiaryEnabled = !empty($profileMetadata['MATERIALIZE_DIARY_ENABLED']);
+        $latestDiaryContextEnabled = !empty($profileMetadata['LATEST_DIARY_CONTEXT_ENABLED']);
         $randomizerEnabled = !empty($profileMetadata['LLM_RANDOMIZER_ENABLED']);
         $fallbackEnabled = !empty($profileMetadata['LLM_FALLBACK_ENABLED']);
 
@@ -1846,6 +1847,7 @@ $ittById = $byId($ittRows);
             ['key' => 'AUTO_DIARY_ENABLED', 'icon' => '&#x1F4D9;', 'title' => 'Auto Diary', 'enabled' => $autoDiaryEnabled, 'short' => 'Generate nearby NPC diaries during sleep or wait.', 'help' => 'Automatically generate diary entries when NPCs are nearby during sleep/wait events. NPCs using this profile will have auto diary enabled by default.'],
             ['key' => 'AUTO_DIARY_WAIT_ENABLED', 'icon' => '&#x23F3;', 'title' => 'Auto Diary Wait', 'enabled' => $autoDiaryWaitEnabled, 'short' => 'Include wait events when Auto Diary is enabled.', 'help' => 'When Auto Diary is enabled, this controls whether diary entries are created during wait events. If disabled, auto diary will only trigger on sleep events.'],
             ['key' => 'MATERIALIZE_DIARY_ENABLED', 'icon' => '&#x1F4D5;', 'title' => 'Physical Diary', 'enabled' => $physicalDiaryEnabled, 'short' => 'Create a physical ingame diary that can be read.', 'help' => 'Automatically creates one physical diary in each NPC\'s inventory when they write a diary entry, then refreshes that same book after future entries.'],
+            ['key' => 'LATEST_DIARY_CONTEXT_ENABLED', 'icon' => '&#x1F4D6;', 'title' => 'Include Latest Diary Entry', 'enabled' => $latestDiaryContextEnabled, 'short' => 'Include the NPC\'s latest diary entry in response context.', 'help' => 'Adds the latest diary entry written by an NPC to the character section of every response prompt.'],
             ['key' => 'LLM_RANDOMIZER_ENABLED', 'icon' => '&#x1F3B2;', 'title' => 'LLM Randomizer', 'enabled' => $randomizerEnabled, 'short' => 'Rotate among the four profile LLM connectors.', 'help' => 'Randomly switches between the 4 LLM connectors for NPCs using this profile. Will roughly switch every 2-3 responses per NPC.'],
             ['key' => 'LLM_FALLBACK_ENABLED', 'icon' => '&#x1F504;', 'title' => 'LLM Fallback', 'enabled' => $fallbackEnabled, 'short' => 'Retry failed requests with the fallback connector.', 'help' => 'Automatically retry with the fallback connector when the primary connector fails. Response time will be longer when fallback is used.'],
         ];
@@ -1923,7 +1925,7 @@ $ittById = $byId($ittRows);
 
     <script>
     document.addEventListener('DOMContentLoaded', function(){
-        const names = ['default_npc','meta_vis[LLM_RANDOMIZER_ENABLED]','meta_vis[LLM_FALLBACK_ENABLED]','meta_vis[DYNAMIC_PROFILE_ENABLED]','meta_vis[MIDDLE_TERM_MEMORY_ENABLED]','meta_vis[AUTO_DIARY_ENABLED]','meta_vis[AUTO_DIARY_WAIT_ENABLED]','meta_vis[MATERIALIZE_DIARY_ENABLED]'];
+        const names = ['default_npc','meta_vis[LLM_RANDOMIZER_ENABLED]','meta_vis[LLM_FALLBACK_ENABLED]','meta_vis[DYNAMIC_PROFILE_ENABLED]','meta_vis[MIDDLE_TERM_MEMORY_ENABLED]','meta_vis[AUTO_DIARY_ENABLED]','meta_vis[AUTO_DIARY_WAIT_ENABLED]','meta_vis[MATERIALIZE_DIARY_ENABLED]','meta_vis[LATEST_DIARY_CONTEXT_ENABLED]'];
         names.forEach(n=>{
             const cb = document.querySelector(`input[type="checkbox"][name="${n}"]`);
             if (!cb) return;
@@ -2172,7 +2174,7 @@ const saveAllBtn = document.getElementById('btn_save_all');
                 'mode' => 'profile',
                 'fieldName' => 'metadata',
                 'settingsCatalog' => $profileOverrideCatalog,
-                'reservedKeys' => ['DYNAMIC_PROFILE_ENABLED', 'MIDDLE_TERM_MEMORY_ENABLED', 'AUTO_DIARY_ENABLED', 'AUTO_DIARY_WAIT_ENABLED', 'MATERIALIZE_DIARY_ENABLED', 'LLM_RANDOMIZER_ENABLED', 'RPG_COMMENTS', 'RPG_COMMENTS_CHANCE', 'DYNAMIC_PROFILE_FIELDS'],
+                'reservedKeys' => ['DYNAMIC_PROFILE_ENABLED', 'MIDDLE_TERM_MEMORY_ENABLED', 'AUTO_DIARY_ENABLED', 'AUTO_DIARY_WAIT_ENABLED', 'MATERIALIZE_DIARY_ENABLED', 'LATEST_DIARY_CONTEXT_ENABLED', 'LLM_RANDOMIZER_ENABLED', 'RPG_COMMENTS', 'RPG_COMMENTS_CHANCE', 'DYNAMIC_PROFILE_FIELDS'],
                 'currentData' => $currentProfileOverrides,
                 'systemFields' => [],
             ];

--- a/ui/core/core_profiles.php
+++ b/ui/core/core_profiles.php
@@ -399,7 +399,10 @@ h1.api-title {
 }
 .profile-prompt-field { margin-top:10px; }
 .profile-prompt-field textarea { min-height:82px; }
-.profile-toggle-grid { display:grid; grid-template-columns:repeat(3, minmax(0, 1fr)); gap:8px; margin-top:10px; }
+.profile-toggle-groups { display:grid; gap:9px; margin-top:10px; }
+.profile-toggle-group { padding:9px; border:1px solid #3f3f3f; border-radius:7px; background:#202020; }
+.profile-toggle-group-title { margin:0 0 7px; color:#f27c11; font-family:'MagicCards', serif; font-size:1em; letter-spacing:0.4px; word-spacing:4px; }
+.profile-toggle-grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(220px, 1fr)); gap:8px; }
 .profile-toggle-card {
     display:block !important;
     min-height:78px;
@@ -1841,15 +1844,30 @@ $ittById = $byId($ittRows);
         $currentId = (int)($editItem['id'] ?? 0);
         $currentSlot = isset($editItem['slot']) ? (int)$editItem['slot'] : 0;
 
-        $profileToggleCards = [
-            ['key' => 'DYNAMIC_PROFILE_ENABLED', 'icon' => '&#x267B;&#xFE0F;', 'title' => 'Dynamic Profile', 'enabled' => $dynamicProfileEnabled, 'short' => 'Allow gameplay events to evolve NPC profiles.', 'help' => 'Allow systems to evolve NPC profiles based on gameplay events. NPCs using this profile will have dynamic profile enabled by default.'],
-            ['key' => 'MIDDLE_TERM_MEMORY_ENABLED', 'icon' => '&#x1F4C3;', 'title' => 'Middle Term Memory', 'enabled' => $mtmEnabled, 'short' => 'Include periodic middle-term memory summaries.', 'help' => 'Saves a list of recent events after every 10 memory summaries. NPCs using this profile will have MTM enabled by default.'],
-            ['key' => 'AUTO_DIARY_ENABLED', 'icon' => '&#x1F4D9;', 'title' => 'Auto Diary', 'enabled' => $autoDiaryEnabled, 'short' => 'Generate nearby NPC diaries during sleep or wait.', 'help' => 'Automatically generate diary entries when NPCs are nearby during sleep/wait events. NPCs using this profile will have auto diary enabled by default.'],
-            ['key' => 'AUTO_DIARY_WAIT_ENABLED', 'icon' => '&#x23F3;', 'title' => 'Auto Diary Wait', 'enabled' => $autoDiaryWaitEnabled, 'short' => 'Include wait events when Auto Diary is enabled.', 'help' => 'When Auto Diary is enabled, this controls whether diary entries are created during wait events. If disabled, auto diary will only trigger on sleep events.'],
-            ['key' => 'MATERIALIZE_DIARY_ENABLED', 'icon' => '&#x1F4D5;', 'title' => 'Physical Diary', 'enabled' => $physicalDiaryEnabled, 'short' => 'Create a physical ingame diary that can be read.', 'help' => 'Automatically creates one physical diary in each NPC\'s inventory when they write a diary entry, then refreshes that same book after future entries.'],
-            ['key' => 'LATEST_DIARY_CONTEXT_ENABLED', 'icon' => '&#x1F4D6;', 'title' => 'Include Latest Diary Entry', 'enabled' => $latestDiaryContextEnabled, 'short' => 'Include the NPC\'s latest diary entry in response context.', 'help' => 'Adds the latest diary entry written by an NPC to the character section of every response prompt.'],
-            ['key' => 'LLM_RANDOMIZER_ENABLED', 'icon' => '&#x1F3B2;', 'title' => 'LLM Randomizer', 'enabled' => $randomizerEnabled, 'short' => 'Rotate among the four profile LLM connectors.', 'help' => 'Randomly switches between the 4 LLM connectors for NPCs using this profile. Will roughly switch every 2-3 responses per NPC.'],
-            ['key' => 'LLM_FALLBACK_ENABLED', 'icon' => '&#x1F504;', 'title' => 'LLM Fallback', 'enabled' => $fallbackEnabled, 'short' => 'Retry failed requests with the fallback connector.', 'help' => 'Automatically retry with the fallback connector when the primary connector fails. Response time will be longer when fallback is used.'],
+        $profileToggleGroups = [
+            [
+                'title' => 'Profiles & Memories',
+                'cards' => [
+                    ['key' => 'DYNAMIC_PROFILE_ENABLED', 'icon' => '&#x267B;&#xFE0F;', 'title' => 'Dynamic Profile', 'enabled' => $dynamicProfileEnabled, 'short' => 'Allow gameplay events to evolve NPC profiles.', 'help' => 'Allow systems to evolve NPC profiles based on gameplay events. NPCs using this profile will have dynamic profile enabled by default.'],
+                    ['key' => 'MIDDLE_TERM_MEMORY_ENABLED', 'icon' => '&#x1F4C3;', 'title' => 'Middle Term Memory', 'enabled' => $mtmEnabled, 'short' => 'Include periodic middle-term memory summaries.', 'help' => 'Saves a list of recent events after every 10 memory summaries. NPCs using this profile will have MTM enabled by default.'],
+                ],
+            ],
+            [
+                'title' => 'Diary',
+                'cards' => [
+                    ['key' => 'AUTO_DIARY_ENABLED', 'icon' => '&#x1F4D9;', 'title' => 'Auto Diary', 'enabled' => $autoDiaryEnabled, 'short' => 'Generate nearby NPC diaries during sleep or wait.', 'help' => 'Automatically generate diary entries when NPCs are nearby during sleep/wait events. NPCs using this profile will have auto diary enabled by default.'],
+                    ['key' => 'AUTO_DIARY_WAIT_ENABLED', 'icon' => '&#x23F3;', 'title' => 'Auto Diary Wait', 'enabled' => $autoDiaryWaitEnabled, 'short' => 'Include wait events when Auto Diary is enabled.', 'help' => 'When Auto Diary is enabled, this controls whether diary entries are created during wait events. If disabled, auto diary will only trigger on sleep events.'],
+                    ['key' => 'MATERIALIZE_DIARY_ENABLED', 'icon' => '&#x1F4D5;', 'title' => 'Physical Diary', 'enabled' => $physicalDiaryEnabled, 'short' => 'Create a physical ingame diary that can be read.', 'help' => 'Automatically creates one physical diary in each NPC\'s inventory when they write a diary entry, then refreshes that same book after future entries.'],
+                    ['key' => 'LATEST_DIARY_CONTEXT_ENABLED', 'icon' => '&#x1F4D6;', 'title' => 'Include Latest Diary Entry', 'enabled' => $latestDiaryContextEnabled, 'short' => 'Include the NPC\'s latest diary entry in response context.', 'help' => 'Adds the latest diary entry written by an NPC to the character section of every response prompt.'],
+                ],
+            ],
+            [
+                'title' => 'LLM',
+                'cards' => [
+                    ['key' => 'LLM_RANDOMIZER_ENABLED', 'icon' => '&#x1F3B2;', 'title' => 'LLM Randomizer', 'enabled' => $randomizerEnabled, 'short' => 'Rotate among the four profile LLM connectors.', 'help' => 'Randomly switches between the 4 LLM connectors for NPCs using this profile. Will roughly switch every 2-3 responses per NPC.'],
+                    ['key' => 'LLM_FALLBACK_ENABLED', 'icon' => '&#x1F504;', 'title' => 'LLM Fallback', 'enabled' => $fallbackEnabled, 'short' => 'Retry failed requests with the fallback connector.', 'help' => 'Automatically retry with the fallback connector when the primary connector fails. Response time will be longer when fallback is used.'],
+                ],
+            ],
         ];
     ?>
 
@@ -1906,19 +1924,26 @@ $ittById = $byId($ittRows);
             <small class="hint">Optional profile-specific system instructions appended to requests.</small>
         </div>
 
-        <div class="profile-toggle-grid">
-            <?php foreach ($profileToggleCards as $toggleCard): ?>
-                <label class="profile-toggle-card" title="<?= htmlspecialchars($toggleCard['help']) ?>">
-                    <span class="profile-toggle-heading">
-                        <span><?= $toggleCard['icon'] ?> <?= htmlspecialchars($toggleCard['title']) ?></span>
-                        <span class="profile-toggle-control">
-                            <input type="hidden" name="meta_vis[<?= htmlspecialchars($toggleCard['key']) ?>]" value="">
-                            <input type="checkbox" name="meta_vis[<?= htmlspecialchars($toggleCard['key']) ?>]" value="1" <?= $toggleCard['enabled'] ? "checked" : "" ?>>
-                            <span class="toggle-text"><?= $toggleCard['enabled'] ? 'On' : 'Off' ?></span>
-                        </span>
-                    </span>
-                    <span class="profile-toggle-description"><?= htmlspecialchars($toggleCard['short']) ?></span>
-                </label>
+        <div class="profile-toggle-groups">
+            <?php foreach ($profileToggleGroups as $toggleGroup): ?>
+                <section class="profile-toggle-group">
+                    <h3 class="profile-toggle-group-title"><?= htmlspecialchars($toggleGroup['title']) ?></h3>
+                    <div class="profile-toggle-grid">
+                        <?php foreach ($toggleGroup['cards'] as $toggleCard): ?>
+                            <label class="profile-toggle-card" title="<?= htmlspecialchars($toggleCard['help']) ?>">
+                                <span class="profile-toggle-heading">
+                                    <span><?= $toggleCard['icon'] ?> <?= htmlspecialchars($toggleCard['title']) ?></span>
+                                    <span class="profile-toggle-control">
+                                        <input type="hidden" name="meta_vis[<?= htmlspecialchars($toggleCard['key']) ?>]" value="">
+                                        <input type="checkbox" name="meta_vis[<?= htmlspecialchars($toggleCard['key']) ?>]" value="1" <?= $toggleCard['enabled'] ? "checked" : "" ?>>
+                                        <span class="toggle-text"><?= $toggleCard['enabled'] ? 'On' : 'Off' ?></span>
+                                    </span>
+                                </span>
+                                <span class="profile-toggle-description"><?= htmlspecialchars($toggleCard['short']) ?></span>
+                            </label>
+                        <?php endforeach; ?>
+                    </div>
+                </section>
             <?php endforeach; ?>
         </div>
     </div>


### PR DESCRIPTION
﻿## Summary
- add an **Include Latest Diary Entry** profile toggle, disabled by default
- group top-level profile controls into **Profiles & Memories**, **Diary**, and **LLM** categories
- include the current NPC's newest diary entry near the bottom of `<character>` for normal response prompts
- select the newest exact-name diary row by game timestamp and add an idempotent lookup index migration

## Behavior
- existing and new profiles remain disabled unless the user opts in
- the disabled path performs no diary database query
- missing or empty diary entries add no prompt content
- diary text is XML-escaped before prompt composition
- narrator prompts are excluded from this NPC profile behavior
- control grouping changes presentation only; metadata keys and save behavior are unchanged

## Validation
- `php -l` passed for all 5 changed PHP files
- helper probes passed for disabled/enabled behavior, exact-name lookup, latest-row ordering, XML escaping, empty values, and narrator exclusion
- `ProfileImportCreateIdTest` and `PromptCompositionTest`: **5 tests, 23 assertions passed**
- the existing `DiaryTest` database fixture remains blocked by the unrelated baseline `sql::escapeLiteral()` error at `debug/db_updates.php:985`
- profile page returned HTTP 200 and visually rendered all three categories without horizontal overflow
- `git diff --check` passed

## Related draft PRs
- StobeServer: https://github.com/Dwemer-Dynamics/StobeServer/pull/42
- DialecticServer: https://github.com/Dwemer-Dynamics/DialecticServer/pull/19

## Deployment
Deployed locally to `/var/www/html/HerikaServer`. No CHIM game-plugin change is required.
