### PR TITLE
Remove Iron Ore from Background Life NPC creation

### DIFF
--- a/lib/background_life_npc_creation.php
+++ b/lib/background_life_npc_creation.php
@@ -15,7 +15,6 @@ function chimBglNpcCreationDefaults(): array
         'goal' => '',
         'starting_point' => '',
         'gold_qty' => '100',
-        'iron_ore_qty' => '10',
         'gold_ore_qty' => '5',
     ];
 }
@@ -88,7 +87,6 @@ function chimBglNpcCreationFormData(array $input): array
         'goal' => trim((string)($input['npc_goal'] ?? $input['goal'] ?? $defaults['goal'])),
         'starting_point' => trim((string)($input['npc_starting_point'] ?? $input['starting_point'] ?? $defaults['starting_point'])),
         'gold_qty' => (string)max(0, (int)($input['npc_inventory_gold'] ?? $input['gold_qty'] ?? $defaults['gold_qty'])),
-        'iron_ore_qty' => (string)max(0, (int)($input['npc_inventory_iron_ore'] ?? $input['iron_ore_qty'] ?? $defaults['iron_ore_qty'])),
         'gold_ore_qty' => (string)max(0, (int)($input['npc_inventory_gold_ore'] ?? $input['gold_ore_qty'] ?? 0)),
     ];
 }
@@ -195,7 +193,6 @@ function chimBglCreateNpc(array $input): array
     $inventoryItems = [];
     foreach ([
         ['key' => 'gold_qty', 'refid' => '0x0000000F'],
-        ['key' => 'iron_ore_qty', 'refid' => '0x00071cf3'],
         ['key' => 'gold_ore_qty', 'refid' => '0x0005acde'],
     ] as $inventoryDefinition) {
         $quantity = (int)$formData[$inventoryDefinition['key']];

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -2979,10 +2979,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                         <label for="npc_inventory_gold">Gold</label>
                         <input id="npc_inventory_gold" name="npc_inventory_gold" type="number" min="0" step="1" value="<?php echo htmlspecialchars($spawnNpcFormData['gold_qty'] ?? '100'); ?>">
                     </div>
-                    <div class="bgl-create-field">
-                        <label for="npc_inventory_iron_ore">Iron Ore</label>
-                        <input id="npc_inventory_iron_ore" name="npc_inventory_iron_ore" type="number" min="0" step="1" value="<?php echo htmlspecialchars($spawnNpcFormData['iron_ore_qty'] ?? '10'); ?>">
-                    </div>
                 </div>
             </details>
 


### PR DESCRIPTION
﻿## Summary
- remove the Iron Ore field from the Background Life NPC creation form
- stop accepting the removed field in normalized form data
- stop automatically adding Iron Ore to newly created Background Life NPCs

## Compatibility
- no database migration or schema change
- existing NPCs and inventories are unchanged
- Gold and Gold Ore creation options remain unchanged

## Validation
- `php -l lib/background_life_npc_creation.php`
- `php -l ui/mapview.php`
- focused PHP probe confirmed Iron Ore is absent from defaults and normalized form data
- residual-reference scan of the affected creation files
- `git diff --check`

## Deployment
Not deployed.

## Manual limits
The PHP modal was not visually or in-game tested in this PR worktree.

## Related PR
- Dwemer-Dynamics/CHIM#95
