### PR TITLE
Reject invented relationship types

### DIFF
--- a/ext/relationship_system/relationship_llm.php
+++ b/ext/relationship_system/relationship_llm.php
@@ -480,17 +480,19 @@ PROMPT;
             return null;
         }
 
-        // Validate and normalize
+        // Validate and normalize. Initial analysis may select only built-in types;
+        // custom types do not exist in this initialization context.
         $relationships = [];
-        $validTypes = ['romantic', 'platonic', 'familial', 'professional', 'rival', 'enemy', 'neutral'];
 
         foreach ($parsed['relationships'] as $target => $data) {
             $aff = isset($data['aff']) ? intval($data['aff']) : 0;
-            $type = isset($data['type']) ? strtolower($data['type']) : 'neutral';
+            $rawType = isset($data['type']) ? (string)$data['type'] : 'neutral';
+            $type = RelationshipManager::canonicalizeRelationshipType($rawType);
             $note = isset($data['note']) ? trim($data['note']) : '';
 
             $aff = max(-100, min(100, $aff));
-            if (!in_array($type, $validTypes) && !preg_match('/^[a-z]+$/', $type)) {
+            if ($type === null) {
+                Logger::info("[REL-LLM] REJECTED invented initial relationship type '{$rawType}' for {$target}; using neutral");
                 $type = 'neutral';
             }
 
@@ -932,8 +934,10 @@ Only suggest changes for SIGNIFICANT moments - not every interaction needs a cha
 {$outputKeyInstruction}
 
 Return JSON: {"changes": {"{$listenerKey}": {"delta": X, "reason": "brief"}}}
-If (and ONLY if) this exchange changed the relationship's NATURE - romance, betrayal,
-marriage, becoming enemies - also include "type", e.g.
+If (and ONLY if) this exchange changed the relationship's NATURE - a romance forming,
+a betrayal, marriage, becoming enemies - also include "type". "type" must be EXACTLY one
+of: romantic, platonic, familial, professional, rival, enemy, crush, ex, betrayed
+(the value is "romantic", never "romance"), e.g.
 {"changes": {"{$listenerKey}": {"delta": X, "type": "crush", "reason": "brief"}}}
 Be conservative: one passing line never flips a type. The change must be backed by sustained
 energy or real/implied history, and it must come from {$npcName}'s own expressed feelings -
@@ -1224,7 +1228,10 @@ REASON FORMAT - Keep it SHORT (under 15 words):
 
 TYPE CHANGES (rare - only for DEFINING moments):
 - Add "type" ONLY when this exchange visibly changed the NATURE of the relationship:
-  romance, betrayal, marriage, family reveal, becoming enemies.
+  a romance forming, a betrayal, marriage, a family reveal, becoming enemies.
+- "type" must be EXACTLY one of: romantic, platonic, familial, professional, rival,
+  enemy, crush, ex, betrayed. Never invent other labels: the value is "romantic",
+  NOT "romance"; "betrayed", NOT "betrayal"; "enemy", NOT "enemies".
 - Be conservative. One passing compliment, joke, or flirty line NEVER flips a type.
   A type change must be backed by sustained energy in this exchange or by the history
   between them - repeated warmth, declarations, a shared past, stated or clearly implied.
@@ -1243,6 +1250,13 @@ PROMPT;
         // Seeded defaults from before the type-change syntax existed teach a delta-only output;
         // upgrade them in place. Custom prompts that already know "type" are left alone.
         if (strpos($prompt, 'only for defining moments') !== false && strpos($prompt, '"type"') === false) {
+            return $fallback;
+        }
+        // Older defaults listed the defining MOMENTS ("romance, betrayal, marriage...") right where
+        // a type value was expected, so models copied them verbatim as types ("romance" instead of
+        // "romantic") and the sex-eligibility gates never matched. Supersede any prompt (seeded
+        // default or stale custom) still teaching that wording with the corrected fallback.
+        if (strpos($prompt, 'romance, betrayal') !== false) {
             return $fallback;
         }
         return $prompt;
@@ -1311,14 +1325,19 @@ PROMPT;
             'narrator', 'the narrator'
         ];
 
+        // Custom types become selectable only after the player has created and saved
+        // one in the relationship editor. The shared manager owns canonicalization.
+        $allowedCustomTypes = RelationshipManager::getCustomRelationshipTypes($currentRels);
+
         foreach ($changes as $target => $change) {
             $delta = intval($change['delta'] ?? 0);
-            $newType = $change['type'] ?? null;
-            if (is_string($newType)) {
-                $newType = strtolower(trim($newType));
-                if ($newType === '') {
-                    $newType = null;
-                }
+            $rawType = $change['type'] ?? null;
+            $newType = $rawType === null
+                ? null
+                : RelationshipManager::canonicalizeRelationshipType($rawType, $allowedCustomTypes);
+            if ($rawType !== null && $newType === null) {
+                $loggedType = is_scalar($rawType) ? (string)$rawType : gettype($rawType);
+                Logger::info("[REL-LLM] REJECTED invented type '{$loggedType}' for {$npc['npc_name']} -> {$target}: not an available type (delta still applies)");
             }
             $reason = $change['reason'] ?? '';
 
@@ -1484,12 +1503,14 @@ PROMPT;
                 // worker changed the same target; copying the pre-eval target would
                 // clobber that newer state.
                 $existingRels = RelationshipManager::normalizeRelationshipMap($extended['relationships'] ?? []);
+                $freshCustomTypes = RelationshipManager::getCustomRelationshipTypes($existingRels);
                 foreach ($applied as $target => $change) {
                     $freshRel = $existingRels[$target] ?? [];
                     $rebasedRel = $this->rebaseRelationshipChange(
                         $freshRel,
                         $currentRels[$target] ?? [],
-                        $change
+                        $change,
+                        $freshCustomTypes
                     );
                     $freshAff = (int)($freshRel['aff'] ?? 0);
                     $staleAff = (int)($change['old'] ?? 0);
@@ -1527,7 +1548,7 @@ PROMPT;
      * Apply an LLM relationship change to the latest DB value instead of the
      * stale value captured when the evaluation was queued.
      */
-    private function rebaseRelationshipChange($freshRel, $computedRel, $change) {
+    private function rebaseRelationshipChange($freshRel, $computedRel, $change, $allowedCustomTypes = []) {
         if (!is_array($freshRel)) {
             $freshRel = [];
         }
@@ -1547,9 +1568,9 @@ PROMPT;
         }
 
         $requestedType = $change['requested_type'] ?? null;
-        if (is_string($requestedType)) {
-            $requestedType = strtolower(trim($requestedType));
-        }
+        $requestedType = $requestedType === null
+            ? null
+            : RelationshipManager::canonicalizeRelationshipType($requestedType, $allowedCustomTypes);
 
         // ROMANTIC AUTO-PROMOTION GUARD (mirrors the main apply path): never let the concurrent-rebase apply a
         // romantic-leaning type on top of a non-romantic one. Romantic types are player-set, not model-assigned.

--- a/lib/relationship_manager.php
+++ b/lib/relationship_manager.php
@@ -53,6 +53,18 @@ class RelationshipManager {
         'awed', 'contempt', 'pitying', 'grateful', 'curious', 'dismissive'
     ];
 
+    // Common model wording mapped onto canonical relationship types. These aliases
+    // are inputs only; the canonical value is what is persisted.
+    const TYPE_ALIASES = [
+        'romance' => 'romantic',
+        'marriage' => 'romantic',
+        'married' => 'romantic',
+        'lover' => 'romantic',
+        'lovers' => 'romantic',
+        'betrayal' => 'betrayed',
+        'enemies' => 'enemy'
+    ];
+
     // Tier boundaries - 11 tiers with BELL CURVE distribution
     // Extremes are HARD to reach (10 pts), center tiers are WIDE (25 pts)
     // Score => Label (checked from high to low)
@@ -183,6 +195,68 @@ class RelationshipManager {
         return $target;
     }
 
+    /**
+     * Canonicalize a model-supplied relationship type against a closed allow-list.
+     *
+     * Built-in types are always valid. Custom types are valid only when the caller
+     * explicitly supplies types already created by the player. Returning null means
+     * the model invented a type and the requested type change must be ignored.
+     */
+    public static function canonicalizeRelationshipType($type, $allowedCustomTypes = []) {
+        if (!is_string($type)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim($type));
+        if ($normalized === '') {
+            return null;
+        }
+
+        $normalized = self::TYPE_ALIASES[$normalized] ?? $normalized;
+        if (in_array($normalized, self::TYPES, true)) {
+            return $normalized;
+        }
+
+        foreach ((array)$allowedCustomTypes as $customType) {
+            $customType = strtolower(trim((string)$customType));
+            if ($customType === '' || !preg_match('/^[a-z][a-z0-9_-]{0,49}$/', $customType)) {
+                continue;
+            }
+            $customType = self::TYPE_ALIASES[$customType] ?? $customType;
+            if ($normalized === $customType) {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Return only player-created custom types already present in relationship data.
+     * The model may select one of these, but cannot turn a new word into a type.
+     */
+    public static function getCustomRelationshipTypes($relationships) {
+        if (!is_array($relationships)) {
+            return [];
+        }
+
+        $customTypes = [];
+        foreach ($relationships as $relationship) {
+            if (!is_array($relationship)) {
+                continue;
+            }
+            $type = strtolower(trim((string)($relationship['type'] ?? '')));
+            if ($type === '' || isset(self::TYPE_ALIASES[$type]) || in_array($type, self::TYPES, true)) {
+                continue;
+            }
+            if (preg_match('/^[a-z][a-z0-9_-]{0,49}$/', $type)) {
+                $customTypes[$type] = true;
+            }
+        }
+
+        return array_keys($customTypes);
+    }
+
     public static function normalizeRelationshipMap($relationships) {
         if (!is_array($relationships)) {
             return [];
@@ -198,6 +272,15 @@ class RelationshipManager {
             if ($canonicalTarget === '') {
                 continue;
             }
+
+            // Repair casing and historical model aliases on every read. Unknown
+            // single-word values remain untouched because they may be legitimate
+            // player-created custom types.
+            $storedType = strtolower(trim((string)($rel['type'] ?? 'neutral')));
+            if ($storedType === '') {
+                $storedType = 'neutral';
+            }
+            $rel['type'] = self::TYPE_ALIASES[$storedType] ?? $storedType;
 
             if (!isset($normalized[$canonicalTarget])) {
                 $normalized[$canonicalTarget] = $rel;
@@ -666,24 +749,29 @@ class RelationshipManager {
         }
 
         // Parse type changes: #TYPE:Target=Romantic#
-        // Accepts both default types AND custom types (any single word)
-        if (preg_match_all('/#TYPE:([^=]+)=([a-zA-Z]+)#/', $aiResponse, $matches)) {
+        // The model may select a built-in type or an existing player-created custom
+        // type. It may never create a new type merely by emitting a new word.
+        $allowedCustomTypes = self::getCustomRelationshipTypes($rels);
+        if (preg_match_all('/#TYPE:([^=]+)=([a-zA-Z][a-zA-Z0-9_-]{0,49})#/', $aiResponse, $matches)) {
             foreach ($matches[1] as $i => $target) {
                 $target = self::normalizeTargetName($target);
                 if (in_array(strtolower($target), ['the narrator', 'narrator'], true)) continue; // never track the narrator as a relationship
-                $newType = strtolower(trim($matches[2][$i]));
+                $rawType = trim($matches[2][$i]);
+                $newType = self::canonicalizeRelationshipType($rawType, $allowedCustomTypes);
 
-                // Accept any single-word type (allows custom types like "client", "mentor", etc.)
-                if (preg_match('/^[a-z]+$/', $newType)) {
-                    if (!isset($rels[$target])) {
-                        $rels[$target] = ['aff' => 0, 'type' => 'neutral'];
-                    }
-                    $oldType = $rels[$target]['type'];
-                    $rels[$target]['type'] = $newType;
-
-                    error_log("[REL] $npcName -> $target: type $oldType -> $newType");
-                    $changed = true;
+                if ($newType === null) {
+                    error_log("[REL] Rejected invented relationship type '$rawType' for $npcName -> $target");
+                    continue;
                 }
+
+                if (!isset($rels[$target])) {
+                    $rels[$target] = ['aff' => 0, 'type' => 'neutral'];
+                }
+                $oldType = $rels[$target]['type'];
+                $rels[$target]['type'] = $newType;
+
+                error_log("[REL] $npcName -> $target: type $oldType -> $newType");
+                $changed = true;
             }
         }
 
@@ -727,10 +815,11 @@ class RelationshipManager {
 
         $rels[$targetName]['aff'] = max(-100, min(100, (int)$affinity));
 
-        // Accept any type - predefined or custom
-        // Custom types are allowed to support user creativity
+        // Direct/admin writes may create custom types, but known model aliases are
+        // still stored canonically ("romance" becomes "romantic").
         if ($type !== null && is_string($type) && strlen($type) > 0 && strlen($type) <= 50) {
-            $rels[$targetName]['type'] = strtolower(trim($type));
+            $normalizedType = strtolower(trim($type));
+            $rels[$targetName]['type'] = self::TYPE_ALIASES[$normalizedType] ?? $normalizedType;
         }
 
         $extended['relationships'] = $rels;
@@ -761,16 +850,16 @@ class RelationshipManager {
      * Get the system prompt addition for relationship tracking
      */
     public static function getSystemPromptAddition() {
-        return <<<'PROMPT'
+        $prompt = <<<'PROMPT'
 [SYSTEM: RELATIONSHIPS]
 You have relationships with others defined by a Score (-100 to +100) and a Type.
 Levels: Hostile(-100) < Resentful < Cold < Wary < Neutral(0) < Warm < Fond < Attached < Devoted(+100).
 
 COMMANDS (use when feelings change - scale to the significance of the action):
 - To adjust affinity: #REL:Name=+/-Amount#
-- To change relationship type: #TYPE:Name=NewType#
+- To change relationship type: #TYPE:Name=NewType# where NewType is EXACTLY one of the types below. Never invent a type.
 
-Types: Romantic, Platonic, Familial, Professional, Rival, Enemy, Neutral
+Types: {RELATIONSHIP_TYPES}
 
 SCALE YOUR RESPONSE TO THE ACTION:
 - Minor: +/-5 to 10 (small kindness, rude comment)
@@ -784,6 +873,8 @@ Saved your life: "You... you saved me! I won't forget this." #REL:Player=+40#
 Attacked you: "You dare strike me?!" #REL:Player=-35# #TYPE:Player=Rival#
 Killed your friend: "MURDERER! I will NEVER forgive you!" #REL:Player=-70#
 PROMPT;
+
+        return str_replace('{RELATIONSHIP_TYPES}', implode(', ', self::TYPES), $prompt);
     }
 
     /**

--- a/unittests/tests/RelationshipTypeValidationTest.php
+++ b/unittests/tests/RelationshipTypeValidationTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+$GLOBALS['ENGINE_PATH'] = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+require_once $GLOBALS['ENGINE_PATH'] . 'lib' . DIRECTORY_SEPARATOR . 'relationship_manager.php';
+require_once $GLOBALS['ENGINE_PATH'] . 'ext' . DIRECTORY_SEPARATOR . 'relationship_system'
+    . DIRECTORY_SEPARATOR . 'relationship_llm.php';
+
+final class RelationshipTypeValidationTest extends TestCase
+{
+    public function testBuiltInTypesAndKnownAliasesAreCanonicalized(): void
+    {
+        $this->assertSame('romantic', RelationshipManager::canonicalizeRelationshipType('Romantic'));
+        $this->assertSame('romantic', RelationshipManager::canonicalizeRelationshipType('Romance'));
+        $this->assertSame('betrayed', RelationshipManager::canonicalizeRelationshipType('Betrayal'));
+        $this->assertSame('enemy', RelationshipManager::canonicalizeRelationshipType('Enemies'));
+    }
+
+    public function testModelCannotCreateANewRelationshipType(): void
+    {
+        $this->assertNull(RelationshipManager::canonicalizeRelationshipType('soulmate'));
+        $this->assertNull(RelationshipManager::canonicalizeRelationshipType('new made up type'));
+        $this->assertNull(RelationshipManager::canonicalizeRelationshipType(42));
+    }
+
+    public function testExistingPlayerCustomTypeCanBeSelectedButNotRecreatedAfterRemoval(): void
+    {
+        $this->assertSame(
+            'trusted',
+            RelationshipManager::canonicalizeRelationshipType('Trusted', ['trusted'])
+        );
+        $this->assertNull(RelationshipManager::canonicalizeRelationshipType('trusted'));
+    }
+
+    public function testCustomTypeExtractionExcludesBuiltInsAliasesAndMalformedValues(): void
+    {
+        $relationships = [
+            ['type' => 'trusted'],
+            ['type' => 'Romance'],
+            ['type' => 'enemy'],
+            ['type' => 'bad type'],
+        ];
+
+        $this->assertSame(['trusted'], RelationshipManager::getCustomRelationshipTypes($relationships));
+    }
+
+    public function testRelationshipMapRepairsLegacyAliasesWithoutDestroyingCustomTypes(): void
+    {
+        $normalized = RelationshipManager::normalizeRelationshipMap([
+            'Player' => ['aff' => 60, 'type' => 'Romance'],
+            'Lydia' => ['aff' => 20, 'type' => 'Trusted'],
+        ]);
+
+        $this->assertSame('romantic', $normalized['Player']['type']);
+        $this->assertSame('trusted', $normalized['Lydia']['type']);
+    }
+
+    public function testInitialLlmAnalysisCannotPersistAnInventedType(): void
+    {
+        $llm = (new ReflectionClass(RelationshipLLM::class))->newInstanceWithoutConstructor();
+        $parse = new ReflectionMethod(RelationshipLLM::class, 'parseResponse');
+        $parsed = $parse->invoke($llm, json_encode([
+            'relationships' => [
+                'Player' => ['aff' => 60, 'type' => 'Soulmate'],
+                'Lydia' => ['aff' => 60, 'type' => 'Romance'],
+            ],
+        ]));
+
+        $this->assertSame('neutral', $parsed['Player']['type']);
+        $this->assertSame('romantic', $parsed['Lydia']['type']);
+    }
+
+    public function testConcurrentRebaseRevalidatesTheRequestedType(): void
+    {
+        $llm = (new ReflectionClass(RelationshipLLM::class))->newInstanceWithoutConstructor();
+        $rebase = new ReflectionMethod(RelationshipLLM::class, 'rebaseRelationshipChange');
+        $rebased = $rebase->invoke(
+            $llm,
+            ['aff' => 20, 'type' => 'platonic'],
+            ['aff' => 25, 'type' => 'soulmate'],
+            ['delta' => 5, 'requested_type' => 'soulmate'],
+            []
+        );
+
+        $this->assertSame(25, $rebased['aff']);
+        $this->assertSame('platonic', $rebased['type']);
+    }
+}


### PR DESCRIPTION
## Summary
- treat relationship type output as an enum instead of accepting arbitrary model-generated words
- canonicalize common aliases such as `romance` to `romantic` before storage and on legacy reads
- allow custom relationship types only after the player has created and saved them
- enforce the same rule in initial REL analysis, incremental evaluation, legacy `#TYPE:` parsing, and the concurrent rebase path
- update REL prompts to require an exact listed type

## Behavior
Invalid model types are ignored while valid affinity deltas still apply. Existing player-created custom types remain selectable. If a custom type is removed before an async result is applied, the rebase rejects the stale request.

## Tests
`./vendor/bin/phpunit tests/RelationshipTypeValidationTest.php`

Result: 7 tests, 16 assertions.