### PR TITLE
Restore full playable-race NPC spawn bases

### DIFF
--- a/data/quest_assets/chim_spawn_templates.json
+++ b/data/quest_assets/chim_spawn_templates.json
@@ -1006,6 +1006,134 @@
             },
             "safety_status": "approved",
             "active": true
+        },
+        {
+            "stable_ref": "AIAgent.esp|00045CE7",
+            "signature": "NPC_",
+            "editor_id": "AIAgentTemplateAltmerMale",
+            "display_name": "CHIM Altmer Male Spawn Template",
+            "source_plugin": "AIAgent.esp",
+            "winning_plugin": "AIAgent.esp",
+            "metadata": {
+                "race": "altmer",
+                "gender": "male",
+                "curation": "CHIM-owned spawn template",
+                "curated_scope": "spawn_base"
+            },
+            "safety_status": "approved",
+            "active": true
+        },
+        {
+            "stable_ref": "AIAgent.esp|00045CE8",
+            "signature": "NPC_",
+            "editor_id": "AIAgentTemplateAltmerFemale",
+            "display_name": "CHIM Altmer Female Spawn Template",
+            "source_plugin": "AIAgent.esp",
+            "winning_plugin": "AIAgent.esp",
+            "metadata": {
+                "race": "altmer",
+                "gender": "female",
+                "curation": "CHIM-owned spawn template",
+                "curated_scope": "spawn_base"
+            },
+            "safety_status": "approved",
+            "active": true
+        },
+        {
+            "stable_ref": "AIAgent.esp|00045CE9",
+            "signature": "NPC_",
+            "editor_id": "AIAgentTemplateBosmerMale",
+            "display_name": "CHIM Bosmer Male Spawn Template",
+            "source_plugin": "AIAgent.esp",
+            "winning_plugin": "AIAgent.esp",
+            "metadata": {
+                "race": "bosmer",
+                "gender": "male",
+                "curation": "CHIM-owned spawn template",
+                "curated_scope": "spawn_base"
+            },
+            "safety_status": "approved",
+            "active": true
+        },
+        {
+            "stable_ref": "AIAgent.esp|00045CEA",
+            "signature": "NPC_",
+            "editor_id": "AIAgentTemplateBosmerFemale",
+            "display_name": "CHIM Bosmer Female Spawn Template",
+            "source_plugin": "AIAgent.esp",
+            "winning_plugin": "AIAgent.esp",
+            "metadata": {
+                "race": "bosmer",
+                "gender": "female",
+                "curation": "CHIM-owned spawn template",
+                "curated_scope": "spawn_base"
+            },
+            "safety_status": "approved",
+            "active": true
+        },
+        {
+            "stable_ref": "AIAgent.esp|00045CEB",
+            "signature": "NPC_",
+            "editor_id": "AIAgentTemplateDunmerMale",
+            "display_name": "CHIM Dunmer Male Spawn Template",
+            "source_plugin": "AIAgent.esp",
+            "winning_plugin": "AIAgent.esp",
+            "metadata": {
+                "race": "dunmer",
+                "gender": "male",
+                "curation": "CHIM-owned spawn template",
+                "curated_scope": "spawn_base"
+            },
+            "safety_status": "approved",
+            "active": true
+        },
+        {
+            "stable_ref": "AIAgent.esp|00045CEC",
+            "signature": "NPC_",
+            "editor_id": "AIAgentTemplateDunmerFemale",
+            "display_name": "CHIM Dunmer Female Spawn Template",
+            "source_plugin": "AIAgent.esp",
+            "winning_plugin": "AIAgent.esp",
+            "metadata": {
+                "race": "dunmer",
+                "gender": "female",
+                "curation": "CHIM-owned spawn template",
+                "curated_scope": "spawn_base"
+            },
+            "safety_status": "approved",
+            "active": true
+        },
+        {
+            "stable_ref": "AIAgent.esp|00045CED",
+            "signature": "NPC_",
+            "editor_id": "AIAgentTemplateKhajiitMale",
+            "display_name": "CHIM Khajiit Male Spawn Template",
+            "source_plugin": "AIAgent.esp",
+            "winning_plugin": "AIAgent.esp",
+            "metadata": {
+                "race": "khajiit",
+                "gender": "male",
+                "curation": "CHIM-owned spawn template",
+                "curated_scope": "spawn_base"
+            },
+            "safety_status": "approved",
+            "active": true
+        },
+        {
+            "stable_ref": "AIAgent.esp|00045CEE",
+            "signature": "NPC_",
+            "editor_id": "AIAgentTemplateKhajiitFemale",
+            "display_name": "CHIM Khajiit Female Spawn Template",
+            "source_plugin": "AIAgent.esp",
+            "winning_plugin": "AIAgent.esp",
+            "metadata": {
+                "race": "khajiit",
+                "gender": "female",
+                "curation": "CHIM-owned spawn template",
+                "curated_scope": "spawn_base"
+            },
+            "safety_status": "approved",
+            "active": true
         }
     ],
     "groups": [
@@ -4594,6 +4722,2998 @@
             },
             "active": true,
             "members": []
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_noble",
+            "label": "Male Altmer Noble",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_merchant",
+            "label": "Male Altmer Merchant",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_warrior",
+            "label": "Male Altmer Warrior",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_assassin",
+            "label": "Male Altmer Assassin",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_mage",
+            "label": "Male Altmer Mage",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_beggar",
+            "label": "Male Altmer Beggar",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_farmer",
+            "label": "Male Altmer Farmer",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_bard",
+            "label": "Male Altmer Bard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_soldier",
+            "label": "Male Altmer Soldier",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_blacksmith",
+            "label": "Male Altmer Blacksmith",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_hunter",
+            "label": "Male Altmer Hunter",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_bandit",
+            "label": "Male Altmer Bandit",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_miner",
+            "label": "Male Altmer Miner",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_guard",
+            "label": "Male Altmer Guard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_imperial",
+            "label": "Male Altmer Imperial",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_stormcloak",
+            "label": "Male Altmer Stormcloak",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_thalmor",
+            "label": "Male Altmer Thalmor",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_dawnguard",
+            "label": "Male Altmer Dawnguard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_skaal",
+            "label": "Male Altmer Skaal",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_priest",
+            "label": "Male Altmer Priest",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_vampire",
+            "label": "Male Altmer Vampire",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_altmer_cultist",
+            "label": "Male Altmer Cultist",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE7",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_noble",
+            "label": "Female Altmer Noble",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_merchant",
+            "label": "Female Altmer Merchant",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_warrior",
+            "label": "Female Altmer Warrior",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_assassin",
+            "label": "Female Altmer Assassin",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_mage",
+            "label": "Female Altmer Mage",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_beggar",
+            "label": "Female Altmer Beggar",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_farmer",
+            "label": "Female Altmer Farmer",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_bard",
+            "label": "Female Altmer Bard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_soldier",
+            "label": "Female Altmer Soldier",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_blacksmith",
+            "label": "Female Altmer Blacksmith",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_hunter",
+            "label": "Female Altmer Hunter",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_bandit",
+            "label": "Female Altmer Bandit",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_miner",
+            "label": "Female Altmer Miner",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_guard",
+            "label": "Female Altmer Guard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_imperial",
+            "label": "Female Altmer Imperial",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_stormcloak",
+            "label": "Female Altmer Stormcloak",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_thalmor",
+            "label": "Female Altmer Thalmor",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_dawnguard",
+            "label": "Female Altmer Dawnguard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_skaal",
+            "label": "Female Altmer Skaal",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_priest",
+            "label": "Female Altmer Priest",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_vampire",
+            "label": "Female Altmer Vampire",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_altmer_cultist",
+            "label": "Female Altmer Cultist",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE8",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_noble",
+            "label": "Male Bosmer Noble",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_merchant",
+            "label": "Male Bosmer Merchant",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_warrior",
+            "label": "Male Bosmer Warrior",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_assassin",
+            "label": "Male Bosmer Assassin",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_mage",
+            "label": "Male Bosmer Mage",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_beggar",
+            "label": "Male Bosmer Beggar",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_farmer",
+            "label": "Male Bosmer Farmer",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_bard",
+            "label": "Male Bosmer Bard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_soldier",
+            "label": "Male Bosmer Soldier",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_blacksmith",
+            "label": "Male Bosmer Blacksmith",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_hunter",
+            "label": "Male Bosmer Hunter",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_bandit",
+            "label": "Male Bosmer Bandit",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_miner",
+            "label": "Male Bosmer Miner",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_guard",
+            "label": "Male Bosmer Guard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_imperial",
+            "label": "Male Bosmer Imperial",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_stormcloak",
+            "label": "Male Bosmer Stormcloak",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_thalmor",
+            "label": "Male Bosmer Thalmor",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_dawnguard",
+            "label": "Male Bosmer Dawnguard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_skaal",
+            "label": "Male Bosmer Skaal",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_priest",
+            "label": "Male Bosmer Priest",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_vampire",
+            "label": "Male Bosmer Vampire",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_bosmer_cultist",
+            "label": "Male Bosmer Cultist",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CE9",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_noble",
+            "label": "Female Bosmer Noble",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_merchant",
+            "label": "Female Bosmer Merchant",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_warrior",
+            "label": "Female Bosmer Warrior",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_assassin",
+            "label": "Female Bosmer Assassin",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_mage",
+            "label": "Female Bosmer Mage",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_beggar",
+            "label": "Female Bosmer Beggar",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_farmer",
+            "label": "Female Bosmer Farmer",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_bard",
+            "label": "Female Bosmer Bard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_soldier",
+            "label": "Female Bosmer Soldier",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_blacksmith",
+            "label": "Female Bosmer Blacksmith",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_hunter",
+            "label": "Female Bosmer Hunter",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_bandit",
+            "label": "Female Bosmer Bandit",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_miner",
+            "label": "Female Bosmer Miner",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_guard",
+            "label": "Female Bosmer Guard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_imperial",
+            "label": "Female Bosmer Imperial",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_stormcloak",
+            "label": "Female Bosmer Stormcloak",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_thalmor",
+            "label": "Female Bosmer Thalmor",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_dawnguard",
+            "label": "Female Bosmer Dawnguard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_skaal",
+            "label": "Female Bosmer Skaal",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_priest",
+            "label": "Female Bosmer Priest",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_vampire",
+            "label": "Female Bosmer Vampire",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_bosmer_cultist",
+            "label": "Female Bosmer Cultist",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEA",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_noble",
+            "label": "Male Dunmer Noble",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_merchant",
+            "label": "Male Dunmer Merchant",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_warrior",
+            "label": "Male Dunmer Warrior",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_assassin",
+            "label": "Male Dunmer Assassin",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_mage",
+            "label": "Male Dunmer Mage",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_beggar",
+            "label": "Male Dunmer Beggar",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_farmer",
+            "label": "Male Dunmer Farmer",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_bard",
+            "label": "Male Dunmer Bard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_soldier",
+            "label": "Male Dunmer Soldier",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_blacksmith",
+            "label": "Male Dunmer Blacksmith",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_hunter",
+            "label": "Male Dunmer Hunter",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_bandit",
+            "label": "Male Dunmer Bandit",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_miner",
+            "label": "Male Dunmer Miner",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_guard",
+            "label": "Male Dunmer Guard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_imperial",
+            "label": "Male Dunmer Imperial",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_stormcloak",
+            "label": "Male Dunmer Stormcloak",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_thalmor",
+            "label": "Male Dunmer Thalmor",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_dawnguard",
+            "label": "Male Dunmer Dawnguard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_skaal",
+            "label": "Male Dunmer Skaal",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_priest",
+            "label": "Male Dunmer Priest",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_vampire",
+            "label": "Male Dunmer Vampire",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_dunmer_cultist",
+            "label": "Male Dunmer Cultist",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEB",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_noble",
+            "label": "Female Dunmer Noble",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_merchant",
+            "label": "Female Dunmer Merchant",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_warrior",
+            "label": "Female Dunmer Warrior",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_assassin",
+            "label": "Female Dunmer Assassin",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_mage",
+            "label": "Female Dunmer Mage",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_beggar",
+            "label": "Female Dunmer Beggar",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_farmer",
+            "label": "Female Dunmer Farmer",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_bard",
+            "label": "Female Dunmer Bard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_soldier",
+            "label": "Female Dunmer Soldier",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_blacksmith",
+            "label": "Female Dunmer Blacksmith",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_hunter",
+            "label": "Female Dunmer Hunter",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_bandit",
+            "label": "Female Dunmer Bandit",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_miner",
+            "label": "Female Dunmer Miner",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_guard",
+            "label": "Female Dunmer Guard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_imperial",
+            "label": "Female Dunmer Imperial",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_stormcloak",
+            "label": "Female Dunmer Stormcloak",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_thalmor",
+            "label": "Female Dunmer Thalmor",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_dawnguard",
+            "label": "Female Dunmer Dawnguard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_skaal",
+            "label": "Female Dunmer Skaal",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_priest",
+            "label": "Female Dunmer Priest",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_vampire",
+            "label": "Female Dunmer Vampire",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_dunmer_cultist",
+            "label": "Female Dunmer Cultist",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEC",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_noble",
+            "label": "Male Khajiit Noble",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_merchant",
+            "label": "Male Khajiit Merchant",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_warrior",
+            "label": "Male Khajiit Warrior",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_assassin",
+            "label": "Male Khajiit Assassin",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_mage",
+            "label": "Male Khajiit Mage",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_beggar",
+            "label": "Male Khajiit Beggar",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_farmer",
+            "label": "Male Khajiit Farmer",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_bard",
+            "label": "Male Khajiit Bard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_soldier",
+            "label": "Male Khajiit Soldier",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_blacksmith",
+            "label": "Male Khajiit Blacksmith",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_hunter",
+            "label": "Male Khajiit Hunter",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_bandit",
+            "label": "Male Khajiit Bandit",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_miner",
+            "label": "Male Khajiit Miner",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_guard",
+            "label": "Male Khajiit Guard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_imperial",
+            "label": "Male Khajiit Imperial",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_stormcloak",
+            "label": "Male Khajiit Stormcloak",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_thalmor",
+            "label": "Male Khajiit Thalmor",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_dawnguard",
+            "label": "Male Khajiit Dawnguard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_skaal",
+            "label": "Male Khajiit Skaal",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_priest",
+            "label": "Male Khajiit Priest",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_vampire",
+            "label": "Male Khajiit Vampire",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "male_khajiit_cultist",
+            "label": "Male Khajiit Cultist",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CED",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_noble",
+            "label": "Female Khajiit Noble",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_merchant",
+            "label": "Female Khajiit Merchant",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_warrior",
+            "label": "Female Khajiit Warrior",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_assassin",
+            "label": "Female Khajiit Assassin",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_mage",
+            "label": "Female Khajiit Mage",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_beggar",
+            "label": "Female Khajiit Beggar",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_farmer",
+            "label": "Female Khajiit Farmer",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_bard",
+            "label": "Female Khajiit Bard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_soldier",
+            "label": "Female Khajiit Soldier",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_blacksmith",
+            "label": "Female Khajiit Blacksmith",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_hunter",
+            "label": "Female Khajiit Hunter",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_bandit",
+            "label": "Female Khajiit Bandit",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_miner",
+            "label": "Female Khajiit Miner",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_guard",
+            "label": "Female Khajiit Guard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_imperial",
+            "label": "Female Khajiit Imperial",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_stormcloak",
+            "label": "Female Khajiit Stormcloak",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_thalmor",
+            "label": "Female Khajiit Thalmor",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_dawnguard",
+            "label": "Female Khajiit Dawnguard",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_skaal",
+            "label": "Female Khajiit Skaal",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_priest",
+            "label": "Female Khajiit Priest",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_vampire",
+            "label": "Female Khajiit Vampire",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
+        },
+        {
+            "dataset": "npc_own_templates",
+            "key": "female_khajiit_cultist",
+            "label": "Female Khajiit Cultist",
+            "description": "CHIM-owned NPC spawn base.",
+            "selection_policy": {},
+            "active": true,
+            "members": [
+                {
+                    "stable_ref": "AIAgent.esp|00045CEE",
+                    "weight": 1,
+                    "constraints": {},
+                    "note": "",
+                    "active": true
+                }
+            ]
         }
     ]
 }

--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -7525,6 +7525,58 @@ if ($checkVersion("quest_asset_library") < 20260719001) {
     }
 }
 
+if ($checkVersion("quest_asset_library") < 20260729001) {
+    Logger::debug("Applying quest_asset_library 20260729001 - restore shipped playable race NPC templates");
+
+    require_once __DIR__ . "/../lib/quest_asset_library.php";
+    require_once __DIR__ . "/../lib/quest_reference_data.php";
+
+    $migrationOk = true;
+    $manifestPath = __DIR__ . "/../data/quest_assets/chim_spawn_templates.json";
+    $result = quest_asset_import_manifest_file($manifestPath);
+    if (empty($result["success"])) {
+        $migrationOk = false;
+        Logger::error(
+            "Failed importing playable race NPC templates: "
+            . implode("; ", $result["errors"] ?? ["unknown error"])
+        );
+    }
+
+    if ($migrationOk) {
+        $manifest = json_decode((string) file_get_contents($manifestPath), true);
+        $spawnTemplates = [];
+        foreach (($manifest["groups"] ?? []) as $group) {
+            if (strtolower(trim((string) ($group["dataset"] ?? ""))) !== "npc_own_templates") {
+                continue;
+            }
+
+            $groupKey = strtolower(trim((string) ($group["key"] ?? "")));
+            if ($groupKey === "") {
+                continue;
+            }
+
+            foreach (($group["members"] ?? []) as $member) {
+                $stableRef = trim((string) ($member["stable_ref"] ?? ""));
+                if ($stableRef !== "") {
+                    $spawnTemplates[$groupKey][] = $stableRef;
+                }
+            }
+        }
+
+        $migrationOk = quest_reference_add_missing_dataset_entries(
+            "npc_own_templates",
+            $spawnTemplates
+        ) !== false;
+    }
+
+    if ($migrationOk) {
+        $updateVersion("quest_asset_library", 20260729001);
+        Logger::info("Applied patch quest_asset_library 20260729001");
+    } else {
+        Logger::error("Failed to apply quest_asset_library 20260729001");
+    }
+}
+
 if ($checkVersion("prompts") < 20260719001) {
     Logger::debug("Applying prompts 20260719001 - improve book reading prompt");
 

--- a/lib/quest_reference_data.php
+++ b/lib/quest_reference_data.php
@@ -269,6 +269,7 @@ if (!function_exists('quest_reference_normalize_formid')) {
             && (
                 ($runtimeValue >= 0x00025844 && $runtimeValue <= 0x0002584D)
                 || ($runtimeValue >= 0x00025DAF && $runtimeValue <= 0x00025DED)
+                || ($runtimeValue >= 0x00045CE7 && $runtimeValue <= 0x00045CEE)
             )
         ) {
             return 'AIAgent.esp';

--- a/lib/rolemaster_helpers.php
+++ b/lib/rolemaster_helpers.php
@@ -203,6 +203,29 @@ $GLOBALS["npc_own_templates"] = [
 
 ];
 
+$questRaceSpawnBases = [
+    "male_altmer" => "AIAgent.esp|00045CE7",
+    "female_altmer" => "AIAgent.esp|00045CE8",
+    "male_bosmer" => "AIAgent.esp|00045CE9",
+    "female_bosmer" => "AIAgent.esp|00045CEA",
+    "male_dunmer" => "AIAgent.esp|00045CEB",
+    "female_dunmer" => "AIAgent.esp|00045CEC",
+    "male_khajiit" => "AIAgent.esp|00045CED",
+    "female_khajiit" => "AIAgent.esp|00045CEE",
+];
+$questSpawnAliases = [];
+foreach (array_keys($GLOBALS["npc_own_templates"]) as $templateKey) {
+    if (preg_match('/^male_argonian_(.+)$/', $templateKey, $matches)) {
+        $questSpawnAliases[] = $matches[1];
+    }
+}
+foreach ($questRaceSpawnBases as $templatePrefix => $formId) {
+    foreach ($questSpawnAliases as $classAlias) {
+        $GLOBALS["npc_own_templates"]["{$templatePrefix}_{$classAlias}"] = [$formId];
+    }
+}
+unset($questRaceSpawnBases, $questSpawnAliases, $templateKey, $templatePrefix, $classAlias, $formId, $matches);
+
 $GLOBALS["outfit"] = [
     "beggar" => [0x000a1983],
     "mage" => [0x0006e26f, 0x001034ef, 0x000a199c, 0x000d504c, 0x0007eab5, 0x0001703a, 0x000f3e7d, 0x00106114, 0x000fba59, 0x000e9ac4, 0x000b7a3e, 0x000b7a3f],

--- a/unittests/tests/QuestAssetLibraryTest.php
+++ b/unittests/tests/QuestAssetLibraryTest.php
@@ -58,7 +58,7 @@ final class QuestAssetLibraryTest extends TestCase
     {
         $expected = [
             'skyrim_official.json' => [178, 93],
-            'chim_spawn_templates.json' => [71, 266],
+            'chim_spawn_templates.json' => [79, 442],
         ];
 
         foreach ($expected as $filename => [$assetCount, $groupCount]) {
@@ -84,7 +84,8 @@ final class QuestAssetLibraryTest extends TestCase
             $localFormId = hexdec(substr($asset['stable_ref'], strrpos($asset['stable_ref'], '|') + 1));
             $this->assertTrue(
                 ($localFormId >= 0x00025844 && $localFormId <= 0x0002584D)
-                    || ($localFormId >= 0x00025DAF && $localFormId <= 0x00025DED),
+                    || ($localFormId >= 0x00025DAF && $localFormId <= 0x00025DED)
+                    || ($localFormId >= 0x00045CE7 && $localFormId <= 0x00045CEE),
                 $asset['stable_ref'] . ' is not a shipped AIAgent.esp NPC template.'
             );
         }
@@ -108,18 +109,12 @@ final class QuestAssetLibraryTest extends TestCase
             $ownGroups[$group['key']] = true;
         }
 
-        $shippedSpawnRaces = ['nord', 'imperial', 'redguard', 'breton', 'orc', 'argonian'];
         foreach (['male', 'female'] as $gender) {
-            foreach ($shippedSpawnRaces as $race) {
+            foreach (quest_reference_playable_races() as $race) {
                 foreach ($classes as $class) {
                     $this->assertArrayHasKey("{$gender}_{$race}_{$class}", $ownGroups);
                 }
             }
-        }
-
-        foreach (['altmer', 'bosmer', 'dunmer', 'khajiit'] as $unsupportedRace) {
-            $this->assertArrayNotHasKey("male_{$unsupportedRace}_warrior", $ownGroups);
-            $this->assertArrayNotHasKey("female_{$unsupportedRace}_warrior", $ownGroups);
         }
     }
 
@@ -303,7 +298,7 @@ final class QuestAssetLibraryTest extends TestCase
         }
 
         $this->assertSame(
-            ['nord', 'imperial', 'redguard', 'breton', 'orc', 'argonian'],
+            quest_reference_playable_races(),
             quest_reference_spawnable_playable_races($donorKeys, $spawnKeys, $classes)
         );
     }


### PR DESCRIPTION
## Problem

CHIM PR #78 shipped male and female Altmer, Bosmer, Dunmer, and Khajiit ActorBase records in `AIAgent.esp`, but HerikaServer had already removed their quest spawn catalog entries while those records were still unshipped. Background Life and quest NPC creation therefore could not resolve those four playable races to safe CHIM-owned spawn bases.

## Changes

- Restore the eight shipped `AIAgent.esp` spawn records (`00045CE7` through `00045CEE`) and their race/class aliases.
- Restore legacy FormID ownership recognition for that exact range.
- Add idempotent migration `quest_asset_library 20260729001` to reimport the manifest and repopulate missing `npc_own_templates` entries on existing installations.
- Update the existing quest asset assertions for all ten playable races.

## Validation

- Verified all eight local FormIDs exist as `NPC_` records in current CHIM `origin/unstable` `AIAgent.esp`.
- `php -l` passed for all changed PHP files.
- `QuestAssetLibraryTest`: 20 tests, 1,909 assertions, all passing.
- `git diff --check` passed.

## Status

- Not locally deployed.
- Not tested in-game; final spawn verification requires Skyrim running with the current CHIM plugin and the migration applied.