### PR TITLE
Improve profile, connector, event, and log UI consistency

### DIFF
--- a/ui/adventurelog.php
+++ b/ui/adventurelog.php
@@ -318,7 +318,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 ?>
 <!-- Ensure main.css is loaded after any reboot.css -->
 <link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/main.css">
-<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/diary_adventure.css">
+<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/diary_adventure.css?v=<?php echo (int) @filemtime(__DIR__ . '/css/diary_adventure.css'); ?>">
 <style>
     @font-face {
         font-family: 'MagicCards';
@@ -780,7 +780,7 @@ if ($shouldFetchEvents) {
             foreach ($currentCsvParams as $key => $value) {
                 echo "<input type='hidden' name='" . htmlspecialchars($key) . "' value='" . htmlspecialchars($value) . "'>";
             }
-            echo "<button type='submit' class='btn-base btn-save'>Download Current Date</button>";
+        echo "<button type='submit' class='btn-base btn-save log-action-button'>Download Current Date</button>";
             echo "</form>";
 
             $allCsvParams = ['export' => 'all_csv'];
@@ -797,7 +797,7 @@ if ($shouldFetchEvents) {
             foreach ($allCsvParams as $key => $value) {
                 echo "<input type='hidden' name='" . htmlspecialchars($key) . "' value='" . htmlspecialchars($value) . "'>";
             }
-            echo "<button type='submit' class='btn-base btn-save'>Download Entire Adventure Log</button>";
+    echo "<button type='submit' class='btn-base btn-save log-action-button'>Download Entire Adventure Log</button>";
             echo "</form>";
 
             echo "</div>";

--- a/ui/core/core_profiles.php
+++ b/ui/core/core_profiles.php
@@ -44,7 +44,7 @@ ob_start();
 include(__DIR__.DIRECTORY_SEPARATOR."../tmpl/head.html");
 ?>
 
-<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/main.css">
+<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/main.css?v=<?php echo (int) @filemtime(dirname(__DIR__) . '/css/main.css'); ?>">
 <style>
 /* Match Oghma/Connectors spacing and title styling */
 @font-face {
@@ -1377,14 +1377,14 @@ $ittById = $byId($ittRows);
 
 <div class="llm-layout">
     <div class="llm-left">
-        <div style="margin: 6px 0 10px 4px; display:flex; gap:8px; flex-wrap:wrap;">
-            <form method="get" action="core_profiles.php" style="display:inline">
+        <div class="sidebar-action-grid">
+            <form method="get" action="core_profiles.php">
                 <input type="hidden" name="create_blank" value="1">
-                <button type="submit" class="btn-save">New Profile</button>
+                <button type="submit" class="btn-save">New</button>
             </form>
-            <button type="button" id="import_profile_btn" class="btn-primary">Import Profile</button>
-            <button type="button" id="open_import_rules_btn" class="btn-primary">Profile Rules</button>
-            <button type="button" id="profile_test_all_btn" class="btn-primary">Test All Profiles</button>
+            <button type="button" id="import_profile_btn" class="btn-primary">Import</button>
+            <button type="button" id="open_import_rules_btn" class="btn-primary">Rules</button>
+            <button type="button" id="profile_test_all_btn" class="btn-primary">Test</button>
         </div>
         <div id="profiles_list" class="conn-list"></div>
         <script>

--- a/ui/core/llm_connectors.php
+++ b/ui/core/llm_connectors.php
@@ -211,7 +211,7 @@ ob_start();
 include(__DIR__.DIRECTORY_SEPARATOR."../tmpl/head.html");
 ?>
 
-<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/main.css">
+<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/main.css?v=<?php echo (int) @filemtime(dirname(__DIR__) . '/css/main.css'); ?>">
 <style>
 /* Match Oghma page spacing and title styling */
 @font-face {
@@ -1490,12 +1490,12 @@ if (isset($_GET["edit"])) {
 
 <div class="llm-layout">
     <div class="llm-left position-sticky">
-        <div style="margin: 6px 0 10px 4px; display:flex; gap:8px; flex-wrap:wrap;">
-            <form method="get" style="display:inline" action="llm_connectors.php">
+        <div class="sidebar-action-grid">
+            <form method="get" action="llm_connectors.php">
                 <input type="hidden" name="create_blank" value="1">
-                <button type="submit" class="btn-save">New Connector</button>
+                <button type="submit" class="btn-save">New</button>
             </form>
-            <form method="post" style="display:inline" action="llm_connectors.php" enctype="multipart/form-data" id="llm_import_form">
+            <form method="post" action="llm_connectors.php" enctype="multipart/form-data" id="llm_import_form">
                 <input type="hidden" name="import" value="1">
                 <input type="file" name="import_file[]" id="llm_import_file" accept=".csv" multiple style="display:none">
                 <button type="button" class="btn-primary" id="llm_import_btn">Import</button>

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -2092,15 +2092,16 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
 .npc-editor-tab:focus-visible { outline:2px solid rgb(242,124,17); outline-offset:2px; }
 .npc-editor-panels { display:block; }
 .npc-editor-panel[hidden] { display:none !important; }
+.npc-editor-panel[data-npc-editor-panel="bios"] { grid-template-columns:minmax(0, 1fr); }
 @media (max-width:700px) { .npc-editor-tabs { grid-template-columns:repeat(2, minmax(0, 1fr)); } }
 </style>
 <script>
 (function(){
     const fieldSections = {
         general: new Set(['npc_name','profile_id','lock_profile','npc_favorite','gender','race','base','refid','oghma_knowledge_tags','worldknowledge_tags','world_knowledge_tags','voiceid','faction','dynamic_profile','middle_term_enabled','individual_memory_enabled','auto_diary_enabled','auto_diary_wait_enabled','salutation_after_a_while','prompt_head']),
-        bios: new Set(['core','npc_static_bio','appearance','personality','occupation','speechstyle','goals']),
-        relationships: new Set(['relationships','relationships_jsonb']),
-        info: new Set(['skills','emote_moods','middle_term_latest','metadata','extended_data'])
+        bios: new Set(['core','npc_static_bio','appearance','personality','occupation','skills','speechstyle','goals']),
+        relationships: new Set(['relationships','relationships_jsonb','middle_term_latest']),
+        info: new Set(['emote_moods','metadata','extended_data'])
     };
 
     function initNpcEditorTabs(){

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -2054,7 +2054,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
 
     <div class="npc-editor-tabs" role="tablist" aria-label="NPC editor categories" data-npc-editor-tabs data-storage-key="herika-npc-editor-tab">
     <button type="button" class="npc-editor-tab is-active" role="tab" aria-selected="true" data-npc-editor-tab="general">🧭 General</button>
-    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="bios">📖 Bios</button>
+    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="bios">📖 Roleplay</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="relationships">🤝 Relationships</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="info">🛠️ Info</button>
 </div>

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 $enginePath = __DIR__ . DIRECTORY_SEPARATOR . "../../";
 
@@ -2052,7 +2052,164 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
     </script>
     <?php endif; ?>
 
-    <div class="form-grid">
+    <div class="npc-editor-tabs" role="tablist" aria-label="NPC editor categories" data-npc-editor-tabs data-storage-key="herika-npc-editor-tab">
+    <button type="button" class="npc-editor-tab is-active" role="tab" aria-selected="true" data-npc-editor-tab="general">🧭 General</button>
+    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="bios">📖 Bios</button>
+    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="relationships">🤝 Relationships</button>
+    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="info">🛠️ Info</button>
+</div>
+<style>
+.npc-editor-tabs {
+    display:grid;
+    grid-template-columns:repeat(4, minmax(0, 1fr));
+    gap:8px;
+    margin-bottom:14px;
+    padding:8px;
+    border:1px solid #3a3a3a;
+    border-radius:10px;
+    background:rgba(30, 30, 30, 0.92);
+}
+.npc-editor-tab {
+    position:relative;
+    min-height:40px;
+    padding:8px 12px;
+    border:1px solid #444;
+    border-radius:7px;
+    background:#303030;
+    color:#ddd;
+    font-weight:700;
+    cursor:pointer;
+    transition:border-color 0.15s ease, background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+.npc-editor-tab:hover { border-color:rgba(242,124,17,0.55); background:#383838; }
+.npc-editor-tabs .npc-editor-tab.is-active {
+    border-color:rgb(242,124,17) !important;
+    color:#fff !important;
+    background:rgba(92,53,25,0.95) !important;
+    box-shadow:inset 0 0 0 1px rgba(242,124,17,0.28), 0 0 12px rgba(242,124,17,0.24) !important;
+    transform:translateY(-1px) !important;
+}
+.npc-editor-tab:focus-visible { outline:2px solid rgb(242,124,17); outline-offset:2px; }
+.npc-editor-panels { display:block; }
+.npc-editor-panel[hidden] { display:none !important; }
+@media (max-width:700px) { .npc-editor-tabs { grid-template-columns:repeat(2, minmax(0, 1fr)); } }
+</style>
+<script>
+(function(){
+    const fieldSections = {
+        general: new Set(['npc_name','profile_id','lock_profile','npc_favorite','gender','race','base','refid','oghma_knowledge_tags','worldknowledge_tags','world_knowledge_tags','voiceid','faction','dynamic_profile','middle_term_enabled','individual_memory_enabled','auto_diary_enabled','auto_diary_wait_enabled','salutation_after_a_while','prompt_head']),
+        bios: new Set(['core','npc_static_bio','appearance','personality','occupation','speechstyle','goals']),
+        relationships: new Set(['relationships','relationships_jsonb']),
+        info: new Set(['skills','emote_moods','middle_term_latest','metadata','extended_data'])
+    };
+
+    function initNpcEditorTabs(){
+        document.querySelectorAll('[data-npc-editor-tabs]').forEach(function(tablist, index){
+            if (tablist.dataset.initialized === '1') return;
+            const form = tablist.closest('form');
+            const grid = form ? form.querySelector('.form-grid') : null;
+            if (!form || !grid) return;
+            tablist.dataset.initialized = '1';
+
+            const panels = {};
+            ['general','bios','relationships','info'].forEach(function(section){
+                const panel = document.createElement('div');
+                panel.className = 'npc-editor-panel form-grid';
+                panel.dataset.npcEditorPanel = section;
+                panel.id = 'npc-editor-panel-' + section + '-' + index;
+                panel.setAttribute('role', 'tabpanel');
+                panels[section] = panel;
+                const button = tablist.querySelector('[data-npc-editor-tab="' + section + '"]');
+                if (button) button.setAttribute('aria-controls', panel.id);
+            });
+
+            function tokensFor(unit){
+                const nodes = [];
+                if (unit.matches('[id],[name]')) nodes.push(unit);
+                unit.querySelectorAll('[id],[name]').forEach(function(node){ nodes.push(node); });
+                const tokens = [];
+                nodes.forEach(function(node){
+                    if (node.id) tokens.push(node.id);
+                    if (node.getAttribute('name')) tokens.push(node.getAttribute('name'));
+                });
+                return tokens;
+            }
+
+            function sectionFor(unit){
+                if (unit.id === 'relationship-editor-section' || unit.querySelector('#relationship-editor-section')) return 'relationships';
+                const label = unit.querySelector('label:not([for])');
+                if (label && label.textContent.replace(/\s+/g, ' ').trim() === 'Relationships') return 'relationships';
+                const tokens = tokensFor(unit);
+                for (const section of ['relationships','general','bios','info']) {
+                    if (tokens.some(function(token){ return fieldSections[section].has(token); })) return section;
+                }
+                return 'info';
+            }
+
+            function isFieldUnit(unit){
+                if (!(unit instanceof Element)) return false;
+                if (unit.matches('.form-item,#relationship-editor-section,input,textarea,select,details')) return true;
+                return Boolean(unit.querySelector('input,textarea,select,details,#relationship-editor-section'));
+            }
+
+            function moveUnit(unit){
+                if (!isFieldUnit(unit)) return;
+                panels[sectionFor(unit)].appendChild(unit);
+            }
+
+            Array.from(grid.children).forEach(function(unit){
+                if (unit.classList.contains('dynamic-profile-section')) {
+                    Array.from(unit.children).forEach(moveUnit);
+                    unit.hidden = true;
+                    return;
+                }
+                moveUnit(unit);
+            });
+
+            grid.classList.remove('form-grid');
+            grid.classList.add('npc-editor-panels');
+            Object.values(panels).forEach(function(panel){ grid.appendChild(panel); });
+
+            const storageKey = tablist.dataset.storageKey || 'npc-editor-tab';
+            function activate(section){
+                if (!panels[section]) section = 'general';
+                tablist.querySelectorAll('[data-npc-editor-tab]').forEach(function(button){
+                    const active = button.dataset.npcEditorTab === section;
+                    button.classList.toggle('is-active', active);
+                    button.setAttribute('aria-selected', active ? 'true' : 'false');
+                    button.tabIndex = active ? 0 : -1;
+                });
+                Object.entries(panels).forEach(function(entry){ entry[1].hidden = entry[0] !== section; });
+                try { window.localStorage.setItem(storageKey, section); } catch (_e) {}
+            }
+
+            tablist.addEventListener('click', function(event){
+                const button = event.target.closest('[data-npc-editor-tab]');
+                if (button) activate(button.dataset.npcEditorTab);
+            });
+            tablist.addEventListener('keydown', function(event){
+                if (!['ArrowLeft','ArrowRight','Home','End'].includes(event.key)) return;
+                const buttons = Array.from(tablist.querySelectorAll('[data-npc-editor-tab]'));
+                let next = buttons.indexOf(document.activeElement);
+                if (event.key === 'Home') next = 0;
+                else if (event.key === 'End') next = buttons.length - 1;
+                else next = (next + (event.key === 'ArrowRight' ? 1 : -1) + buttons.length) % buttons.length;
+                event.preventDefault();
+                buttons[next].focus();
+                activate(buttons[next].dataset.npcEditorTab);
+            });
+
+            let initial = 'general';
+            try { initial = window.localStorage.getItem(storageKey) || initial; } catch (_e) {}
+            activate(initial);
+        });
+    }
+
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initNpcEditorTabs);
+    window.setTimeout(initNpcEditorTabs, 0);
+})();
+</script>
+<div class="form-grid">
         <div class="form-item span-2">
             <label for="npc_name">NPC Name</label>
             <input type="text" id="npc_name" name="npc_name" placeholder="e.g. Aela the Huntress" value="<?= htmlspecialchars($editItem["npc_name"] ?? "") ?>">
@@ -2392,14 +2549,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
         <?php if (file_exists(__DIR__."/../../ext/relationship_system/relationship_editor.php")) {
             include(__DIR__."/../../ext/relationship_system/relationship_editor.php");
         } ?>
-
-        <div class="form-item">
-            <label for="relationships">Relationships (Deprecated)</label>
-            <textarea id="relationships" name="relationships" placeholder="Legacy relationship text."><?= htmlspecialchars($editItem["relationships"] ?? "") ?></textarea>
-            <small class="hint">This legacy text field is still editable, but it is no longer used in prompting. Prompt relationship context comes from Relationships above.</small>
-        </div>
-
-        <div class="form-item">
+<div class="form-item">
             <label for="occupation">Occupation</label>
             <textarea id="occupation" name="occupation" placeholder="Role, job, affiliations."><?= htmlspecialchars($editItem["occupation"] ?? "") ?></textarea>
             <small class="hint">Primary role or job. Include relevant guilds or factions.</small>

--- a/ui/core/tts_connectors.php
+++ b/ui/core/tts_connectors.php
@@ -582,7 +582,7 @@ if (!$isEmbed) {
 }
 ?>
 
-<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/main.css">
+<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/main.css?v=<?php echo (int) @filemtime(dirname(__DIR__) . '/css/main.css'); ?>">
 <style>
 @font-face {
     font-family: 'MagicCards';
@@ -653,9 +653,9 @@ h1.api-title { margin: 0 0 20px 0; font-family: 'MagicCards', serif; word-spacin
 
         <div class="layout">
             <div class="left-col">
-                <div class="btn-row">
-                    <a class="btn-save" href="<?php echo h(ttsPageUrl(['create_blank' => 1])); ?>">New Connector</a>
-                    <form method="post" action="<?php echo h(ttsPageUrl()); ?>" enctype="multipart/form-data" id="tts_import_form" style="display:inline;">
+                <div class="btn-row sidebar-action-grid">
+                    <a class="btn-save" href="<?php echo h(ttsPageUrl(['create_blank' => 1])); ?>">New</a>
+                    <form method="post" action="<?php echo h(ttsPageUrl()); ?>" enctype="multipart/form-data" id="tts_import_form">
                         <input type="hidden" name="import" value="1">
                         <input type="file" name="import_file[]" id="tts_import_file" accept=".csv" multiple style="display:none;">
                         <button type="button" class="btn-primary" id="tts_import_btn">Import</button>

--- a/ui/css/diary_adventure.css
+++ b/ui/css/diary_adventure.css
@@ -1,3 +1,10 @@
+:root {
+    --log-accent: #f27c11;
+    --log-accent-hover: #ca5c0a;
+    --log-accent-soft: rgba(242, 124, 17, 0.2);
+    --log-button-text: #ffffff;
+}
+
 /* ==========================================================================
    Combined Diary and Adventure Log Styles
    ========================================================================== */
@@ -51,9 +58,9 @@
 }
 
 .calendar td.has-event a {
-    background-color: rgb(212, 94, 0, 0.9);
-    color: white;
-    border: 2px solid rgb(172, 76, 0);
+    background-color: var(--log-accent);
+    color: var(--log-button-text);
+    border: 2px solid var(--log-accent-hover);
     border-radius: 5px;
     box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
     transition: all 0.3s ease-in-out;
@@ -67,10 +74,10 @@
 }
 
 .calendar td.has-event a:hover {
-    background-color: rgb(172, 76, 0, 0.95);
+    background-color: var(--log-accent-hover);
     transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-    color: white;
+    color: var(--log-button-text);
 }
 
 .calendar td.has-event a:hover::after {
@@ -80,7 +87,7 @@
     left: 50%;
     transform: translateX(-50%);
     background-color: #333;
-    color: white;
+    color: var(--log-button-text);
     padding: 5px 10px;
     border-radius: 5px;
     font-size: 12px;
@@ -90,14 +97,14 @@
 
 .calendar td.current-date a {
     background-color: #28a745;
-    color: white;
+    color: var(--log-button-text);
     border: 2px solid #1e7e34;
     font-weight: bold;
 }
 
 .calendar td.current-date.has-event a {
     background-color: #28a745;
-    color: white;
+    color: var(--log-button-text);
     border: 2px solid #1e7e34;
 }
 
@@ -130,14 +137,14 @@
     padding: 8px 15px;
     text-decoration: none;
     border-radius: 5px;
-    background-color: rgb(212, 94, 0, 0.9);
-    color: white;
-    border: 2px solid rgb(172, 76, 0);
+    background-color: var(--log-accent);
+    color: var(--log-button-text);
+    border: 2px solid var(--log-accent-hover);
     transition: all 0.3s ease;
 }
 
 .calendar-navigation a:hover {
-    background-color: rgb(172, 76, 0, 0.95);
+    background-color: var(--log-accent-hover);
     transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
@@ -158,14 +165,14 @@
 }
 
 .calendar-mode-toggle .btn-primary {
-    background-color: rgb(212, 94, 0, 0.9);
-    color: white;
-    border: 2px solid rgb(172, 76, 0);
+    background-color: var(--log-accent);
+    color: var(--log-button-text);
+    border: 2px solid var(--log-accent-hover);
 }
 
 .calendar-mode-toggle .btn-secondary {
     background-color: #6c757d;
-    color: white;
+    color: var(--log-button-text);
     border: 2px solid #545b62;
 }
 
@@ -175,7 +182,7 @@
 }
 
 .calendar-mode-toggle .btn-primary:hover {
-    background-color: rgb(172, 76, 0, 0.95);
+    background-color: var(--log-accent-hover);
 }
 
 /* CSV Buttons Container */
@@ -190,6 +197,20 @@
 
 .csv-buttons button {
     min-width: 200px;
+}
+
+.csv-buttons .btn-save,
+body .csv-buttons button.log-action-button[type="submit"] {
+    background: var(--log-accent) !important;
+    background-image: none !important;
+    border-color: var(--log-accent-hover) !important;
+    color: var(--log-button-text) !important;
+}
+
+.csv-buttons .btn-save:hover,
+body .csv-buttons button.log-action-button[type="submit"]:hover {
+    background: var(--log-accent-hover) !important;
+    color: var(--log-button-text) !important;
 }
 
 /* Event Table Styles */
@@ -216,7 +237,7 @@
 }
 
 .event-table .entry-cell:hover {
-    background-color: rgba(212, 94, 0, 0.2);
+    background-color: var(--log-accent-soft);
     transform: translateY(-1px);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
@@ -288,7 +309,7 @@ main.container {
 
 .people-search:focus {
     outline: none;
-    border-color: rgb(212, 94, 0);
+    border-color: var(--log-accent);
 }
 
 .people-list form {
@@ -320,13 +341,13 @@ main.container {
 
 .people-item:hover {
     background-color: #555555;
-    border-color: rgb(212, 94, 0);
+    border-color: var(--log-accent);
     transform: translateX(5px);
 }
 
 .people-count {
-    background-color: rgb(212, 94, 0);
-    color: white;
+    background-color: var(--log-accent);
+    color: var(--log-button-text);
     padding: 4px 8px;
     border-radius: 4px;
     font-size: 14px;
@@ -335,10 +356,10 @@ main.container {
 
 .pdf-export-btn {
     padding: 10px 18px;
-    background-color: rgb(212, 94, 0);
-    border: 2px solid rgb(172, 76, 0);
+    background-color: var(--log-accent);
+    border: 2px solid var(--log-accent-hover);
     border-radius: 6px;
-    color: #fff;
+    color: var(--log-button-text);
     font-size: 16px;
     font-weight: 600;
     cursor: pointer;
@@ -352,7 +373,7 @@ main.container {
 }
 
 .pdf-export-btn:hover {
-    background-color: rgb(172, 76, 0);
+    background-color: var(--log-accent-hover);
     transform: translateY(-1px);
     box-shadow: 0 4px 10px rgba(0,0,0,0.3);
 }
@@ -476,7 +497,7 @@ body.modal-open {
 }
 
 #entryModal .entry-content::-webkit-scrollbar-thumb {
-    background: rgba(212, 94, 0, 0.5);
+    background: rgba(242, 124, 17, 0.5);
     border-radius: 4px;
 }
 

--- a/ui/css/main.css
+++ b/ui/css/main.css
@@ -1685,3 +1685,34 @@ body .installer-container .status-error {
     }
 }
 
+.sidebar-action-grid,
+.btn-row.sidebar-action-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin: 6px 0 10px 4px;
+}
+
+.sidebar-action-grid > form {
+    display: block;
+    margin: 0;
+    min-width: 0;
+}
+
+.sidebar-action-grid > button,
+.sidebar-action-grid > a,
+.sidebar-action-grid > form > button {
+    width: 100%;
+    min-height: 36px;
+    margin: 0;
+    justify-content: center;
+    background-image: none !important;
+    box-shadow: none !important;
+    transform: none !important;
+}
+
+.sidebar-action-grid.single-action > form,
+.sidebar-action-grid.single-action > button,
+.sidebar-action-grid.single-action > a {
+    grid-column: 1 / -1;
+}

--- a/ui/diarylog.php
+++ b/ui/diarylog.php
@@ -461,7 +461,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 ?>
 <!-- Ensure main.css is loaded after any reboot.css -->
 <link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/main.css">
-<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/diary_adventure.css">
+<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/diary_adventure.css?v=<?php echo (int) @filemtime(__DIR__ . '/css/diary_adventure.css'); ?>">
 <style>
     @font-face {
         font-family: 'MagicCards';
@@ -924,7 +924,7 @@ if ($shouldFetchEvents) {
             foreach ($currentCsvParams as $key => $value) {
                 echo "<input type='hidden' name='" . htmlspecialchars($key) . "' value='" . htmlspecialchars($value) . "'>";
             }
-            echo "<button type='submit' class='btn-save'>Download Current Diaries</button>";
+        echo "<button type='submit' class='btn-save log-action-button'>Download Current Diaries</button>";
             echo "</form>";
 
             // For all entries, only preserve month and year if they exist
@@ -941,7 +941,7 @@ if ($shouldFetchEvents) {
             foreach ($allCsvParams as $key => $value) {
                 echo "<input type='hidden' name='" . htmlspecialchars($key) . "' value='" . htmlspecialchars($value) . "'>";
             }
-            echo "<button type='submit' class='btn-save'>Download All Diary Entries</button>";
+    echo "<button type='submit' class='btn-save log-action-button'>Download All Diary Entries</button>";
             echo "</form>";
 
             // Delete all button

--- a/ui/events-memories.php
+++ b/ui/events-memories.php
@@ -634,7 +634,6 @@ function getTimeColor($time) {
                 'data' => 'Events',
                 'gamets' => '<a href="https://en.uesp.net/wiki/Lore:Calendar" target="_blank" style="color: yellow;">Tamrielic Time</a>',
                 'localts' => 'Time (UTC)',
-                'ts' => 'TS',
             ];
             
             $mappedResults = array_map(function ($row) use ($columnHeaders) {
@@ -686,7 +685,7 @@ function getTimeColor($time) {
                             $peoplePresent = chimRenderNarratorRoleplayText($peoplePresent);
                         }
                         $mappedRow['People Present'] = htmlspecialchars($peoplePresent);
-                    } else if ($key === 'people') {
+                    } else if ($key === 'people' || $key === 'ts') {
                         // Skip rendering raw people column; we show only 'People Present'
                         continue;
                     } else {
@@ -929,12 +928,9 @@ function getTimeColor($time) {
                                 newRow.appendChild(td5);
                                 
                                 const td6 = document.createElement('td');
-                                td6.innerHTML = row['TS'] || '';
+                                const rowId = row['ROWID'] || '';
+                                td6.innerHTML = '<a class=\"icon-link\" href=\"#\" style=\"color: red !important;\" onclick=\"deleteRowAndRefresh(\'eventlog\', ' + JSON.stringify(rowId) + '); return false;\">' + rowId + ' <i class=\"bi-trash\" style=\"color: red !important;\"></i></a>';
                                 newRow.appendChild(td6);
-                                
-                                const td7 = document.createElement('td');
-                                td7.textContent = row['ROWID'] || '';
-                                newRow.appendChild(td7);
                                 
                                 if (headerRow && headerRow.nextSibling) {
                                     tbody.insertBefore(newRow, headerRow.nextSibling);

--- a/ui/global_settings.php
+++ b/ui/global_settings.php
@@ -112,16 +112,17 @@ $gsSections = [
 ];
 
 $settingsTabs = [
-    'prompt-rechat' => 'Prompt & Rechat',
-    'ai-memory' => 'AI & Memory',
-    'context-knowledge' => 'Context & Knowledge',
-    'general' => 'General',
+    'prompt-rechat' => '💬 Prompt & Rechat',
+    'global-connectors' => '🔌 Global Connectors',
+    'ai-memory' => '🧠 AI & Memory',
+    'context-knowledge' => '📚 Context & Knowledge',
+    'general' => '⚙️ General',
 ];
 
 $sectionTabs = [
     'Prompt & Rechat' => 'prompt-rechat',
     'Memory' => 'ai-memory',
-    'Global Connectors' => 'ai-memory',
+    'Global Connectors' => 'global-connectors',
     'Oghma' => 'context-knowledge',
     'Context' => 'context-knowledge',
     $promptContextSectionTitle => 'context-knowledge',
@@ -132,6 +133,7 @@ $sectionTabs = [
 
 $tabControlPanels = [
     'prompt-rechat' => 'settings-panel-prompt-rechat-prompt-rechat',
+    'global-connectors' => 'settings-panel-global-connectors-global-connectors',
     'ai-memory' => 'settings-panel-ai-memory-memory',
     'context-knowledge' => 'settings-panel-context-knowledge-oghma',
     'general' => 'settings-panel-general-misc',
@@ -513,7 +515,7 @@ h1.gs-title {
 
 .settings-tabs {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 8px;
     margin-bottom: 14px;
     padding: 8px;
@@ -523,6 +525,7 @@ h1.gs-title {
 }
 
 .settings-tab {
+    position: relative;
     min-height: 40px;
     padding: 8px 12px;
     border: 1px solid #444;
@@ -531,6 +534,7 @@ h1.gs-title {
     color: #ddd;
     font-weight: 700;
     cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
 }
 
 .settings-tab:hover {
@@ -538,11 +542,12 @@ h1.gs-title {
     background: #383838;
 }
 
-.settings-tab.is-active {
-    border-color: rgb(242,124,17);
-    color: #fff;
-    background: #3b3028;
-    box-shadow: inset 0 0 0 1px rgba(242, 124, 17, 0.18);
+body .settings-tabs .settings-tab.is-active {
+    border-color: rgb(242,124,17) !important;
+    color: #fff !important;
+    background: rgba(92, 53, 25, 0.95) !important;
+    box-shadow: inset 0 0 0 1px rgba(242, 124, 17, 0.28), 0 0 12px rgba(242, 124, 17, 0.24) !important;
+    transform: translateY(-1px) !important;
 }
 
 .settings-tab:focus-visible {

--- a/ui/global_settings.php
+++ b/ui/global_settings.php
@@ -206,12 +206,57 @@ function pretty_label(string $flatName): string
 function icon_for_field(string $flatName): string
 {
     $u = strtoupper($flatName);
-    if ($u === 'PLAYER_WORST_MEMORY_GAME_DAYS') return '💔';
-    if (strpos($u, 'FEATURES@MEMORY_EMBEDDING@') === 0 || strpos($u, 'MEMORY_') !== false) return '💭';
-    if ($u === 'PLAYER_NAME') return '🏷️';
-    if ($u === 'PROMPT_HEAD') return '🔝';
-    if ($u === 'EMOTEMOODS') return '🎭';
-    if ($u === 'PROMPT_TIMESTAMP') return '🕐';
+    $icons = [
+        'PLAYER_NAME' => '🏷️',
+        'PROMPT_HEAD' => '🔝',
+        'EMOTEMOODS' => '🎭',
+        'RECHAT_MODE' => '🔁',
+        'ENFORCE_STRICT_RECHAT_RESPONSE' => '🎯',
+        'OGHMA_INFINIUM' => '📚',
+        'OGHMA_AMOUNT' => '🔢',
+        'RACIAL_OGHMA' => '🧬',
+        'LOCATION_OGHMA' => '📍',
+        'FEATURES@MEMORY_EMBEDDING@ENABLED' => '🧠',
+        'FEATURES@MEMORY_EMBEDDING@TXTAI_URL' => '🔗',
+        'FEATURES@MEMORY_EMBEDDING@USE_TEXT2VEC' => '🔤',
+        'FEATURES@MEMORY_EMBEDDING@AUTO_CREATE_SUMMARY_INTERVAL' => '⏱️',
+        'PLAYER_WORST_MEMORY_GAME_DAYS' => '💔',
+        'AUTO_LOCK_PROFILE' => '🔒',
+        'AUTOFILL_CUSTOM_PROFILES' => '✨',
+        'AUTOFILL_CUSTOM_PROFILES_TRIGGER' => '🎯',
+        'BGL_TRIGGER_HOURS' => '🌍',
+        'END_CONVERSATION_COOLDOWN' => '⏳',
+        'CHIM_AI_QUEST_PROGRESSION' => '🗺️',
+        'CHIM_PLAYER_ONLY_QUEST_ADVANCEMENT' => '🧍',
+        'SCENE_CLASSIFIER_ENABLED' => '🎭',
+        'RELATIONSHIP_SYSTEM_ENABLED' => '💞',
+        'RELLLM_CONNECTOR' => '🔗',
+        'DETECT_MAGIC_EVENT' => '✨',
+        'GROUND_ITEMS_DESCRIPTIONS_ONLY' => '🪨',
+        'INVENTORY_ITEMS_DESCRIPTIONS_ONLY' => '🎒',
+        'HIDE_AMBIENT_COMBAT' => '🕊️',
+        'DISABLE_REANIMATION_TRACKING' => '🧟',
+        'TRANSFORMATION_DETECTION' => '🐺',
+        'POWER_AWARENESS_ENABLED' => '⚔️',
+        'CHIM_ITEM_PICKUP_EVENTLOG_MIN_VALUE' => '💰',
+        'PROMPT_TIMESTAMP' => '🕐',
+        'MAGIC_EVENT_BLACKLIST' => '🪄',
+        'LOCATION_BLACKLIST' => '📍',
+        'ITEM_BLACKLIST' => '📦',
+        'EVENT_TYPE_FILTER' => '🔍',
+        'TRANSLATION_FUNCTION' => '🌐',
+        'TRANSLATION@SETTINGS@TRANSLATE_AUDIO' => '🎧',
+        'TRANSLATION@SETTINGS@TRANSLATE_TEXT' => '📝',
+        'TRANSLATION@SETTINGS@SAVE_TRANSLATED_TEXT' => '💾',
+        'TRANSLATION@SETTINGS@TRANSLATE_PLAYER_AUDIO' => '🎙️',
+        'TRANSLATION@SETTINGS@SAVE_TRANSLATED_PLAYER_TEXT' => '💾',
+        'TRANSLATION@DEEPL@SOURCE_LANGUAGE' => '🗣️',
+        'TRANSLATION@DEEPL@TARGET_LANGUAGE' => '🌍',
+        'TRANSLATION@DEEPL@URL' => '🔗',
+        'TRANSLATION@DEEPL@PLAYER_SOURCE_LANGUAGE' => '🎤',
+        'TRANSLATION@DEEPL@PLAYER_TARGET_LANGUAGE' => '🌎',
+    ];
+    if (isset($icons[$u])) return $icons[$u];
     if (strpos($u, 'CORE_CONNECTOR_') === 0) {
         if ($u === 'CORE_CONNECTOR_PLAYER') return '🎮';
         if ($u === 'CORE_CONNECTOR_SUMMARY') return '📝';
@@ -220,20 +265,18 @@ function icon_for_field(string $flatName): string
         if ($u === 'CORE_CONNECTOR_PROFILES') return '👥';
         if ($u === 'CORE_CONNECTOR_DIRECTOR') return '🎬';
         if ($u === 'CORE_CONNECTOR_BGL') return '⏱️';
-        if ($u === 'CORE_CONNECTOR_OGHMA_CUSTOM') return '🐙';
+        if ($u === 'CORE_CONNECTOR_OGHMA_CUSTOM') return '📖';
         return '🔌';
     }
-    if ($u === 'SCENE_CLASSIFIER_ENABLED') return '🎭';
-    if ($u === 'RELATIONSHIP_SYSTEM_ENABLED') return '💞';
-    if ($u === 'RELLLM_CONNECTOR') return '🔗';
-    if ($u === 'POWER_AWARENESS_ENABLED') return '⚔️';
     if (strpos($u, 'RESPEECH') !== false) return '🦜';
     if (strpos($u, 'SPEECH_STYLE') !== false) return '🦜';
-    if (strpos($u, 'SUMMARY_PROMPT') === 0) return '🎭';
-    if (strpos($u, 'DYNAMIC_PROMPT_') === 0) return '🎭';
+    if (strpos($u, 'SUMMARY_PROMPT') === 0) return '📝';
+    if (strpos($u, 'DYNAMIC_PROMPT_') === 0) return '👥';
     if (strpos($u, 'DIARY') !== false) return '📙';
     if (strpos($u, 'NARRATOR') !== false) return '🗣️';
-    return '⚙️';
+    if (strpos($u, 'MEMORY') !== false) return '🧠';
+    if (strpos($u, 'COOLDOWN') !== false || strpos($u, 'INTERVAL') !== false) return '⏱️';
+    return '🧩';
 }
 
 function select_option_label(string $fieldName, string $optionValue): string

--- a/ui/global_settings.php
+++ b/ui/global_settings.php
@@ -113,30 +113,28 @@ $gsSections = [
 
 $settingsTabs = [
     'prompt-rechat' => '💬 Prompt & Rechat',
-    'global-connectors' => '🔌 Global Connectors',
-    'ai-memory' => '🧠 AI & Memory',
+    'ai-memory' => '🧠 Memory & Others',
     'context-knowledge' => '📚 Context & Knowledge',
-    'general' => '⚙️ General',
+    'global-connectors' => '🔌 Global Connectors',
 ];
 
 $sectionTabs = [
     'Prompt & Rechat' => 'prompt-rechat',
     'Memory' => 'ai-memory',
-    'Global Connectors' => 'global-connectors',
+    'Misc' => 'ai-memory',
+    'Quests' => 'ai-memory',
+    'Translation' => 'ai-memory',
     'Oghma' => 'context-knowledge',
     'Context' => 'context-knowledge',
     $promptContextSectionTitle => 'context-knowledge',
-    'Misc' => 'general',
-    'Quests' => 'general',
-    'Translation' => 'general',
+    'Global Connectors' => 'global-connectors',
 ];
 
 $tabControlPanels = [
     'prompt-rechat' => 'settings-panel-prompt-rechat-prompt-rechat',
-    'global-connectors' => 'settings-panel-global-connectors-global-connectors',
     'ai-memory' => 'settings-panel-ai-memory-memory',
     'context-knowledge' => 'settings-panel-context-knowledge-oghma',
-    'general' => 'settings-panel-general-misc',
+    'global-connectors' => 'settings-panel-global-connectors-global-connectors',
 ];
 
 function pretty_label(string $flatName): string

--- a/ui/global_settings.php
+++ b/ui/global_settings.php
@@ -46,7 +46,6 @@ $gsSections = [
     'Prompt & Rechat' => [
         [ 'name' => 'PROMPT_HEAD', 'type' => 'longstring' ],
         [ 'name' => 'EMOTEMOODS', 'type' => 'longstring' ],
-        [ 'name' => 'DETECT_MAGIC_EVENT', 'type' => 'boolean' ],
         [ 'name' => 'RECHAT_MODE', 'type' => 'select', 'values' => ['tight', 'conversational', 'group', 'random'] ],
         [ 'name' => 'ENFORCE_STRICT_RECHAT_RESPONSE', 'type' => 'boolean' ],
     ],
@@ -56,6 +55,13 @@ $gsSections = [
         [ 'name' => 'RACIAL_OGHMA', 'type' => 'boolean' ],
         [ 'name' => 'LOCATION_OGHMA', 'type' => 'boolean' ],
         [ 'name' => 'CORE_CONNECTOR_OGHMA_CUSTOM', 'type' => 'foreign:core_llm_connector:id:label' ],
+    ],
+    'Memory' => [
+        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@ENABLED', 'type' => 'boolean' ],
+        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@TXTAI_URL', 'type' => 'url' ],
+        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@USE_TEXT2VEC', 'type' => 'boolean' ],
+        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@AUTO_CREATE_SUMMARY_INTERVAL', 'type' => 'integer' ],
+        [ 'name' => 'PLAYER_WORST_MEMORY_GAME_DAYS', 'type' => 'integer', 'min' => 0, 'max' => 365, 'default' => 7, 'help' => 'How long the player\'s worst memory of an NPC lingers before it fades, in in-game days (0 = never forget). Default 7 (one game-week). NPC-to-NPC worst memories are always permanent.' ],
     ],
     'Misc' => [
         [ 'name' => 'AUTO_LOCK_PROFILE', 'type' => 'boolean' ],
@@ -68,13 +74,6 @@ $gsSections = [
         [ 'name' => 'CHIM_AI_QUEST_PROGRESSION', 'type' => 'boolean' ],
         [ 'name' => 'CHIM_PLAYER_ONLY_QUEST_ADVANCEMENT', 'type' => 'boolean' ],
     ],
-    'Memory' => [
-        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@ENABLED', 'type' => 'boolean' ],
-        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@TXTAI_URL', 'type' => 'url' ],
-        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@USE_TEXT2VEC', 'type' => 'boolean' ],
-        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@AUTO_CREATE_SUMMARY_INTERVAL', 'type' => 'integer' ],
-        [ 'name' => 'PLAYER_WORST_MEMORY_GAME_DAYS', 'type' => 'integer', 'min' => 0, 'max' => 365, 'default' => 7, 'help' => 'How long the player\'s worst memory of an NPC lingers before it fades, in in-game days (0 = never forget). Default 7 (one game-week). NPC-to-NPC worst memories are always permanent.' ],
-    ],
     'Global Connectors' => [
         [ 'name' => 'CORE_CONNECTOR_PLAYER', 'type' => 'foreign:core_llm_connector:id:label' ],
         [ 'name' => 'CORE_CONNECTOR_SUMMARY', 'type' => 'foreign:core_llm_connector:id:label' ],
@@ -86,6 +85,7 @@ $gsSections = [
         [ 'name' => 'RELLLM_CONNECTOR', 'type' => 'foreign:core_llm_connector:id:label' ],
     ],
     'Context' => [
+        [ 'name' => 'DETECT_MAGIC_EVENT', 'type' => 'boolean' ],
         [ 'name' => 'GROUND_ITEMS_DESCRIPTIONS_ONLY', 'type' => 'boolean' ],
         [ 'name' => 'INVENTORY_ITEMS_DESCRIPTIONS_ONLY', 'type' => 'boolean' ],
         [ 'name' => 'HIDE_AMBIENT_COMBAT', 'type' => 'boolean' ],
@@ -640,7 +640,8 @@ body .settings-tabs .settings-tab.is-active {
     gap: 10px;
     color: #e0e0e0;
     min-width: 0;
-    flex-wrap: wrap;
+    width: 100%;
+    flex-wrap: nowrap;
 }
 
 .provider-icon {
@@ -667,6 +668,14 @@ body .settings-tabs .settings-tab.is-active {
     gap: 10px;
     width: 100%;
     min-width: 0;
+}
+
+.filter-setting-card {
+    grid-template-columns: minmax(180px, 0.65fr) minmax(420px, 1.7fr) minmax(180px, 0.65fr);
+}
+
+.filter-setting-card .provider-body {
+    width: 100%;
 }
 
 .btn-filter-browse {
@@ -724,9 +733,10 @@ body .settings-tabs .settings-tab.is-active {
 }
 
 .provider-toggle {
-    margin-left: 10px;
+    margin-left: auto;
     display: flex;
     align-items: center;
+    flex: 0 0 auto;
 }
 
 .provider-toggle input[type="checkbox"] {
@@ -1382,7 +1392,7 @@ body .settings-tabs .settings-tab.is-active {
                                             $isReadonly = isset($schemaDefinition['readonly']) && $schemaDefinition['readonly'] === true;
                                             $readonlyAttr = $isReadonly ? 'readonly' : '';
                                             ?>
-                                            <div class="provider-card">
+                                            <div class="provider-card<?php echo isset($filterBrowseFieldConfigs[$fieldName]) ? ' filter-setting-card' : ''; ?>">
                                                 <div class="provider-head">
                                                     <div class="provider-title">
                                                         <div class="provider-icon"><?php echo icon_for_field($fieldName); ?></div>
@@ -1415,10 +1425,10 @@ body .settings-tabs .settings-tab.is-active {
                                                             <textarea name="<?php echo htmlspecialchars($fieldName); ?>" rows="4" <?php echo $readonlyAttr; ?>><?php echo htmlspecialchars(strval($current)); ?></textarea>
                                                         <?php endif; ?>
                                                     <?php endif; ?>
-                                                    <?php if (!empty($help)): ?>
-                                                        <p class="provider-help"><?php echo render_provider_help($fieldName, $help, $webRoot); ?></p>
-                                                    <?php endif; ?>
                                                 </div>
+                                                <?php if (!empty($help)): ?>
+                                                    <p class="provider-help"><?php echo render_provider_help($fieldName, $help, $webRoot); ?></p>
+                                                <?php endif; ?>
                                             </div>
                                         <?php endforeach; ?>
                                     </div>
@@ -1458,7 +1468,7 @@ body .settings-tabs .settings-tab.is-active {
                             $isReadonly = isset($schemaDefinition['readonly']) && $schemaDefinition['readonly'] === true;
                             $readonlyAttr = $isReadonly ? 'readonly' : '';
                             ?>
-                            <div class="provider-card">
+                            <div class="provider-card<?php echo isset($filterBrowseFieldConfigs[$fieldName]) ? ' filter-setting-card' : ''; ?>">
                                 <div class="provider-head">
                                     <div class="provider-title">
                                         <div class="provider-icon"><?php echo icon_for_field($fieldName); ?></div>

--- a/ui/global_settings.php
+++ b/ui/global_settings.php
@@ -43,10 +43,12 @@ $promptContextOptionFields = [
 ];
 
 $gsSections = [
-    'Prompt' => [
+    'Prompt & Rechat' => [
         [ 'name' => 'PROMPT_HEAD', 'type' => 'longstring' ],
         [ 'name' => 'EMOTEMOODS', 'type' => 'longstring' ],
         [ 'name' => 'DETECT_MAGIC_EVENT', 'type' => 'boolean' ],
+        [ 'name' => 'RECHAT_MODE', 'type' => 'select', 'values' => ['tight', 'conversational', 'group', 'random'] ],
+        [ 'name' => 'ENFORCE_STRICT_RECHAT_RESPONSE', 'type' => 'boolean' ],
     ],
     'Oghma' => [
         [ 'name' => 'OGHMA_INFINIUM', 'type' => 'boolean' ],
@@ -54,10 +56,6 @@ $gsSections = [
         [ 'name' => 'RACIAL_OGHMA', 'type' => 'boolean' ],
         [ 'name' => 'LOCATION_OGHMA', 'type' => 'boolean' ],
         [ 'name' => 'CORE_CONNECTOR_OGHMA_CUSTOM', 'type' => 'foreign:core_llm_connector:id:label' ],
-    ],
-    'Rechat' => [
-        [ 'name' => 'RECHAT_MODE', 'type' => 'select', 'values' => ['tight', 'conversational', 'group', 'random'] ],
-        [ 'name' => 'ENFORCE_STRICT_RECHAT_RESPONSE', 'type' => 'boolean' ],
     ],
     'Misc' => [
         [ 'name' => 'AUTO_LOCK_PROFILE', 'type' => 'boolean' ],
@@ -75,6 +73,7 @@ $gsSections = [
         [ 'name' => 'FEATURES@MEMORY_EMBEDDING@TXTAI_URL', 'type' => 'url' ],
         [ 'name' => 'FEATURES@MEMORY_EMBEDDING@USE_TEXT2VEC', 'type' => 'boolean' ],
         [ 'name' => 'FEATURES@MEMORY_EMBEDDING@AUTO_CREATE_SUMMARY_INTERVAL', 'type' => 'integer' ],
+        [ 'name' => 'PLAYER_WORST_MEMORY_GAME_DAYS', 'type' => 'integer', 'min' => 0, 'max' => 365, 'default' => 7, 'help' => 'How long the player\'s worst memory of an NPC lingers before it fades, in in-game days (0 = never forget). Default 7 (one game-week). NPC-to-NPC worst memories are always permanent.' ],
     ],
     'Global Connectors' => [
         [ 'name' => 'CORE_CONNECTOR_PLAYER', 'type' => 'foreign:core_llm_connector:id:label' ],
@@ -85,7 +84,6 @@ $gsSections = [
         [ 'name' => 'CORE_CONNECTOR_DIRECTOR', 'type' => 'foreign:core_llm_connector:id:label' ],
         [ 'name' => 'CORE_CONNECTOR_BGL', 'type' => 'foreign:core_llm_connector:id:label' ],
         [ 'name' => 'RELLLM_CONNECTOR', 'type' => 'foreign:core_llm_connector:id:label' ],
-        [ 'name' => 'PLAYER_WORST_MEMORY_GAME_DAYS', 'type' => 'integer', 'min' => 0, 'max' => 365, 'default' => 7, 'help' => 'How long the player\'s worst memory of an NPC lingers before it fades, in in-game days (0 = never forget). Default 7 (one game-week). NPC-to-NPC worst memories are always permanent.' ],
     ],
     'Context' => [
         [ 'name' => 'GROUND_ITEMS_DESCRIPTIONS_ONLY', 'type' => 'boolean' ],
@@ -111,6 +109,32 @@ $gsSections = [
         [ 'name' => 'TRANSLATION@DeepL@player_source_language', 'type' => 'string' ],
         [ 'name' => 'TRANSLATION@DeepL@player_target_language', 'type' => 'string' ],
     ],
+];
+
+$settingsTabs = [
+    'prompt-rechat' => 'Prompt & Rechat',
+    'ai-memory' => 'AI & Memory',
+    'context-knowledge' => 'Context & Knowledge',
+    'general' => 'General',
+];
+
+$sectionTabs = [
+    'Prompt & Rechat' => 'prompt-rechat',
+    'Memory' => 'ai-memory',
+    'Global Connectors' => 'ai-memory',
+    'Oghma' => 'context-knowledge',
+    'Context' => 'context-knowledge',
+    $promptContextSectionTitle => 'context-knowledge',
+    'Misc' => 'general',
+    'Quests' => 'general',
+    'Translation' => 'general',
+];
+
+$tabControlPanels = [
+    'prompt-rechat' => 'settings-panel-prompt-rechat-prompt-rechat',
+    'ai-memory' => 'settings-panel-ai-memory-memory',
+    'context-knowledge' => 'settings-panel-context-knowledge-oghma',
+    'general' => 'settings-panel-general-misc',
 ];
 
 function pretty_label(string $flatName): string
@@ -487,6 +511,45 @@ h1.gs-title {
     font-size: 13px;
 }
 
+.settings-tabs {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: 14px;
+    padding: 8px;
+    border: 1px solid #3a3a3a;
+    border-radius: 10px;
+    background: rgba(30, 30, 30, 0.92);
+}
+
+.settings-tab {
+    min-height: 40px;
+    padding: 8px 12px;
+    border: 1px solid #444;
+    border-radius: 7px;
+    background: #303030;
+    color: #ddd;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.settings-tab:hover {
+    border-color: rgba(242, 124, 17, 0.55);
+    background: #383838;
+}
+
+.settings-tab.is-active {
+    border-color: rgb(242,124,17);
+    color: #fff;
+    background: #3b3028;
+    box-shadow: inset 0 0 0 1px rgba(242, 124, 17, 0.18);
+}
+
+.settings-tab:focus-visible {
+    outline: 2px solid rgb(242,124,17);
+    outline-offset: 2px;
+}
+
 .content-grid {
     display: grid;
     grid-template-columns: 1fr;
@@ -540,6 +603,24 @@ h1.gs-title {
     grid-template-columns: minmax(220px, 280px) minmax(420px, 720px) minmax(200px, 1fr);
     gap: 12px 16px;
     align-items: center;
+}
+
+.connector-section .provider-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.connector-section .provider-card {
+    grid-template-columns: 1fr;
+    align-content: start;
+    align-items: start;
+}
+
+.connector-section .provider-body {
+    width: 100%;
+}
+
+.connector-section .provider-help {
+    margin-top: 0;
 }
 
 .provider-head {
@@ -1159,6 +1240,11 @@ h1.gs-title {
 }
 
 @media (max-width: 900px) {
+    .settings-tabs,
+    .connector-section .provider-grid {
+        grid-template-columns: 1fr;
+    }
+
     main {
         padding-left: 5%;
         padding-right: 5%;
@@ -1225,10 +1311,36 @@ h1.gs-title {
         <div class="result-ok" style="margin-bottom: 16px;">Global settings saved to the database.</div>
     <?php endif; ?>
 
+    <div class="settings-tabs" role="tablist" aria-label="Global settings categories">
+        <?php foreach ($settingsTabs as $tabId => $tabLabel): ?>
+            <button
+                type="button"
+                class="settings-tab<?php echo $tabId === 'prompt-rechat' ? ' is-active' : ''; ?>"
+                id="settings-tab-<?php echo htmlspecialchars($tabId); ?>"
+                role="tab"
+                aria-selected="<?php echo $tabId === 'prompt-rechat' ? 'true' : 'false'; ?>"
+                aria-controls="<?php echo htmlspecialchars($tabControlPanels[$tabId]); ?>"
+                data-settings-tab="<?php echo htmlspecialchars($tabId); ?>"
+            ><?php echo htmlspecialchars($tabLabel); ?></button>
+        <?php endforeach; ?>
+    </div>
+
     <form method="post" action="" id="gs_form">
         <div class="content-grid">
             <?php foreach ($gsSections as $sectionTitle => $fields): ?>
-                <div class="content-section">
+                <?php
+                $sectionTab = $sectionTabs[$sectionTitle] ?? 'general';
+                $isInitialTab = $sectionTab === 'prompt-rechat';
+                $sectionClasses = 'content-section' . ($sectionTitle === 'Global Connectors' ? ' connector-section' : '');
+                ?>
+                <div
+                    class="<?php echo htmlspecialchars($sectionClasses); ?>"
+                    id="settings-panel-<?php echo htmlspecialchars($sectionTab); ?>-<?php echo htmlspecialchars(preg_replace('/[^a-z0-9]+/i', '-', strtolower($sectionTitle))); ?>"
+                    role="tabpanel"
+                    aria-labelledby="settings-tab-<?php echo htmlspecialchars($sectionTab); ?>"
+                    data-settings-panel="<?php echo htmlspecialchars($sectionTab); ?>"
+                    <?php echo $isInitialTab ? '' : 'hidden'; ?>
+                >
                     <h2><?php echo htmlspecialchars($sectionTitle); ?></h2>
                     <div class="provider-grid">
                         <?php if ($sectionTitle === $promptContextSectionTitle): ?>
@@ -1308,6 +1420,8 @@ h1.gs-title {
                                         <?php endforeach; ?>
                                     </div>
                                 </div>
+                            </div>
+                            </div>
                             </div>
                             <?php continue; ?>
                         <?php endif; ?>
@@ -1447,6 +1561,78 @@ h1.gs-title {
             <?php endforeach; ?>
         </div>
     </form>
+
+    <script>
+    (() => {
+        const storageKey = 'herika-global-settings-tab';
+        const tabs = Array.from(document.querySelectorAll('[data-settings-tab]'));
+        const panels = Array.from(document.querySelectorAll('[data-settings-panel]'));
+        const form = document.getElementById('gs_form');
+        const validTabs = new Set(tabs.map((tab) => tab.dataset.settingsTab));
+
+        function activateTab(tabId, focusTab = false) {
+            if (!validTabs.has(tabId)) {
+                tabId = 'prompt-rechat';
+            }
+
+            tabs.forEach((tab) => {
+                const active = tab.dataset.settingsTab === tabId;
+                tab.classList.toggle('is-active', active);
+                tab.setAttribute('aria-selected', active ? 'true' : 'false');
+                tab.tabIndex = active ? 0 : -1;
+                if (active && focusTab) {
+                    tab.focus();
+                }
+            });
+
+            panels.forEach((panel) => {
+                panel.hidden = panel.dataset.settingsPanel !== tabId;
+            });
+
+            try {
+                sessionStorage.setItem(storageKey, tabId);
+            } catch (error) {
+                // Storage can be unavailable in privacy-restricted browsers.
+            }
+        }
+
+        tabs.forEach((tab, index) => {
+            tab.addEventListener('click', () => activateTab(tab.dataset.settingsTab));
+            tab.addEventListener('keydown', (event) => {
+                let nextIndex = null;
+                if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+                    nextIndex = (index + 1) % tabs.length;
+                } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+                    nextIndex = (index - 1 + tabs.length) % tabs.length;
+                } else if (event.key === 'Home') {
+                    nextIndex = 0;
+                } else if (event.key === 'End') {
+                    nextIndex = tabs.length - 1;
+                }
+
+                if (nextIndex !== null) {
+                    event.preventDefault();
+                    activateTab(tabs[nextIndex].dataset.settingsTab, true);
+                }
+            });
+        });
+
+        form?.addEventListener('invalid', (event) => {
+            const panel = event.target.closest('[data-settings-panel]');
+            if (panel) {
+                activateTab(panel.dataset.settingsPanel);
+            }
+        }, true);
+
+        let initialTab = 'prompt-rechat';
+        try {
+            initialTab = sessionStorage.getItem(storageKey) || initialTab;
+        } catch (error) {
+            // Keep the default tab when storage is unavailable.
+        }
+        activateTab(initialTab);
+    })();
+    </script>
 
     <div id="global-connector-test-modal" class="global-test-modal" aria-hidden="true">
         <div class="global-test-shell" role="dialog" aria-modal="true" aria-labelledby="global-connector-test-title">


### PR DESCRIPTION
## Summary
- compact profile, LLM, and TTS actions into flat grid layouts
- simplify profile action labels to New, Import, Rules, and Test
- organize Global Settings into emoji-labelled Prompt & Rechat, Memory & Others, Context & Knowledge, and Global Connectors tabs
- move Global Connectors to the final tab and fold Misc, Quests, and Translation into Memory & Others
- keep Memory as the first section in Memory & Others and move Detect Magic Event into Context & Knowledge
- keep boolean toggles aligned to the right and give filter/blacklist editors a consistent near-half-width layout
- add a clear CHIM-orange selected-tab state and preserve the selected tab across reloads
- merge Rechat controls into Prompt & Rechat
- keep Global Connectors in a responsive two-column layout and move Worst Memory Lifespan into Memory
- hide the raw event timestamp column while retaining Tamrielic and UTC time
- keep row-level event deletion aligned with the ROWID column
- apply CHIM orange controls with white text to diary and adventure logs
- version affected stylesheets to prevent stale browser styling after updates
- give every Global Settings option a semantic emoji and remove generic cog icons
- split the NPC editor into General, Roleplay, Relationships, and Info tabs while preserving product-specific fields
- keep biography fields full-width, place editable biography Skills under Roleplay, and retain detected metadata Skills under Info
- move the recent Middle Term Memory display into Relationships
- remove the visible deprecated relationship textarea where present and keep the structured relationship editor

## Validation
- PHP syntax checks passed for every changed PHP file
- `git diff --check` passed
- affected routes returned HTTP 200 locally
- profile, LLM, TTS, events, diary, adventure, and Global Settings views were inspected in-browser
- tab order, selected-state styling, persistence, and all Memory & Others sections were exercised locally
- NPC tab membership, keyboard navigation, single-column Roleplay layout, and field placement were exercised locally
- verified 53/53 visible Global Settings rows have non-empty semantic icons with no cog or fallback icons
- browser console remained free of warnings and errors during tested UI interactions
- deployed locally; source/runtime hashes match

## Notes
- no schema or migration changes
- no files were added, removed, or moved
- all Global Settings fields remain in one form and Save All still submits every tab
- deletion controls were inspected but not executed against local user data

## Related PRs
- HerikaServer: https://github.com/abeiro/HerikaServer/pull/637
- StobeServer: https://github.com/Dwemer-Dynamics/StobeServer/pull/43
- DialecticServer: https://github.com/Dwemer-Dynamics/DialecticServer/pull/20