### PR TITLE
Improve Background Life NPC history UI

### DIFF
--- a/ui/css/background_life_history.css
+++ b/ui/css/background_life_history.css
@@ -229,7 +229,7 @@
 
 .bgl-npc-history-tabs {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 8px;
     margin-bottom: 14px;
 }
@@ -259,8 +259,11 @@
     display: none;
 }
 
-#npc-letter-history-content {
+#npc-letter-history-content,
+#npc-thought-history-content {
     color: #fff;
+    max-height: 55vh;
+    overflow-y: auto;
 }
 
 .bgl-recent-events-list {

--- a/ui/css/background_life_history.css
+++ b/ui/css/background_life_history.css
@@ -216,6 +216,63 @@
     opacity: 0.65;
 }
 
+.bgl-recent-events-dialog {
+    width: min(820px, 100%);
+}
+
+.bgl-recent-events-status {
+    min-height: 20px;
+    margin-bottom: 12px;
+    color: #aaa;
+    font-size: 13px;
+}
+
+.bgl-recent-events-list {
+    display: grid;
+    gap: 10px;
+}
+
+.bgl-recent-event {
+    padding: 13px 15px;
+    border: 1px solid #444;
+    border-left: 3px solid rgb(242, 124, 17);
+    border-radius: 6px;
+    background: #1a1a1a;
+}
+
+.bgl-recent-event-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 7px;
+    color: #aaa;
+    font-size: 12px;
+}
+
+.bgl-recent-event-category {
+    padding: 2px 7px;
+    border: 1px solid #5a5a5a;
+    border-radius: 999px;
+    color: #ddd;
+    text-transform: capitalize;
+}
+
+.bgl-recent-event-text {
+    color: #eee;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}
+
+.bgl-recent-events-empty {
+    padding: 24px;
+    border: 1px dashed #4a4a4a;
+    border-radius: 6px;
+    color: #aaa;
+    text-align: center;
+}
+
 @media (max-width: 900px) {
     .bgl-history-toolbar {
         grid-template-columns: 1fr 1fr;

--- a/ui/css/background_life_history.css
+++ b/ui/css/background_life_history.css
@@ -227,6 +227,42 @@
     font-size: 13px;
 }
 
+.bgl-npc-history-tabs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+    margin-bottom: 14px;
+}
+
+.bgl-npc-history-tab {
+    min-height: 40px;
+    padding: 9px 14px;
+    border: 1px solid #4b4b4b;
+    border-radius: 6px;
+    background: #303030;
+    color: #ddd;
+    cursor: pointer;
+    font-weight: 700;
+}
+
+.bgl-npc-history-tab:hover {
+    border-color: rgba(242, 124, 17, 0.75);
+}
+
+.bgl-npc-history-tab.active {
+    border-color: rgb(242, 124, 17);
+    background: rgba(242, 124, 17, 0.18);
+    color: #ffd2a8;
+}
+
+.bgl-npc-history-panel[hidden] {
+    display: none;
+}
+
+#npc-letter-history-content {
+    color: #fff;
+}
+
 .bgl-recent-events-list {
     display: grid;
     gap: 10px;

--- a/ui/js/background_life_history.js
+++ b/ui/js/background_life_history.js
@@ -276,15 +276,18 @@
     }
 
     function setNpcHistoryTab(tabName) {
-        const showEvents = tabName === 'events';
-        const eventsPanel = document.getElementById('npc-event-history-panel');
-        const lettersPanel = document.getElementById('npc-letters-history-panel');
-        if (!eventsPanel || !lettersPanel) {
+        const panels = {
+            events: document.getElementById('npc-event-history-panel'),
+            letters: document.getElementById('npc-letters-history-panel'),
+            thoughts: document.getElementById('npc-thoughts-history-panel')
+        };
+        if (!panels.events || !panels.letters || !panels.thoughts || !panels[tabName]) {
             return;
         }
 
-        eventsPanel.hidden = !showEvents;
-        lettersPanel.hidden = showEvents;
+        Object.entries(panels).forEach(function ([name, panel]) {
+            panel.hidden = name !== tabName;
+        });
         document.querySelectorAll('[data-npc-history-tab]').forEach(function (tab) {
             const selected = tab.dataset.npcHistoryTab === tabName;
             tab.classList.toggle('active', selected);
@@ -292,9 +295,10 @@
         });
     }
 
-    function renderNpcLetters(npcName) {
-        const content = document.getElementById('npc-letter-history-content');
-        if (!content) {
+    function renderNpcWrittenHistory(npcName) {
+        const lettersContent = document.getElementById('npc-letter-history-content');
+        const thoughtsContent = document.getElementById('npc-thought-history-content');
+        if (!lettersContent || !thoughtsContent) {
             return;
         }
 
@@ -304,10 +308,15 @@
             return;
         }
 
-        content.replaceChildren(createElement(
+        lettersContent.replaceChildren(createElement(
             'div',
             'bgl-recent-events-empty',
-            'No letters or inner thoughts have been recorded for this NPC.'
+            'No letters have been recorded for this NPC.'
+        ));
+        thoughtsContent.replaceChildren(createElement(
+            'div',
+            'bgl-recent-events-empty',
+            'No inner thoughts have been recorded for this NPC.'
         ));
     }
 
@@ -325,7 +334,7 @@
         status.style.color = '';
         list.replaceChildren();
         setNpcHistoryTab('events');
-        renderNpcLetters(npcName);
+        renderNpcWrittenHistory(npcName);
         openBglModal('npc-recent-events');
 
         if (npcRecentEventsController) {

--- a/ui/js/background_life_history.js
+++ b/ui/js/background_life_history.js
@@ -1,6 +1,302 @@
 (function () {
     'use strict';
 
+    function initBackgroundLifeMap() {
+        const viewport = document.getElementById('bglMapViewport');
+        const canvas = document.getElementById('bglMapCanvas');
+        const image = document.getElementById('mapImage');
+        const zoomValue = document.getElementById('bglMapZoomValue');
+        const zoomInButton = document.querySelector('[data-map-zoom-in]');
+        const zoomOutButton = document.querySelector('[data-map-zoom-out]');
+        const resetButton = document.querySelector('[data-map-reset]');
+        if (!viewport || !canvas || !image || !zoomValue || !zoomInButton || !zoomOutButton || !resetButton) {
+            return;
+        }
+
+        const storageKey = 'bglMapCameraV1';
+        const provinceBounds = {
+            left: 0.025,
+            top: 0.14,
+            right: 0.98,
+            bottom: 0.89
+        };
+        const state = {
+            fitScale: 1,
+            zoom: 1,
+            scale: 1,
+            x: 0,
+            y: 0,
+            initialized: false,
+            dragging: false,
+            pointerId: null,
+            lastPointerX: 0,
+            lastPointerY: 0
+        };
+        let resizeTimer = null;
+
+        function clamp(value, minimum, maximum) {
+            return Math.min(maximum, Math.max(minimum, value));
+        }
+
+        function updateFitScale() {
+            const provinceWidth = canvas.offsetWidth * (provinceBounds.right - provinceBounds.left);
+            const provinceHeight = canvas.offsetHeight * (provinceBounds.bottom - provinceBounds.top);
+            if (!provinceWidth || !provinceHeight) {
+                return false;
+            }
+
+            state.fitScale = Math.min(
+                viewport.clientWidth / provinceWidth,
+                viewport.clientHeight / provinceHeight
+            ) * 0.96;
+            return Number.isFinite(state.fitScale) && state.fitScale > 0;
+        }
+
+        function clampPan() {
+            const scaledWidth = canvas.offsetWidth * state.scale;
+            const scaledHeight = canvas.offsetHeight * state.scale;
+
+            state.x = scaledWidth <= viewport.clientWidth
+                ? (viewport.clientWidth - scaledWidth) / 2
+                : clamp(state.x, viewport.clientWidth - scaledWidth, 0);
+            state.y = scaledHeight <= viewport.clientHeight
+                ? (viewport.clientHeight - scaledHeight) / 2
+                : clamp(state.y, viewport.clientHeight - scaledHeight, 0);
+        }
+
+        function renderCamera() {
+            clampPan();
+            canvas.style.transform = 'translate3d(' + state.x + 'px, ' + state.y + 'px, 0) scale(' + state.scale + ')';
+            zoomValue.textContent = Math.round(state.zoom * 100) + '%';
+        }
+
+        function currentCenter() {
+            return {
+                x: (viewport.clientWidth / 2 - state.x) / (canvas.offsetWidth * state.scale),
+                y: (viewport.clientHeight / 2 - state.y) / (canvas.offsetHeight * state.scale)
+            };
+        }
+
+        function saveCamera() {
+            if (!state.initialized) {
+                return;
+            }
+
+            const center = currentCenter();
+            localStorage.setItem(storageKey, JSON.stringify({
+                version: 1,
+                zoom: state.zoom,
+                centerX: center.x,
+                centerY: center.y
+            }));
+        }
+
+        function setCameraCenter(centerX, centerY) {
+            state.scale = state.fitScale * state.zoom;
+            state.x = viewport.clientWidth / 2 - centerX * canvas.offsetWidth * state.scale;
+            state.y = viewport.clientHeight / 2 - centerY * canvas.offsetHeight * state.scale;
+            renderCamera();
+        }
+
+        function fitProvince(savePreference) {
+            if (!updateFitScale()) {
+                return;
+            }
+
+            state.zoom = 1;
+            setCameraCenter(
+                (provinceBounds.left + provinceBounds.right) / 2,
+                (provinceBounds.top + provinceBounds.bottom) / 2
+            );
+            state.initialized = true;
+            if (savePreference) {
+                saveCamera();
+            }
+        }
+
+        function restoreCamera() {
+            if (!updateFitScale()) {
+                return false;
+            }
+
+            try {
+                const saved = JSON.parse(localStorage.getItem(storageKey));
+                if (
+                    saved
+                    && saved.version === 1
+                    && Number.isFinite(saved.zoom)
+                    && Number.isFinite(saved.centerX)
+                    && Number.isFinite(saved.centerY)
+                ) {
+                    state.zoom = clamp(saved.zoom, 0.72, 3);
+                    setCameraCenter(
+                        clamp(saved.centerX, 0, 1),
+                        clamp(saved.centerY, 0, 1)
+                    );
+                    state.initialized = true;
+                    return true;
+                }
+            } catch (error) {
+                localStorage.removeItem(storageKey);
+            }
+
+            return false;
+        }
+
+        function initializeCamera() {
+            if (!canvas.offsetWidth || !canvas.offsetHeight) {
+                return;
+            }
+
+            if (!restoreCamera()) {
+                fitProvince(false);
+            }
+        }
+
+        function zoomAt(factor, clientX, clientY) {
+            if (!state.initialized) {
+                initializeCamera();
+            }
+
+            const viewportRect = viewport.getBoundingClientRect();
+            const focalX = clientX === undefined ? viewport.clientWidth / 2 : clientX - viewportRect.left;
+            const focalY = clientY === undefined ? viewport.clientHeight / 2 : clientY - viewportRect.top;
+            const mapX = (focalX - state.x) / state.scale;
+            const mapY = (focalY - state.y) / state.scale;
+
+            state.zoom = clamp(state.zoom * factor, 0.72, 3);
+            state.scale = state.fitScale * state.zoom;
+            state.x = focalX - mapX * state.scale;
+            state.y = focalY - mapY * state.scale;
+            renderCamera();
+            saveCamera();
+        }
+
+        zoomInButton.addEventListener('click', function () {
+            zoomAt(1.25);
+        });
+        zoomOutButton.addEventListener('click', function () {
+            zoomAt(0.8);
+        });
+        resetButton.addEventListener('click', function () {
+            fitProvince(true);
+        });
+
+        viewport.addEventListener('wheel', function (event) {
+            event.preventDefault();
+            zoomAt(event.deltaY < 0 ? 1.12 : 1 / 1.12, event.clientX, event.clientY);
+        }, { passive: false });
+
+        viewport.addEventListener('pointerdown', function (event) {
+            if (
+                event.button !== 0
+                || event.target.closest('.marker, .location-marker, .map-navigation-controls')
+            ) {
+                return;
+            }
+
+            state.dragging = true;
+            state.pointerId = event.pointerId;
+            state.lastPointerX = event.clientX;
+            state.lastPointerY = event.clientY;
+            viewport.classList.add('is-dragging');
+            viewport.setPointerCapture(event.pointerId);
+        });
+
+        viewport.addEventListener('pointermove', function (event) {
+            if (!state.dragging || event.pointerId !== state.pointerId) {
+                return;
+            }
+
+            state.x += event.clientX - state.lastPointerX;
+            state.y += event.clientY - state.lastPointerY;
+            state.lastPointerX = event.clientX;
+            state.lastPointerY = event.clientY;
+            renderCamera();
+        });
+
+        function finishDragging(event) {
+            if (!state.dragging || event.pointerId !== state.pointerId) {
+                return;
+            }
+
+            state.dragging = false;
+            state.pointerId = null;
+            viewport.classList.remove('is-dragging');
+            if (viewport.hasPointerCapture(event.pointerId)) {
+                viewport.releasePointerCapture(event.pointerId);
+            }
+            saveCamera();
+        }
+
+        viewport.addEventListener('pointerup', finishDragging);
+        viewport.addEventListener('pointercancel', finishDragging);
+
+        viewport.addEventListener('keydown', function (event) {
+            if (event.target !== viewport) {
+                return;
+            }
+
+            const panStep = 50;
+            if (event.key === '+' || event.key === '=') {
+                event.preventDefault();
+                zoomAt(1.25);
+            } else if (event.key === '-') {
+                event.preventDefault();
+                zoomAt(0.8);
+            } else if (event.key === '0' || event.key === 'Home') {
+                event.preventDefault();
+                fitProvince(true);
+            } else if (event.key.startsWith('Arrow')) {
+                event.preventDefault();
+                state.x += event.key === 'ArrowLeft' ? panStep : event.key === 'ArrowRight' ? -panStep : 0;
+                state.y += event.key === 'ArrowUp' ? panStep : event.key === 'ArrowDown' ? -panStep : 0;
+                renderCamera();
+                saveCamera();
+            }
+        });
+
+        window.focusBglMapMarker = function (marker) {
+            const markerPosition = marker ? marker.closest('.marker') : null;
+            if (!markerPosition) {
+                return;
+            }
+            if (!state.initialized) {
+                initializeCamera();
+            }
+
+            state.zoom = Math.max(state.zoom, 1.45);
+            setCameraCenter(
+                markerPosition.offsetLeft / canvas.offsetWidth,
+                markerPosition.offsetTop / canvas.offsetHeight
+            );
+            saveCamera();
+            viewport.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        };
+
+        if (image.complete) {
+            requestAnimationFrame(initializeCamera);
+        } else {
+            image.addEventListener('load', initializeCamera, { once: true });
+        }
+
+        window.addEventListener('resize', function () {
+            window.clearTimeout(resizeTimer);
+            resizeTimer = window.setTimeout(function () {
+                if (!state.initialized) {
+                    initializeCamera();
+                    return;
+                }
+
+                const center = currentCenter();
+                updateFitScale();
+                setCameraCenter(center.x, center.y);
+            }, 120);
+        });
+    }
+
+    initBackgroundLifeMap();
+
     const panel = document.getElementById('bgl-history-panel');
     if (!panel) {
         return;

--- a/ui/js/background_life_history.js
+++ b/ui/js/background_life_history.js
@@ -352,6 +352,18 @@
         });
     });
 
+    document.querySelectorAll('.marker-dot[data-npc-name]').forEach(function (marker) {
+        marker.addEventListener('click', function () {
+            openNpcRecentEvents(marker.dataset.npcName);
+        });
+        marker.addEventListener('keydown', function (event) {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                openNpcRecentEvents(marker.dataset.npcName);
+            }
+        });
+    });
+
     document.querySelectorAll('[data-npc-events]').forEach(function (control) {
         control.addEventListener('click', function (event) {
             event.stopPropagation();

--- a/ui/js/background_life_history.js
+++ b/ui/js/background_life_history.js
@@ -275,6 +275,42 @@
         });
     }
 
+    function setNpcHistoryTab(tabName) {
+        const showEvents = tabName === 'events';
+        const eventsPanel = document.getElementById('npc-event-history-panel');
+        const lettersPanel = document.getElementById('npc-letters-history-panel');
+        if (!eventsPanel || !lettersPanel) {
+            return;
+        }
+
+        eventsPanel.hidden = !showEvents;
+        lettersPanel.hidden = showEvents;
+        document.querySelectorAll('[data-npc-history-tab]').forEach(function (tab) {
+            const selected = tab.dataset.npcHistoryTab === tabName;
+            tab.classList.toggle('active', selected);
+            tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+        });
+    }
+
+    function renderNpcLetters(npcName) {
+        const content = document.getElementById('npc-letter-history-content');
+        if (!content) {
+            return;
+        }
+
+        const data = window.npcDiaryData ? window.npcDiaryData[npcName] : null;
+        if (data && typeof window.renderNpcDiaryContent === 'function') {
+            window.renderNpcDiaryContent(data);
+            return;
+        }
+
+        content.replaceChildren(createElement(
+            'div',
+            'bgl-recent-events-empty',
+            'No letters or inner thoughts have been recorded for this NPC.'
+        ));
+    }
+
     async function openNpcRecentEvents(npcName) {
         const modal = document.getElementById('npc-recent-events');
         const title = document.getElementById('npc-recent-events-title');
@@ -284,10 +320,12 @@
             return;
         }
 
-        title.textContent = npcName + ' Recent Events';
+        title.textContent = npcName + ' History';
         status.textContent = 'Loading recent events...';
         status.style.color = '';
         list.replaceChildren();
+        setNpcHistoryTab('events');
+        renderNpcLetters(npcName);
         openBglModal('npc-recent-events');
 
         if (npcRecentEventsController) {
@@ -378,6 +416,13 @@
                 control.click();
             }
         });
+    });
+
+    document.addEventListener('click', function (event) {
+        const tab = event.target.closest('[data-npc-history-tab]');
+        if (tab) {
+            setNpcHistoryTab(tab.dataset.npcHistoryTab);
+        }
     });
 
     document.addEventListener('keydown', function (event) {

--- a/ui/js/background_life_history.js
+++ b/ui/js/background_life_history.js
@@ -298,11 +298,7 @@
     initBackgroundLifeMap();
 
     const panel = document.getElementById('bgl-history-panel');
-    if (!panel) {
-        return;
-    }
-
-    const apiUrl = panel.dataset.apiUrl;
+    const apiUrl = panel ? panel.dataset.apiUrl : '';
     const tableBody = document.getElementById('bgl-history-body');
     const status = document.getElementById('bgl-history-status');
     const npcFilter = document.getElementById('bgl-history-npc-filter');
@@ -738,31 +734,33 @@
 
     window.closeNpcRecentEvents = closeNpcRecentEvents;
 
-    npcFilter.addEventListener('change', function () {
-        currentPage = 1;
-        loadHistory();
-    });
-    searchInput.addEventListener('input', scheduleSearch);
-    limitSelect.addEventListener('change', function () {
-        currentPage = 1;
-        loadHistory();
-    });
-    refreshButton.addEventListener('click', loadHistory);
-    liveButton.addEventListener('click', function () {
-        setLive(!liveTimer);
-    });
-    previousButton.addEventListener('click', function () {
-        if (currentPage > 1) {
-            currentPage -= 1;
+    if (panel) {
+        npcFilter.addEventListener('change', function () {
+            currentPage = 1;
             loadHistory();
-        }
-    });
-    nextButton.addEventListener('click', function () {
-        if (currentPage < totalPages) {
-            currentPage += 1;
+        });
+        searchInput.addEventListener('input', scheduleSearch);
+        limitSelect.addEventListener('change', function () {
+            currentPage = 1;
             loadHistory();
-        }
-    });
+        });
+        refreshButton.addEventListener('click', loadHistory);
+        liveButton.addEventListener('click', function () {
+            setLive(!liveTimer);
+        });
+        previousButton.addEventListener('click', function () {
+            if (currentPage > 1) {
+                currentPage -= 1;
+                loadHistory();
+            }
+        });
+        nextButton.addEventListener('click', function () {
+            if (currentPage < totalPages) {
+                currentPage += 1;
+                loadHistory();
+            }
+        });
 
-    loadHistory();
+        loadHistory();
+    }
 })();

--- a/ui/js/background_life_history.js
+++ b/ui/js/background_life_history.js
@@ -23,6 +23,7 @@
     let liveTimer = null;
     let searchTimer = null;
     let requestController = null;
+    let npcRecentEventsController = null;
 
     function createElement(tagName, className, text) {
         const element = document.createElement(tagName);
@@ -244,6 +245,136 @@
             }, 10000);
         }
     }
+
+    function renderNpcRecentEvents(entries) {
+        const list = document.getElementById('npc-recent-events-list');
+        list.replaceChildren();
+
+        if (!entries || entries.length === 0) {
+            const empty = createElement(
+                'div',
+                'bgl-recent-events-empty',
+                'No recent Background Life events have been recorded for this NPC.'
+            );
+            list.appendChild(empty);
+            return;
+        }
+
+        entries.forEach(function (entry) {
+            const eventItem = createElement('article', 'bgl-recent-event');
+            const meta = createElement('div', 'bgl-recent-event-meta');
+            meta.appendChild(createElement('span', '', entry.tamrielic_time || 'Unknown time'));
+            meta.appendChild(createElement('span', 'bgl-recent-event-category', entry.category || 'activity'));
+            eventItem.appendChild(meta);
+            eventItem.appendChild(createElement(
+                'div',
+                'bgl-recent-event-text',
+                entry.activity || 'No details recorded'
+            ));
+            list.appendChild(eventItem);
+        });
+    }
+
+    async function openNpcRecentEvents(npcName) {
+        const modal = document.getElementById('npc-recent-events');
+        const title = document.getElementById('npc-recent-events-title');
+        const status = document.getElementById('npc-recent-events-status');
+        const list = document.getElementById('npc-recent-events-list');
+        if (!modal || !title || !status || !list) {
+            return;
+        }
+
+        title.textContent = npcName + ' Recent Events';
+        status.textContent = 'Loading recent events...';
+        status.style.color = '';
+        list.replaceChildren();
+        openBglModal('npc-recent-events');
+
+        if (npcRecentEventsController) {
+            npcRecentEventsController.abort();
+        }
+        npcRecentEventsController = new AbortController();
+
+        const params = new URLSearchParams({
+            npc: npcName,
+            page: '1',
+            limit: '20'
+        });
+
+        try {
+            const response = await fetch(modal.dataset.apiUrl + '?' + params.toString(), {
+                cache: 'no-store',
+                credentials: 'same-origin',
+                signal: npcRecentEventsController.signal
+            });
+            if (!response.ok) {
+                throw new Error('HTTP ' + response.status);
+            }
+
+            const payload = await response.json();
+            if (!payload.success) {
+                throw new Error(payload.error || 'Unable to load recent events');
+            }
+
+            renderNpcRecentEvents(payload.entries);
+            const totalRecords = payload.pagination ? payload.pagination.total_records : payload.entries.length;
+            if (totalRecords > payload.entries.length) {
+                status.textContent = 'Showing the latest ' + payload.entries.length + ' of ' + totalRecords + ' recorded events.';
+            } else {
+                status.textContent = totalRecords === 1
+                    ? '1 recorded event'
+                    : totalRecords + ' recorded events, newest first';
+            }
+        } catch (error) {
+            if (error.name === 'AbortError') {
+                return;
+            }
+            renderNpcRecentEvents([]);
+            status.textContent = 'Recent events could not be loaded.';
+            status.style.color = '#e88989';
+        }
+    }
+
+    function closeNpcRecentEvents() {
+        if (npcRecentEventsController) {
+            npcRecentEventsController.abort();
+            npcRecentEventsController = null;
+        }
+        closeBglModal('npc-recent-events');
+    }
+
+    document.querySelectorAll('.marker-item[data-npc-name]').forEach(function (card) {
+        card.addEventListener('click', function (event) {
+            if (event.target.closest('button, a, input, label, [data-map-focus], [data-npc-events]')) {
+                return;
+            }
+            openNpcRecentEvents(card.dataset.npcName);
+        });
+    });
+
+    document.querySelectorAll('[data-npc-events]').forEach(function (control) {
+        control.addEventListener('click', function (event) {
+            event.stopPropagation();
+            const card = control.closest('.marker-item[data-npc-name]');
+            if (card) {
+                openNpcRecentEvents(card.dataset.npcName);
+            }
+        });
+        control.addEventListener('keydown', function (event) {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                control.click();
+            }
+        });
+    });
+
+    document.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape') {
+            closeNpcRecentEvents();
+        }
+    });
+
+    window.closeNpcRecentEvents = closeNpcRecentEvents;
 
     npcFilter.addEventListener('change', function () {
         currentPage = 1;

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -1367,6 +1367,8 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         flex: 0 0 auto;
         font-size: 16px;
         line-height: 1;
+        transform-origin: center;
+        transition: color 0.15s ease, transform 0.15s ease;
     }
 
     .marker-npc-events:hover,
@@ -1381,6 +1383,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         color: #fff;
         outline: none;
         text-decoration: none;
+        transform: scale(1.1);
     }
 
     #mapImage {

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -2694,44 +2694,34 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             }, 5000); // 3 seconds
         }
 
-        // Render letters and thoughts inside the unified NPC history modal.
-        let currentDiaryTab = 'letters';
-
+        // Render written history into the dedicated letters and thoughts panels.
         function renderDiaryContent(data) {
-            const modalContent = document.getElementById('npc-letter-history-content');
-            currentDiaryTab = 'letters';
-            
-            let html = '';
-            
-            // Tab buttons
-            html += '<div style="display: flex; border-bottom: 2px solid #3a3a3a; margin-bottom: 20px;">';
-            html += '<button id="lettersTab" onclick="switchDiaryTab(\'letters\')" style="flex: 1; padding: 12px; background: ' + (currentDiaryTab === 'letters' ? '#8844ff' : '#2a2a2a') + '; border: none; color: white; cursor: pointer; font-size: 1em; transition: background 0.3s;">✉️ Letters (' + data.letter_count + ')</button>';
-            html += '<button id="thoughtsTab" onclick="switchDiaryTab(\'thoughts\')" style="flex: 1; padding: 12px; background: ' + (currentDiaryTab === 'thoughts' ? '#8844ff' : '#2a2a2a') + '; border: none; color: white; cursor: pointer; font-size: 1em; transition: background 0.3s;">💭 Inner Thoughts (' + data.thought_count + ')</button>';
-            html += '</div>';
-            
-            // Letters content
-            html += '<div id="lettersContent" style="display: ' + (currentDiaryTab === 'letters' ? 'block' : 'none') + '; max-height: 55vh; overflow-y: auto;">';
+            const lettersContent = document.getElementById('npc-letter-history-content');
+            const thoughtsContent = document.getElementById('npc-thought-history-content');
+            if (!lettersContent || !thoughtsContent) {
+                return;
+            }
+
+            let lettersHtml = '';
             if (data.letters && data.letters.length > 0) {
                 data.letters.forEach((entry) => {
-                    html += renderEntry(entry, '#4488ff');
+                    lettersHtml += renderEntry(entry, '#4488ff');
                 });
             } else {
-                html += '<div style="text-align: center; padding: 40px; color: #888;"><p style="font-size: 1.2em;">✉️</p><p>No letters found</p></div>';
+                lettersHtml = '<div style="text-align: center; padding: 40px; color: #888;"><p style="font-size: 1.2em;">✉️</p><p>No letters found</p></div>';
             }
-            html += '</div>';
-            
-            // Thoughts content
-            html += '<div id="thoughtsContent" style="display: ' + (currentDiaryTab === 'thoughts' ? 'block' : 'none') + '; max-height: 55vh; overflow-y: auto;">';
+
+            let thoughtsHtml = '';
             if (data.thoughts && data.thoughts.length > 0) {
                 data.thoughts.forEach((entry) => {
-                    html += renderEntry(entry, '#8844ff');
+                    thoughtsHtml += renderEntry(entry, '#8844ff');
                 });
             } else {
-                html += '<div style="text-align: center; padding: 40px; color: #888;"><p style="font-size: 1.2em;">💭</p><p>No inner thoughts found</p></div>';
+                thoughtsHtml = '<div style="text-align: center; padding: 40px; color: #888;"><p style="font-size: 1.2em;">💭</p><p>No inner thoughts found</p></div>';
             }
-            html += '</div>';
-            
-            modalContent.innerHTML = html;
+
+            lettersContent.innerHTML = lettersHtml;
+            thoughtsContent.innerHTML = thoughtsHtml;
         }
 
         function renderEntry(entry, borderColor) {
@@ -2756,27 +2746,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             html += '</div>';
             
             return html;
-        }
-
-        function switchDiaryTab(tab) {
-            currentDiaryTab = tab;
-            
-            const lettersContent = document.getElementById('lettersContent');
-            const thoughtsContent = document.getElementById('thoughtsContent');
-            const lettersTab = document.getElementById('lettersTab');
-            const thoughtsTab = document.getElementById('thoughtsTab');
-            
-            if (tab === 'letters') {
-                lettersContent.style.display = 'block';
-                thoughtsContent.style.display = 'none';
-                lettersTab.style.background = '#8844ff';
-                thoughtsTab.style.background = '#2a2a2a';
-            } else {
-                lettersContent.style.display = 'none';
-                thoughtsContent.style.display = 'block';
-                lettersTab.style.background = '#2a2a2a';
-                thoughtsTab.style.background = '#8844ff';
-            }
         }
 
         function escapeHtml(text) {
@@ -2888,7 +2857,8 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             </div>
             <div class="bgl-npc-history-tabs" role="tablist" aria-label="NPC history sections">
                 <button type="button" class="bgl-npc-history-tab active" data-npc-history-tab="events" role="tab" aria-selected="true">📚 Event History</button>
-                <button type="button" class="bgl-npc-history-tab" data-npc-history-tab="letters" role="tab" aria-selected="false">✉️ Letters & Thoughts</button>
+                <button type="button" class="bgl-npc-history-tab" data-npc-history-tab="letters" role="tab" aria-selected="false">✉️ Letters</button>
+                <button type="button" class="bgl-npc-history-tab" data-npc-history-tab="thoughts" role="tab" aria-selected="false">💭 Inner Thoughts</button>
             </div>
             <section class="bgl-npc-history-panel" id="npc-event-history-panel">
                 <div class="bgl-recent-events-status" id="npc-recent-events-status" aria-live="polite"></div>
@@ -2896,6 +2866,9 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             </section>
             <section class="bgl-npc-history-panel" id="npc-letters-history-panel" hidden>
                 <div id="npc-letter-history-content"></div>
+            </section>
+            <section class="bgl-npc-history-panel" id="npc-thoughts-history-panel" hidden>
+                <div id="npc-thought-history-content"></div>
             </section>
         </div>
     </div>

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -995,7 +995,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .map-section {
-        flex: 0 0 70%;
+        flex: 0 0 52%;
         min-width: 0;
     }
 
@@ -1019,10 +1019,15 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .sidebar-section {
-        flex: 0 0 calc(30% - 20px);
+        flex: 0 0 20%;
         display: flex;
         flex-direction: column;
         gap: 10px;
+    }
+
+    .npc-list-section {
+        flex: 0 0 calc(28% - 40px);
+        min-width: 0;
     }
 
     .map-container {
@@ -2049,6 +2054,12 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 
         .sidebar-section {
             flex: 0 0 100%;
+            width: 100%;
+        }
+
+        .npc-list-section {
+            flex: 0 0 100%;
+            width: 100%;
         }
 
         .npc-list-container {
@@ -2281,7 +2292,10 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                 <div class="bgl-action-toolbar">
                     <button type="button" class="chim-btn-primary bgl-action-button" onclick="openCreateNpcModal()">Create NPC</button>
                 </div>
-                <div class="npc-list-header">
+            </div>
+            <div class="npc-list-section">
+                <div class="npc-list-container">
+                    <div class="npc-list-header">
                         <h3>📍 NPC Markers</h3>
                         <div style="color: #bbb; font-size: 13px; padding-bottom: 10px; border-bottom: 1px solid #4a4a4a;">
                             <strong>Tracked NPCs:</strong> <?php echo sizeof($translatedMarkers); ?><br/>
@@ -2295,9 +2309,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                             <span class="toggle-text">🗺️ Show all NPCs with coords</span>
                         </label>
                         <button onclick="updateAllCoords()" class="update-all-coords-btn">📍 Update All NPC Coords</button>
-                </div>
-                <div class="npc-list-container">
-                    
+                    </div>
                     <div class="marker-list">
                         <?php foreach ($translatedMarkers as $marker) {?>
                             <div

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -1508,7 +1508,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         justify-content: center;
         min-height: 42px;
         padding: 8px 12px;
-        color: #ddd;
+        color: #fff !important;
         background: #2d2d2d;
         border: 1px solid #474747;
         border-radius: 6px;

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -996,6 +996,26 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 
     .map-section {
         flex: 0 0 75%;
+        min-width: 0;
+    }
+
+    .map-viewport {
+        position: relative;
+        width: 100%;
+        height: clamp(520px, 72vh, 820px);
+        overflow: hidden;
+        background: #111;
+        border: 3px solid rgb(242, 124, 17);
+        border-radius: 8px;
+        box-shadow: 0 0 20px rgba(242, 124, 17, 0.3);
+        box-sizing: border-box;
+        cursor: grab;
+        touch-action: none;
+        user-select: none;
+    }
+
+    .map-viewport.is-dragging {
+        cursor: grabbing;
     }
 
     .sidebar-section {
@@ -1007,16 +1027,18 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 
     .map-container {
         position: relative;
-        display: inline-block;
+        display: block;
         background: #1a1a1a;
         padding: 15px;
-        border: 3px solid rgb(242, 124, 17);
-        box-shadow: 0 0 20px rgba(242, 124, 17, 0.3);
-        margin: 0 auto;
+        border: 0;
+        box-shadow: none;
+        margin: 0;
         width: 100%;
         box-sizing: border-box;
-        border-radius: 8px;
+        border-radius: 0;
         overflow: visible;
+        transform-origin: 0 0;
+        will-change: transform;
     }
 
     .map-container img {
@@ -1025,6 +1047,58 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         height: auto;
         border: 1px solid #4a4a4a;
         border-radius: 4px;
+        pointer-events: none;
+        -webkit-user-drag: none;
+    }
+
+    .map-navigation-controls {
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        z-index: 500;
+        display: grid;
+        width: 42px;
+        overflow: hidden;
+        border: 1px solid rgba(242, 124, 17, 0.7);
+        border-radius: 7px;
+        background: rgba(24, 24, 24, 0.94);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45);
+    }
+
+    .map-navigation-controls button,
+    .map-navigation-controls output {
+        display: grid;
+        place-items: center;
+        width: 42px;
+        min-height: 38px;
+        box-sizing: border-box;
+        border: 0;
+        border-bottom: 1px solid #454545;
+        background: transparent;
+        color: #f2f2f2;
+        font-size: 18px;
+        font-weight: 700;
+    }
+
+    .map-navigation-controls button {
+        cursor: pointer;
+    }
+
+    .map-navigation-controls button:hover,
+    .map-navigation-controls button:focus-visible {
+        background: rgba(242, 124, 17, 0.22);
+        color: #ffd2a8;
+        outline: none;
+    }
+
+    .map-navigation-controls output {
+        min-height: 30px;
+        color: #bbb;
+        font-size: 10px;
+    }
+
+    .map-navigation-controls > :last-child {
+        border-bottom: 0;
     }
 
     .marker {
@@ -1719,41 +1793,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         margin-top: 10px;
     }
 
-    .map-width-controls {
-        display: flex;
-        gap: 12px;
-        align-items: center;
-        margin-bottom: 15px;
-        padding: 12px;
-        background: #2a2a2a;
-        border-radius: 8px;
-        border: 1px solid #4a4a4a;
-    }
-
-    .map-width-controls label {
-        color: rgb(242, 124, 17);
-        font-weight: bold;
-        font-size: 12px;
-        white-space: nowrap;
-    }
-
-    .map-width-slider {
-        flex: 1;
-        display: flex;
-        align-items: center;
-        gap: 10px;
-    }
-
-    .map-width-slider input[type="range"] {
-        flex: 1;
-        height: 6px;
-        border-radius: 3px;
-        background: #3a3a3a;
-        outline: none;
-        -webkit-appearance: none;
-        appearance: none;
-    }
-
     .bgl-settings-card {
         display: grid;
         gap: 10px;
@@ -1829,47 +1868,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         border-color: rgba(255, 80, 80, 0.45);
         background: rgba(255, 80, 80, 0.12);
         color: #ffb8b8;
-    }
-
-    .map-width-slider input[type="range"]::-webkit-slider-thumb {
-        -webkit-appearance: none;
-        appearance: none;
-        width: 18px;
-        height: 18px;
-        border-radius: 50%;
-        background: rgb(242, 124, 17);
-        cursor: pointer;
-        box-shadow: 0 2px 4px rgba(242, 124, 17, 0.5);
-        transition: all 0.2s ease;
-    }
-
-    .map-width-slider input[type="range"]::-webkit-slider-thumb:hover {
-        box-shadow: 0 0 8px rgba(242, 124, 17, 0.8);
-        transform: scale(1.2);
-    }
-
-    .map-width-slider input[type="range"]::-moz-range-thumb {
-        width: 18px;
-        height: 18px;
-        border-radius: 50%;
-        background: rgb(242, 124, 17);
-        cursor: pointer;
-        border: none;
-        box-shadow: 0 2px 4px rgba(242, 124, 17, 0.5);
-        transition: all 0.2s ease;
-    }
-
-    .map-width-slider input[type="range"]::-moz-range-thumb:hover {
-        box-shadow: 0 0 8px rgba(242, 124, 17, 0.8);
-        transform: scale(1.2);
-    }
-
-    .map-width-value {
-        color: #ddd;
-        font-weight: bold;
-        font-size: 12px;
-        min-width: 35px;
-        text-align: right;
     }
 
     img.thumb {
@@ -2071,6 +2069,11 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         .npc-list-container {
             max-height: 400px;
         }
+
+        .map-viewport {
+            height: 62vh;
+            min-height: 420px;
+        }
     }
 
     @keyframes pulse {
@@ -2124,8 +2127,12 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     <div class="container">
         <div class="content-wrapper">
             <div class="map-section">
-               
-                <div class="map-container" >
+                <div
+                    class="map-viewport"
+                    id="bglMapViewport"
+                    tabindex="0"
+                    aria-label="Interactive Skyrim map. Drag to pan and use the mouse wheel or controls to zoom.">
+                <div class="map-container" id="bglMapCanvas">
                     <img src="<?php echo $mapImageUrl; ?>" alt="Skyrim Map" id="mapImage">
 
             <?php
@@ -2203,6 +2210,13 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                 }
             ?>
                 </div>
+                <div class="map-navigation-controls" role="group" aria-label="Map controls">
+                    <button type="button" data-map-zoom-in aria-label="Zoom in" title="Zoom in">+</button>
+                    <output id="bglMapZoomValue" aria-live="polite">100%</output>
+                    <button type="button" data-map-zoom-out aria-label="Zoom out" title="Zoom out">&minus;</button>
+                    <button type="button" data-map-reset aria-label="Fit Skyrim in view" title="Fit Skyrim in view">&#8962;</button>
+                </div>
+                </div>
             </div>
 
             <div class="sidebar-section">
@@ -2248,13 +2262,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                         </div>
                     </div>
                     <button class="toggle-instructions-btn" onclick="toggleInstructions()">Show Instructions</button>
-                </div>
-                <div class="map-width-controls">
-                    <label>Map Width:</label>
-                    <div class="map-width-slider">
-                        <input type="range" id="mapWidthSlider" min="30" max="100" value="100" onchange="updateMapWidthFromSlider()" oninput="updateMapWidthFromSlider()">
-                        <span class="map-width-value"><span id="widthValue">100</span>%</span>
-                    </div>
                 </div>
                 <form id="background-life-settings" class="bgl-settings-card" method="post">
                     <input type="hidden" name="action" value="save_bgl_settings">
@@ -2390,43 +2397,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             }
             window.location.href = url.toString();
         }
-
-        function updateMapWidthFromSlider() {
-            const slider = document.getElementById('mapWidthSlider');
-            const widthPercent = slider.value + '%';
-            const mapContainer = document.querySelector('.map-container');
-            mapContainer.style.width = widthPercent;
-            
-            // Update the displayed value
-            document.getElementById('widthValue').textContent = slider.value;
-            
-            // Save preference to localStorage
-            localStorage.setItem('mapViewWidth', widthPercent);
-        }
-
-        function setMapWidth(width) {
-            const mapContainer = document.querySelector('.map-container');
-            mapContainer.style.width = width;
-            
-            // Extract numeric value from width (e.g., "100%" -> 100)
-            const numericValue = parseInt(width);
-            const slider = document.getElementById('mapWidthSlider');
-            if (slider) {
-                slider.value = numericValue;
-                document.getElementById('widthValue').textContent = numericValue;
-            }
-            
-            // Save preference to localStorage
-            localStorage.setItem('mapViewWidth', width);
-        }
-
-        // Restore saved width preference on page load
-        document.addEventListener('DOMContentLoaded', function() {
-            const savedWidth = localStorage.getItem('mapViewWidth');
-            if (savedWidth) {
-                setMapWidth(savedWidth);
-            }
-        });
 
         function requestAction(npcName) {
             const formData = new FormData();
@@ -2686,6 +2656,13 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     var processingMessage;
         function pulseAnimation(id) {
             const el = document.getElementById(id);
+            if (!el) {
+                return;
+            }
+
+            if (typeof window.focusBglMapMarker === 'function') {
+                window.focusBglMapMarker(el);
+            }
 
             el.classList.add("pulsing");
 

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -1536,63 +1536,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         color: rgb(242, 124, 17);
     }
 
-    .bgl-recent-events-dialog {
-        width: min(820px, 100%);
-    }
-
-    .bgl-recent-events-status {
-        min-height: 20px;
-        margin-bottom: 12px;
-        color: #aaa;
-        font-size: 13px;
-    }
-
-    .bgl-recent-events-list {
-        display: grid;
-        gap: 10px;
-    }
-
-    .bgl-recent-event {
-        padding: 13px 15px;
-        border: 1px solid #444;
-        border-left: 3px solid rgb(242, 124, 17);
-        border-radius: 6px;
-        background: #1a1a1a;
-    }
-
-    .bgl-recent-event-meta {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 12px;
-        margin-bottom: 7px;
-        color: #aaa;
-        font-size: 12px;
-    }
-
-    .bgl-recent-event-category {
-        padding: 2px 7px;
-        border: 1px solid #5a5a5a;
-        border-radius: 999px;
-        color: #ddd;
-        text-transform: capitalize;
-    }
-
-    .bgl-recent-event-text {
-        color: #eee;
-        line-height: 1.45;
-        overflow-wrap: anywhere;
-        white-space: pre-wrap;
-    }
-
-    .bgl-recent-events-empty {
-        padding: 24px;
-        border: 1px dashed #4a4a4a;
-        border-radius: 6px;
-        color: #aaa;
-        text-align: center;
-    }
-
     .bgl-create-npc-notice {
         margin-bottom: 16px;
         padding: 11px 13px;
@@ -2672,114 +2615,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             }
         }
 
-        let npcRecentEventsController = null;
-
-        function renderNpcRecentEvents(entries) {
-            const list = document.getElementById('npc-recent-events-list');
-            list.replaceChildren();
-
-            if (!entries || entries.length === 0) {
-                const empty = document.createElement('div');
-                empty.className = 'bgl-recent-events-empty';
-                empty.textContent = 'No recent Background Life events have been recorded for this NPC.';
-                list.appendChild(empty);
-                return;
-            }
-
-            entries.forEach(function (entry) {
-                const eventItem = document.createElement('article');
-                eventItem.className = 'bgl-recent-event';
-
-                const meta = document.createElement('div');
-                meta.className = 'bgl-recent-event-meta';
-
-                const time = document.createElement('span');
-                time.textContent = entry.tamrielic_time || 'Unknown time';
-                meta.appendChild(time);
-
-                const category = document.createElement('span');
-                category.className = 'bgl-recent-event-category';
-                category.textContent = entry.category || 'activity';
-                meta.appendChild(category);
-
-                const activity = document.createElement('div');
-                activity.className = 'bgl-recent-event-text';
-                activity.textContent = entry.activity || 'No details recorded';
-
-                eventItem.appendChild(meta);
-                eventItem.appendChild(activity);
-                list.appendChild(eventItem);
-            });
-        }
-
-        async function openNpcRecentEvents(npcName) {
-            const modal = document.getElementById('npc-recent-events');
-            const title = document.getElementById('npc-recent-events-title');
-            const status = document.getElementById('npc-recent-events-status');
-            const list = document.getElementById('npc-recent-events-list');
-            if (!modal || !title || !status || !list) {
-                return;
-            }
-
-            title.textContent = npcName + ' Recent Events';
-            status.textContent = 'Loading recent events...';
-            status.style.color = '';
-            list.replaceChildren();
-            openBglModal('npc-recent-events');
-
-            if (npcRecentEventsController) {
-                npcRecentEventsController.abort();
-            }
-            npcRecentEventsController = new AbortController();
-
-            const params = new URLSearchParams({
-                npc: npcName,
-                page: '1',
-                limit: '20'
-            });
-
-            try {
-                const response = await fetch(modal.dataset.apiUrl + '?' + params.toString(), {
-                    cache: 'no-store',
-                    credentials: 'same-origin',
-                    signal: npcRecentEventsController.signal
-                });
-                if (!response.ok) {
-                    throw new Error('HTTP ' + response.status);
-                }
-
-                const payload = await response.json();
-                if (!payload.success) {
-                    throw new Error(payload.error || 'Unable to load recent events');
-                }
-
-                renderNpcRecentEvents(payload.entries);
-                const totalRecords = payload.pagination ? payload.pagination.total_records : payload.entries.length;
-                if (totalRecords > payload.entries.length) {
-                    status.textContent = 'Showing the latest ' + payload.entries.length + ' of ' + totalRecords + ' recorded events.';
-                } else {
-                    status.textContent = totalRecords === 1
-                        ? '1 recorded event'
-                        : totalRecords + ' recorded events, newest first';
-                }
-            } catch (error) {
-                if (error.name === 'AbortError') {
-                    return;
-                }
-                renderNpcRecentEvents([]);
-                status.textContent = 'Recent events could not be loaded.';
-                status.style.color = '#e88989';
-            }
-        }
-
-        function closeNpcRecentEvents() {
-            if (npcRecentEventsController) {
-                npcRecentEventsController.abort();
-                npcRecentEventsController = null;
-            }
-            closeBglModal('npc-recent-events');
-        }
-
         function openCreateNpcModal() {
             openBglModal('create-background-npc', 'npc_name');
         }
@@ -2807,31 +2642,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                 openCreateRumorModal();
             }
 
-            document.querySelectorAll('.marker-item[data-npc-name]').forEach(function (card) {
-                card.addEventListener('click', function (event) {
-                    if (event.target.closest('button, a, input, label, [data-map-focus]')) {
-                        return;
-                    }
-                    openNpcRecentEvents(card.dataset.npcName);
-                });
-            });
-
-            document.querySelectorAll('[data-npc-events]').forEach(function (button) {
-                button.addEventListener('click', function (event) {
-                    event.stopPropagation();
-                    const card = button.closest('.marker-item[data-npc-name]');
-                    if (card) {
-                        openNpcRecentEvents(card.dataset.npcName);
-                    }
-                });
-                button.addEventListener('keydown', function (event) {
-                    if (event.key === 'Enter' || event.key === ' ') {
-                        event.preventDefault();
-                        button.click();
-                    }
-                });
-            });
-
             document.querySelectorAll('[data-map-focus]').forEach(function (control) {
                 control.addEventListener('keydown', function (event) {
                     if (event.key === 'Enter' || event.key === ' ') {
@@ -2846,7 +2656,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             if (event.key === 'Escape') {
                 closeCreateNpcModal();
                 closeCreateRumorModal();
-                closeNpcRecentEvents();
             }
         });
 
@@ -3064,7 +2873,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 
     ?>
 
-    <link rel="stylesheet" href="<?php echo htmlspecialchars($webRoot); ?>/ui/css/background_life_history.css">
+    <link rel="stylesheet" href="<?php echo htmlspecialchars($webRoot); ?>/ui/css/background_life_history.css?v=<?php echo (int) @filemtime(__DIR__ . '/css/background_life_history.css'); ?>">
     <section class="bgl-page-panel" id="bgl-tab-history" <?php echo $activeBglTab === 'history' ? '' : 'hidden'; ?>>
     <div
         class="info-panel bgl-history-panel"
@@ -3123,7 +2932,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         </div>
     </div>
     </section>
-    <script src="<?php echo htmlspecialchars($webRoot); ?>/ui/js/background_life_history.js"></script>
+    <script src="<?php echo htmlspecialchars($webRoot); ?>/ui/js/background_life_history.js?v=<?php echo (int) @filemtime(__DIR__ . '/js/background_life_history.js'); ?>"></script>
 
     <div
         class="bgl-modal"

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -1138,7 +1138,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         border-left: 4px solid rgb(242, 124, 17);
         border-radius: 8px;
         border: 1px solid #4a4a4a;
-        max-height: calc(100vh - 450px);
+        max-height: calc(100vh - 300px);
         overflow-y: auto;
         overflow-x: hidden;
     }
@@ -1204,7 +1204,15 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         width: 100%;
         box-sizing: border-box;
         position: relative;
-        
+        cursor: pointer;
+        transition: border-color 0.2s ease, background-color 0.2s ease;
+    }
+
+    .marker-item:hover,
+    .marker-item:focus-visible {
+        background-color: #202020;
+        border-color: rgb(242, 124, 17);
+        outline: none;
     }
 
     .marker-item::before {
@@ -1242,6 +1250,26 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         font-family: 'MagicCards', serif;
         display: inline-block;
         vertical-align: text-top;
+    }
+
+    .marker-npc-events,
+    .marker-map-focus {
+        display: inline;
+        padding: 0;
+        border: 0;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+    }
+
+    .marker-npc-events:hover,
+    .marker-npc-events:focus-visible,
+    .marker-map-focus:hover,
+    .marker-map-focus:focus-visible {
+        color: #fff;
+        outline: none;
+        text-decoration: underline;
     }
 
     .marker-item-coords {
@@ -1506,6 +1534,63 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     .bgl-modal-close:hover {
         border-color: rgb(242, 124, 17);
         color: rgb(242, 124, 17);
+    }
+
+    .bgl-recent-events-dialog {
+        width: min(820px, 100%);
+    }
+
+    .bgl-recent-events-status {
+        min-height: 20px;
+        margin-bottom: 12px;
+        color: #aaa;
+        font-size: 13px;
+    }
+
+    .bgl-recent-events-list {
+        display: grid;
+        gap: 10px;
+    }
+
+    .bgl-recent-event {
+        padding: 13px 15px;
+        border: 1px solid #444;
+        border-left: 3px solid rgb(242, 124, 17);
+        border-radius: 6px;
+        background: #1a1a1a;
+    }
+
+    .bgl-recent-event-meta {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 7px;
+        color: #aaa;
+        font-size: 12px;
+    }
+
+    .bgl-recent-event-category {
+        padding: 2px 7px;
+        border: 1px solid #5a5a5a;
+        border-radius: 999px;
+        color: #ddd;
+        text-transform: capitalize;
+    }
+
+    .bgl-recent-event-text {
+        color: #eee;
+        line-height: 1.45;
+        overflow-wrap: anywhere;
+        white-space: pre-wrap;
+    }
+
+    .bgl-recent-events-empty {
+        padding: 24px;
+        border: 1px dashed #4a4a4a;
+        border-radius: 6px;
+        color: #aaa;
+        text-align: center;
     }
 
     .bgl-create-npc-notice {
@@ -2264,11 +2349,17 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                     
                     <div class="marker-list">
                         <?php foreach ($translatedMarkers as $marker) {?>
-                            <div id="dtl_<?php echo $marker['id'] ?>" class="marker-item" style="border-left-color:<?php echo $marker['color']; ?>;background-image:url(<?php echo $marker['figure']; ?>);background-position-y: top;" >
+                            <div
+                                id="dtl_<?php echo $marker['id'] ?>"
+                                class="marker-item"
+                                data-npc-name="<?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>"
+                                title="View recent events for <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>"
+                                style="border-left-color:<?php echo $marker['color']; ?>;background-image:url(<?php echo $marker['figure']; ?>);background-position-y: top;">
                                 <h4>
                                     <span class="marker-item-color" style="background-color:                                                                                                                                                                         <?php echo $marker['color']; ?>;"></span>
                                     <!--<a href="#mkr_<?php echo $marker['id'] ?>"><?php echo $marker['name']; ?> &nbsp; ↗️</a> -->
-                                    <span onclick="pulseAnimation('mkr_<?php echo $marker['id'] ?>')" style="cursor:pointer"><?php echo $marker['name']; ?> &nbsp; ↗️</span>
+                                    <span class="marker-npc-events" data-npc-events role="button" tabindex="0"><?php echo $marker['name']; ?></span>
+                                    <span class="marker-map-focus" data-map-focus role="button" tabindex="0" onclick="event.stopPropagation(); pulseAnimation('mkr_<?php echo $marker['id'] ?>')" aria-label="Show <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?> on map">&nbsp;↗️</span>
                                 </h4>
                                 <div class="marker-item-coords">
                                     <ul>
@@ -2298,7 +2389,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                                                data-setting="bg_life_commands" 
                                                <?php echo $marker['bg_life_commands'] ? 'checked' : ''; ?>
                                                onchange="toggleBgLifeSetting(this)">
-                                        <span class="toggle-text">🎮 Auto Actions</span>
+                                        <span class="toggle-text">🎮 Actions</span>
                                     </label>
                                     <label class="toggle-label-inline">
                                         <input type="checkbox" 
@@ -2307,7 +2398,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                                                data-setting="bg_life_letters" 
                                                <?php echo $marker['bg_life_letters'] ? 'checked' : ''; ?>
                                                onchange="toggleBgLifeSetting(this)">
-                                        <span class="toggle-text">✉️ Send Letters</span>
+                                        <span class="toggle-text">✉️ Letters</span>
                                     </label>
                                     <label class="toggle-label-inline">
                                         <input type="checkbox" 
@@ -2316,7 +2407,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                                                data-setting="gps_track" 
                                                <?php echo $marker['gps_track'] ? 'checked' : ''; ?>
                                                onchange="toggleBgLifeSetting(this)">
-                                        <span class="toggle-text">📍 Hourly Tracking</span>
+                                        <span class="toggle-text">📍 Tracking</span>
                                     </label>
                                 </div>
                             </div>
@@ -2581,6 +2672,114 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             }
         }
 
+        let npcRecentEventsController = null;
+
+        function renderNpcRecentEvents(entries) {
+            const list = document.getElementById('npc-recent-events-list');
+            list.replaceChildren();
+
+            if (!entries || entries.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'bgl-recent-events-empty';
+                empty.textContent = 'No recent Background Life events have been recorded for this NPC.';
+                list.appendChild(empty);
+                return;
+            }
+
+            entries.forEach(function (entry) {
+                const eventItem = document.createElement('article');
+                eventItem.className = 'bgl-recent-event';
+
+                const meta = document.createElement('div');
+                meta.className = 'bgl-recent-event-meta';
+
+                const time = document.createElement('span');
+                time.textContent = entry.tamrielic_time || 'Unknown time';
+                meta.appendChild(time);
+
+                const category = document.createElement('span');
+                category.className = 'bgl-recent-event-category';
+                category.textContent = entry.category || 'activity';
+                meta.appendChild(category);
+
+                const activity = document.createElement('div');
+                activity.className = 'bgl-recent-event-text';
+                activity.textContent = entry.activity || 'No details recorded';
+
+                eventItem.appendChild(meta);
+                eventItem.appendChild(activity);
+                list.appendChild(eventItem);
+            });
+        }
+
+        async function openNpcRecentEvents(npcName) {
+            const modal = document.getElementById('npc-recent-events');
+            const title = document.getElementById('npc-recent-events-title');
+            const status = document.getElementById('npc-recent-events-status');
+            const list = document.getElementById('npc-recent-events-list');
+            if (!modal || !title || !status || !list) {
+                return;
+            }
+
+            title.textContent = npcName + ' Recent Events';
+            status.textContent = 'Loading recent events...';
+            status.style.color = '';
+            list.replaceChildren();
+            openBglModal('npc-recent-events');
+
+            if (npcRecentEventsController) {
+                npcRecentEventsController.abort();
+            }
+            npcRecentEventsController = new AbortController();
+
+            const params = new URLSearchParams({
+                npc: npcName,
+                page: '1',
+                limit: '20'
+            });
+
+            try {
+                const response = await fetch(modal.dataset.apiUrl + '?' + params.toString(), {
+                    cache: 'no-store',
+                    credentials: 'same-origin',
+                    signal: npcRecentEventsController.signal
+                });
+                if (!response.ok) {
+                    throw new Error('HTTP ' + response.status);
+                }
+
+                const payload = await response.json();
+                if (!payload.success) {
+                    throw new Error(payload.error || 'Unable to load recent events');
+                }
+
+                renderNpcRecentEvents(payload.entries);
+                const totalRecords = payload.pagination ? payload.pagination.total_records : payload.entries.length;
+                if (totalRecords > payload.entries.length) {
+                    status.textContent = 'Showing the latest ' + payload.entries.length + ' of ' + totalRecords + ' recorded events.';
+                } else {
+                    status.textContent = totalRecords === 1
+                        ? '1 recorded event'
+                        : totalRecords + ' recorded events, newest first';
+                }
+            } catch (error) {
+                if (error.name === 'AbortError') {
+                    return;
+                }
+                renderNpcRecentEvents([]);
+                status.textContent = 'Recent events could not be loaded.';
+                status.style.color = '#e88989';
+            }
+        }
+
+        function closeNpcRecentEvents() {
+            if (npcRecentEventsController) {
+                npcRecentEventsController.abort();
+                npcRecentEventsController = null;
+            }
+            closeBglModal('npc-recent-events');
+        }
+
         function openCreateNpcModal() {
             openBglModal('create-background-npc', 'npc_name');
         }
@@ -2607,12 +2806,47 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             if (rumorModal && rumorModal.dataset.autoOpen === '1') {
                 openCreateRumorModal();
             }
+
+            document.querySelectorAll('.marker-item[data-npc-name]').forEach(function (card) {
+                card.addEventListener('click', function (event) {
+                    if (event.target.closest('button, a, input, label, [data-map-focus]')) {
+                        return;
+                    }
+                    openNpcRecentEvents(card.dataset.npcName);
+                });
+            });
+
+            document.querySelectorAll('[data-npc-events]').forEach(function (button) {
+                button.addEventListener('click', function (event) {
+                    event.stopPropagation();
+                    const card = button.closest('.marker-item[data-npc-name]');
+                    if (card) {
+                        openNpcRecentEvents(card.dataset.npcName);
+                    }
+                });
+                button.addEventListener('keydown', function (event) {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        button.click();
+                    }
+                });
+            });
+
+            document.querySelectorAll('[data-map-focus]').forEach(function (control) {
+                control.addEventListener('keydown', function (event) {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        control.click();
+                    }
+                });
+            });
         });
 
         document.addEventListener('keydown', function (event) {
             if (event.key === 'Escape') {
                 closeCreateNpcModal();
                 closeCreateRumorModal();
+                closeNpcRecentEvents();
             }
         });
 
@@ -2890,6 +3124,22 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     </div>
     </section>
     <script src="<?php echo htmlspecialchars($webRoot); ?>/ui/js/background_life_history.js"></script>
+
+    <div
+        class="bgl-modal"
+        id="npc-recent-events"
+        data-api-url="<?php echo htmlspecialchars($webRoot); ?>/ui/api/background_life_history.php"
+        aria-hidden="true"
+        onclick="if (event.target === this) closeNpcRecentEvents()">
+        <div class="bgl-modal-dialog bgl-recent-events-dialog" role="dialog" aria-modal="true" aria-labelledby="npc-recent-events-title">
+            <div class="bgl-modal-header">
+                <h3 id="npc-recent-events-title">Recent Events</h3>
+                <button type="button" class="bgl-modal-close" onclick="closeNpcRecentEvents()" aria-label="Close recent events modal">&times;</button>
+            </div>
+            <div class="bgl-recent-events-status" id="npc-recent-events-status" aria-live="polite"></div>
+            <div class="bgl-recent-events-list" id="npc-recent-events-list"></div>
+        </div>
+    </div>
 
     <div
         class="bgl-modal"

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -1031,7 +1031,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         position: absolute;
         transform: translate(-50%, -50%);
         cursor: pointer;
-        z-index:10;
+        z-index: 40;
     }
 
     .marker-dot {
@@ -1104,7 +1104,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .marker:hover {
-        z-index: 200;
+        z-index: 300;
     }
 
     .marker:hover .marker-label {
@@ -1987,7 +1987,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .location-marker:hover {
-        z-index: 250;
+        z-index: 20;
     }
 
     .location-marker:hover .location-marker-label {
@@ -2323,7 +2323,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                                     <button onclick="requestAction('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn">🚶‍➡️Trigger Action</button>
                                     <button onclick="requestReporting('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" style="background: #4488ff;">✉️ Request Letter</button>
                                     <button onclick="updateCoords('<?php echo addslashes($marker['name']); ?>')" title="Request coords update now" class="marker-action-btn-trans" style="border: 2px solid #00ff00; background: #44ff44;">📍</button>
-                                    <button onclick="viewDiary('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" style="background: #8844ff;" title="View letters & inner thoughts">✉️💭 View</button>
                                 </div>
                                 <div style="margin-top: 8px; display: flex; gap: 8px; flex-wrap: wrap;">
                                     <label class="toggle-label-inline">
@@ -2366,7 +2365,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     </section>
     <script>
         // NPC Diary Data - embedded directly in page
-        const npcDiaryData = <?php echo json_encode(array_combine(
+        window.npcDiaryData = <?php echo json_encode(array_combine(
             array_column($translatedMarkers, 'name'),
             array_map(function($m) {
                 return [
@@ -2695,30 +2694,12 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             }, 5000); // 3 seconds
         }
 
-        // Letters & Thoughts Modal Functions
+        // Render letters and thoughts inside the unified NPC history modal.
         let currentDiaryTab = 'letters';
-        
-        function viewDiary(npcName) {
-            const modal = document.getElementById('diaryModal');
-            const modalContent = document.getElementById('diaryModalContent');
-            const modalTitle = document.getElementById('diaryModalTitle');
-            
-            // Show modal
-            modal.style.display = 'block';
-            modalTitle.textContent = npcName + "'s Letters & Thoughts";
-            
-            // Get data from embedded npcDiaryData
-            const data = npcDiaryData[npcName];
-            
-            if (data) {
-                renderDiaryContent(data);
-            } else {
-                modalContent.innerHTML = '<div style="text-align: center; padding: 40px; color: #888;"><p style="font-size: 1.2em;">💭</p><p>No data found for this NPC</p></div>';
-            }
-        }
 
         function renderDiaryContent(data) {
-            const modalContent = document.getElementById('diaryModalContent');
+            const modalContent = document.getElementById('npc-letter-history-content');
+            currentDiaryTab = 'letters';
             
             let html = '';
             
@@ -2798,55 +2779,14 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             }
         }
 
-        function closeDiaryModal() {
-            const modal = document.getElementById('diaryModal');
-            modal.style.display = 'none';
-        }
-
         function escapeHtml(text) {
             const div = document.createElement('div');
             div.textContent = text;
             return div.innerHTML;
         }
 
-        // Close modal when clicking outside
-        window.onclick = function(event) {
-            const modal = document.getElementById('diaryModal');
-            if (event.target == modal) {
-                closeDiaryModal();
-            }
-        }
+        window.renderNpcDiaryContent = renderDiaryContent;
     </script>
-
-    <!-- Letters & Thoughts Modal -->
-    <div id="diaryModal" style="display: none; position: fixed; z-index: 10000; left: 0; top: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.7); backdrop-filter: blur(5px);">
-        <div style="background-color: #1a1a1a; margin: 5% auto; padding: 0; border: 2px solid #8844ff; width: 80%; max-width: 900px; border-radius: 12px; box-shadow: 0 4px 20px rgba(136, 68, 255, 0.3);">
-            <div style="background: linear-gradient(135deg, #8844ff 0%, #6622cc 100%); padding: 20px; border-radius: 10px 10px 0 0; display: flex; justify-content: space-between; align-items: center;">
-                <h2 id="diaryModalTitle" style="margin: 0; color: white; font-family: 'MagicCards', sans-serif; letter-spacing: 1.5px;">💭✉️ Letters & Thoughts</h2>
-                <span onclick="closeDiaryModal()" style="color: white; font-size: 32px; font-weight: bold; cursor: pointer; transition: transform 0.2s;" onmouseover="this.style.transform='scale(1.2)'" onmouseout="this.style.transform='scale(1)'">&times;</span>
-            </div>
-            <div id="diaryModalContent" style="padding: 20px; color: #fff;">
-                Loading...
-            </div>
-        </div>
-    </div>
-
-    <style>
-        .loading-spinner {
-            border: 4px solid #2a2a2a;
-            border-top: 4px solid #8844ff;
-            border-radius: 50%;
-            width: 40px;
-            height: 40px;
-            animation: spin 1s linear infinite;
-            margin: 0 auto 15px;
-        }
-
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
-    </style>
 
     <?php
     // Rumors section
@@ -2943,11 +2883,20 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         onclick="if (event.target === this) closeNpcRecentEvents()">
         <div class="bgl-modal-dialog bgl-recent-events-dialog" role="dialog" aria-modal="true" aria-labelledby="npc-recent-events-title">
             <div class="bgl-modal-header">
-                <h3 id="npc-recent-events-title">Recent Events</h3>
+                <h3 id="npc-recent-events-title">NPC History</h3>
                 <button type="button" class="bgl-modal-close" onclick="closeNpcRecentEvents()" aria-label="Close recent events modal">&times;</button>
             </div>
-            <div class="bgl-recent-events-status" id="npc-recent-events-status" aria-live="polite"></div>
-            <div class="bgl-recent-events-list" id="npc-recent-events-list"></div>
+            <div class="bgl-npc-history-tabs" role="tablist" aria-label="NPC history sections">
+                <button type="button" class="bgl-npc-history-tab active" data-npc-history-tab="events" role="tab" aria-selected="true">📚 Event History</button>
+                <button type="button" class="bgl-npc-history-tab" data-npc-history-tab="letters" role="tab" aria-selected="false">✉️ Letters & Thoughts</button>
+            </div>
+            <section class="bgl-npc-history-panel" id="npc-event-history-panel">
+                <div class="bgl-recent-events-status" id="npc-recent-events-status" aria-live="polite"></div>
+                <div class="bgl-recent-events-list" id="npc-recent-events-list"></div>
+            </section>
+            <section class="bgl-npc-history-panel" id="npc-letters-history-panel" hidden>
+                <div id="npc-letter-history-content"></div>
+            </section>
         </div>
     </div>
 

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -2137,9 +2137,10 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                     // Apply grid offset
                     $offsetX = $marker['offset_x'];
                     $offsetY = $marker['offset_y'];
+                    $markerName = htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8');
 
                     echo '<div class="marker" style="left: ' . $percentX . '%; top: ' . $percentY . '%; transform: translate(calc(-50% + ' . $offsetX . 'px), calc(-50% + ' . $offsetY . 'px));">';
-                    echo '<div class="marker-dot" id="mkr_' . $marker['id'] . '" style="width: ' . ($marker['size'] * 2) . 'px; height: ' . ($marker['size'] * 2) . 'px; background-color: ' . $marker['color'] . '; opacity: 0.8;">';
+                    echo '<div class="marker-dot" id="mkr_' . $marker['id'] . '" data-npc-name="' . $markerName . '" role="button" tabindex="0" title="View recent events for ' . $markerName . '" aria-label="View recent events for ' . $markerName . '" style="width: ' . ($marker['size'] * 2) . 'px; height: ' . ($marker['size'] * 2) . 'px; background-color: ' . $marker['color'] . '; opacity: 0.8;">';
                     echo '</div>';
                     echo '<div class="marker-label">' . PHP_EOL;
                     echo "<a style='color:white;text-decoration:none' href='#dtl_{$marker["id"]}'>{$marker["name"]} &nbsp; ↗️</a></br>";

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -995,7 +995,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .map-section {
-        flex: 0 0 75%;
+        flex: 0 0 70%;
         min-width: 0;
     }
 
@@ -1019,7 +1019,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .sidebar-section {
-        flex: 0 0 calc(25% - 20px);
+        flex: 0 0 calc(30% - 20px);
         display: flex;
         flex-direction: column;
         gap: 10px;

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -2289,7 +2289,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                     <div class="bgl-settings-help">Controls how many in-game hours pass before eligible Background Life NPCs automatically run their next update.</div>
                     <button type="submit" class="bgl-settings-save">Save</button>
                 </form>
-                <div class="npc-list-header">
+                <div class="bgl-settings-card">
                     <h3>📍 NPC Markers</h3>
                     <div style="color: #bbb; font-size: 13px; padding-bottom: 10px; border-bottom: 1px solid #4a4a4a;">
                         <strong>Tracked NPCs:</strong> <?php echo sizeof($translatedMarkers); ?><br/>

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -1370,12 +1370,17 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .marker-npc-events:hover,
-    .marker-npc-events:focus-visible,
+    .marker-npc-events:focus-visible {
+        color: #fff;
+        outline: none;
+        text-decoration: underline;
+    }
+
     .marker-map-focus:hover,
     .marker-map-focus:focus-visible {
         color: #fff;
         outline: none;
-        text-decoration: underline;
+        text-decoration: none;
     }
 
     #mapImage {
@@ -2373,8 +2378,8 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                                     </h4>
                                 </div>
                                 <div class="marker-card-actions">
-                                    <button onclick="requestAction('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn">Action</button>
-                                    <button onclick="requestReporting('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" style="background: #4488ff;">Letter</button>
+                                    <button onclick="requestAction('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" title="Request a Background Life action from <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>">Action</button>
+                                    <button onclick="requestReporting('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" title="Request a letter from <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>" style="background: #4488ff;">Letter</button>
                                     <button onclick="updateCoords('<?php echo addslashes($marker['name']); ?>')" title="Request coords update now" class="marker-action-btn-trans" style="border: 2px solid #00ff00; background: #44ff44;">📍</button>
                                 </div>
                                 <div class="marker-card-toggles">

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -1314,15 +1314,33 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         flex: 0 0 auto;
     }
 
+    .marker-card-identity {
+        display: grid;
+        grid-template-columns: 44px minmax(0, 1fr);
+        gap: 8px;
+        align-items: center;
+        margin-bottom: 8px;
+    }
+
+    .marker-card-portrait {
+        width: 44px;
+        height: 44px;
+        border: 1px solid #555;
+        border-radius: 6px;
+        object-fit: cover;
+        background: #111;
+    }
+
     .marker-item h4 {
-        margin: 0 0 8px;
+        margin: 0;
         color: rgb(242, 124, 17);
         font-family: 'MagicCards', serif;
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         gap: 6px;
         min-width: 0;
         font-size: 13px;
+        line-height: 1.2;
     }
 
     .marker-npc-events,
@@ -1337,14 +1355,18 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .marker-npc-events {
+        flex: 1 1 auto;
         overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
     }
 
     .marker-map-focus {
         margin-left: auto;
         flex: 0 0 auto;
+        font-size: 16px;
+        line-height: 1;
     }
 
     .marker-npc-events:hover,
@@ -1376,13 +1398,21 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 
     .marker-card-toggles {
         display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
         gap: 4px;
         margin-top: 6px;
     }
 
     .marker-card-toggles .toggle-label-inline {
-        padding: 4px 6px;
-        font-size: 10px;
+        justify-content: center;
+        gap: 3px;
+        min-width: 0;
+        padding: 4px;
+        font-size: 14px;
+    }
+
+    .marker-card-toggles .toggle-text {
+        line-height: 1;
     }
 
     .marker-item a {
@@ -2334,44 +2364,49 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                                 data-npc-name="<?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>"
                                 title="View recent events for <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>"
                                 style="border-left-color:<?php echo $marker['color']; ?>;">
-                                <h4>
-                                    <span class="marker-item-color" style="background-color:                                                                                                                                                                         <?php echo $marker['color']; ?>;"></span>
-                                    <!--<a href="#mkr_<?php echo $marker['id'] ?>"><?php echo $marker['name']; ?> &nbsp; ↗️</a> -->
-                                    <span class="marker-npc-events" data-npc-events role="button" tabindex="0"><?php echo $marker['name']; ?></span>
-                                    <span class="marker-map-focus" data-map-focus role="button" tabindex="0" onclick="event.stopPropagation(); pulseAnimation('mkr_<?php echo $marker['id'] ?>')" aria-label="Show <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?> on map">&nbsp;↗️</span>
-                                </h4>
+                                <div class="marker-card-identity">
+                                    <img class="marker-card-portrait" src="<?php echo htmlspecialchars($marker['figure'], ENT_QUOTES, 'UTF-8'); ?>" alt="" loading="lazy">
+                                    <h4>
+                                        <span class="marker-item-color" style="background-color:                                                                                                                                                                         <?php echo $marker['color']; ?>;"></span>
+                                        <span class="marker-npc-events" data-npc-events role="button" tabindex="0"><?php echo $marker['name']; ?></span>
+                                        <span class="marker-map-focus" data-map-focus role="button" tabindex="0" onclick="event.stopPropagation(); pulseAnimation('mkr_<?php echo $marker['id'] ?>')" aria-label="Show <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?> on map" title="Show on map">🗺️</span>
+                                    </h4>
+                                </div>
                                 <div class="marker-card-actions">
                                     <button onclick="requestAction('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn">Action</button>
                                     <button onclick="requestReporting('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" style="background: #4488ff;">Letter</button>
                                     <button onclick="updateCoords('<?php echo addslashes($marker['name']); ?>')" title="Request coords update now" class="marker-action-btn-trans" style="border: 2px solid #00ff00; background: #44ff44;">📍</button>
                                 </div>
                                 <div class="marker-card-toggles">
-                                    <label class="toggle-label-inline">
+                                    <label class="toggle-label-inline" title="Toggle automatic actions">
                                         <input type="checkbox" 
                                                class="toggle-checkbox" 
+                                               aria-label="Automatic actions"
                                                data-npc-id="<?php echo $marker['id']; ?>" 
                                                data-setting="bg_life_commands" 
                                                <?php echo $marker['bg_life_commands'] ? 'checked' : ''; ?>
                                                onchange="toggleBgLifeSetting(this)">
-                                        <span class="toggle-text">🎮 Actions</span>
+                                        <span class="toggle-text">🎮</span>
                                     </label>
-                                    <label class="toggle-label-inline">
+                                    <label class="toggle-label-inline" title="Toggle automatic letters">
                                         <input type="checkbox" 
                                                class="toggle-checkbox" 
+                                               aria-label="Automatic letters"
                                                data-npc-id="<?php echo $marker['id']; ?>" 
                                                data-setting="bg_life_letters" 
                                                <?php echo $marker['bg_life_letters'] ? 'checked' : ''; ?>
                                                onchange="toggleBgLifeSetting(this)">
-                                        <span class="toggle-text">✉️ Letters</span>
+                                        <span class="toggle-text">✉️</span>
                                     </label>
-                                    <label class="toggle-label-inline">
+                                    <label class="toggle-label-inline" title="Toggle hourly tracking">
                                         <input type="checkbox" 
                                                class="toggle-checkbox" 
+                                               aria-label="Hourly tracking"
                                                data-npc-id="<?php echo $marker['id']; ?>" 
                                                data-setting="gps_track" 
                                                <?php echo $marker['gps_track'] ? 'checked' : ''; ?>
                                                onchange="toggleBgLifeSetting(this)">
-                                        <span class="toggle-text">📍 Tracking</span>
+                                        <span class="toggle-text">📍</span>
                                     </label>
                                 </div>
                             </div>

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -995,7 +995,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .map-section {
-        flex: 0 0 52%;
+        flex: 0 0 35%;
         min-width: 0;
     }
 
@@ -1026,7 +1026,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .npc-list-section {
-        flex: 0 0 calc(28% - 40px);
+        flex: 0 0 calc(45% - 40px);
         min-width: 0;
     }
 
@@ -1266,21 +1266,20 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .marker-list {
-        display: flex;
-        flex-direction: column;
-        gap: 15px;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
+        align-items: start;
     }
 
     .marker-item {
         background-color: #1a1a1a;
-        padding: 15px;
+        padding: 10px;
         border-left: 4px solid;
         border-radius: 8px;
-        background-size: 100px;
-        background-repeat: no-repeat;
-        background-position: right 10px center;
         border: 1px solid #4a4a4a;
         width: 100%;
+        min-width: 0;
         box-sizing: border-box;
         position: relative;
         cursor: pointer;
@@ -1295,16 +1294,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .marker-item::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: linear-gradient(to right, #1a1a1a 60%, transparent 100%);
-        border-radius: 8px;
-        pointer-events: none;
-        z-index: 1;
+        display: none;
     }
 
     .marker-item > * {
@@ -1314,32 +1304,47 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 
     .marker-item-color {
         display: inline-block;
-        width: 20px;
-        height: 20px;
+        width: 10px;
+        height: 10px;
         border-radius: 50%;
         vertical-align: middle;
-        margin-right: 10px;
-        border: 2px solid white;
+        margin-right: 0;
+        border: 1px solid white;
         box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+        flex: 0 0 auto;
     }
 
     .marker-item h4 {
-        margin: 8px 0;
+        margin: 0 0 8px;
         color: rgb(242, 124, 17);
         font-family: 'MagicCards', serif;
-        display: inline-block;
-        vertical-align: text-top;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+        font-size: 13px;
     }
 
     .marker-npc-events,
     .marker-map-focus {
-        display: inline;
+        display: block;
         padding: 0;
         border: 0;
         background: transparent;
         color: inherit;
         cursor: pointer;
         font: inherit;
+    }
+
+    .marker-npc-events {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .marker-map-focus {
+        margin-left: auto;
+        flex: 0 0 auto;
     }
 
     .marker-npc-events:hover,
@@ -1351,22 +1356,33 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         text-decoration: underline;
     }
 
-    .marker-item-coords {
-        font-size: 12px;
-        color: #bbb;
-        margin: 5px 0;
-    }
-
-    .marker-item-coords ul {
-        padding-left: 15px;
-    }
-
-    .marker-item-coords li {
-        margin: 3px 0;
-    }
-
     #mapImage {
         opacity: 1;
+    }
+
+    .marker-card-actions {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+        gap: 4px;
+    }
+
+    .marker-card-actions .marker-action-btn,
+    .marker-card-actions .marker-action-btn-trans {
+        width: 100%;
+        min-width: 0;
+        padding: 6px 4px;
+        font-size: 10px;
+    }
+
+    .marker-card-toggles {
+        display: grid;
+        gap: 4px;
+        margin-top: 6px;
+    }
+
+    .marker-card-toggles .toggle-label-inline {
+        padding: 4px 6px;
+        font-size: 10px;
     }
 
     .marker-item a {
@@ -2317,33 +2333,19 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                                 class="marker-item"
                                 data-npc-name="<?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>"
                                 title="View recent events for <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>"
-                                style="border-left-color:<?php echo $marker['color']; ?>;background-image:url(<?php echo $marker['figure']; ?>);background-position-y: top;">
+                                style="border-left-color:<?php echo $marker['color']; ?>;">
                                 <h4>
                                     <span class="marker-item-color" style="background-color:                                                                                                                                                                         <?php echo $marker['color']; ?>;"></span>
                                     <!--<a href="#mkr_<?php echo $marker['id'] ?>"><?php echo $marker['name']; ?> &nbsp; ↗️</a> -->
                                     <span class="marker-npc-events" data-npc-events role="button" tabindex="0"><?php echo $marker['name']; ?></span>
                                     <span class="marker-map-focus" data-map-focus role="button" tabindex="0" onclick="event.stopPropagation(); pulseAnimation('mkr_<?php echo $marker['id'] ?>')" aria-label="Show <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?> on map">&nbsp;↗️</span>
                                 </h4>
-                                <div class="marker-item-coords">
-                                    <ul>
-                                    <li><strong>In-game:</strong> x=<?php echo $marker['ingame_x']; ?>, y=<?php echo $marker['ingame_y']; ?>, z=<?php echo $marker['ingame_z']; ?></li>
-                                    <li><strong>Map:</strong> (<?php echo $marker['x']; ?>,<?php echo $marker['y']; ?>)</li>
-                                    <li><strong>RefId:</strong> (<?php echo $marker['refid']; ?>)</li>
-                                    <li><strong>Last Position Timestamp:</strong> (<?php echo $marker['last_pos_ts']; ?>)</li>
-                                    <li><strong>Last Reported:</strong>
-                                        <span title="<?php echo htmlentities($marker['last_letter']); ?>">
-                                            (<?php echo $marker['last_report']; ?>)
-                                            <?php if (isset($marker['last_letter'])) echo "<span style='cursor:help'>📜</span>";?>
-                                    </span>
-                                    </li>
-                                    </ul>
-                                </div>
-                                <div style="margin-top: 10px; display: flex; gap: 5px; flex-wrap: wrap;">
-                                    <button onclick="requestAction('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn">🚶‍➡️Trigger Action</button>
-                                    <button onclick="requestReporting('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" style="background: #4488ff;">✉️ Request Letter</button>
+                                <div class="marker-card-actions">
+                                    <button onclick="requestAction('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn">Action</button>
+                                    <button onclick="requestReporting('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" style="background: #4488ff;">Letter</button>
                                     <button onclick="updateCoords('<?php echo addslashes($marker['name']); ?>')" title="Request coords update now" class="marker-action-btn-trans" style="border: 2px solid #00ff00; background: #44ff44;">📍</button>
                                 </div>
-                                <div style="margin-top: 8px; display: flex; gap: 8px; flex-wrap: wrap;">
+                                <div class="marker-card-toggles">
                                     <label class="toggle-label-inline">
                                         <input type="checkbox" 
                                                class="toggle-checkbox" 

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -2289,27 +2289,27 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                     <div class="bgl-settings-help">Controls how many in-game hours pass before eligible Background Life NPCs automatically run their next update.</div>
                     <button type="submit" class="bgl-settings-save">Save</button>
                 </form>
+                <div class="npc-list-header">
+                    <h3>📍 NPC Markers</h3>
+                    <div style="color: #bbb; font-size: 13px; padding-bottom: 10px; border-bottom: 1px solid #4a4a4a;">
+                        <strong>Tracked NPCs:</strong> <?php echo sizeof($translatedMarkers); ?><br/>
+                        <strong>Current Ingame Date:</strong> <?php echo $currentDate?><br/>
+                        <em style="color: #ffa500;">For traveling to work you must click "Send All Locations" in the CHIM MCM under Tools to add them to Background Life<br/></em>
+                    </div>
+                    <label class="toggle-label-inline" style="margin-top:8px;" title="When enabled, shows all NPCs that have tracked coordinates, regardless of Background Life status">
+                        <input type="checkbox" class="toggle-checkbox" id="showAllCoordsChk"
+                            <?php echo $showAllCoords ? 'checked' : ''; ?>
+                            onchange="toggleShowAllCoords(this.checked)">
+                        <span class="toggle-text">🗺️ Show all NPCs with coords</span>
+                    </label>
+                    <button onclick="updateAllCoords()" class="update-all-coords-btn">📍 Update All NPC Coords</button>
+                </div>
                 <div class="bgl-action-toolbar">
                     <button type="button" class="chim-btn-primary bgl-action-button" onclick="openCreateNpcModal()">Create NPC</button>
                 </div>
             </div>
             <div class="npc-list-section">
                 <div class="npc-list-container">
-                    <div class="npc-list-header">
-                        <h3>📍 NPC Markers</h3>
-                        <div style="color: #bbb; font-size: 13px; padding-bottom: 10px; border-bottom: 1px solid #4a4a4a;">
-                            <strong>Tracked NPCs:</strong> <?php echo sizeof($translatedMarkers); ?><br/>
-                            <strong>Current Ingame Date:</strong> <?php echo $currentDate?><br/>
-                            <em style="color: #ffa500;">For traveling to work you must click "Send All Locations" in the CHIM MCM under Tools to add them to Background Life<br/></em>
-                        </div>
-                        <label class="toggle-label-inline" style="margin-top:8px;" title="When enabled, shows all NPCs that have tracked coordinates, regardless of Background Life status">
-                            <input type="checkbox" class="toggle-checkbox" id="showAllCoordsChk"
-                                <?php echo $showAllCoords ? 'checked' : ''; ?>
-                                onchange="toggleShowAllCoords(this.checked)">
-                            <span class="toggle-text">🗺️ Show all NPCs with coords</span>
-                        </label>
-                        <button onclick="updateAllCoords()" class="update-all-coords-btn">📍 Update All NPC Coords</button>
-                    </div>
                     <div class="marker-list">
                         <?php foreach ($translatedMarkers as $marker) {?>
                             <div


### PR DESCRIPTION
## Summary
- increase the visible height of the Background Life NPC list
- open a unified NPC history modal from each NPC card, NPC name, or current map marker
- provide dedicated `Event History`, `Letters`, and `Inner Thoughts` tabs without nested written-history controls
- remove the redundant per-NPC letters/thoughts View button and standalone diary modal
- prioritize NPC markers over passive town markers when their map hit areas overlap
- support keyboard access to current map markers with Enter or Space
- replace the map width slider with an interactive fixed viewport
- use a compact three-column layout with the map, controls, and NPC list in separate sections
- move the scrollable NPC list into its own right-side panel instead of leaving unused horizontal space
- show tracked NPCs as a compact two-column card grid
- restore each NPC profile portrait in a compact identity header
- keep longer NPC names readable across up to two lines
- replace the old map-focus arrow with a dedicated map icon that grows by 10% without underlining on hover
- compress the Actions, Letters, and Tracking settings into one icon-only row with tooltips and accessible labels
- provide accurate NPC-specific Action and Letter tooltips instead of inheriting the card history tooltip
- remove coordinate, RefID, position timestamp, and reporting metadata from NPC cards
- place the NPC Markers summary and controls in a matching bordered card above Create NPC, separate from the right-side NPC cards
- stack all three sections at equal width on narrower screens
- use white tab labels while retaining the orange active-state treatment
- initially frame useful Skyrim geography instead of decorative map margins
- add compact zoom, reset, mouse-wheel, drag-pan, and keyboard map controls
- persist the selected zoom and map center between page loads
- center and zoom to an NPC when `Show on map` is used, while retaining the existing marker pulse
- initialize NPC history controls on the main Background Life tab as well as the History tab

## Validation
- `php -l ui/mapview.php`
- `node --check ui/js/background_life_history.js`
- `git diff --check`
- local page returned HTTP 200 and included the interactive map markup
- browser-tested the 35/20/45 desktop map, controls, and two-column NPC-card layout with all 13 tracked NPCs present
- browser-tested all 13 profile portraits loading at 44x44 pixels
- browser-tested readable two-line NPC names, dedicated map icons, and three settings aligned in one compact row
- browser-tested tooltip and accessible labels for all compact settings
- browser-tested map hover styling and NPC-specific Action/Letter tooltips
- browser-tested the 10% map-icon hover scale rule without page errors
- browser-tested the NPC Markers controls above Create NPC with only NPC cards remaining in the right panel
- browser-tested absence of NPC metadata rows and NPC history modal access from the card name
- browser-tested equal-width stacking at a 1100px viewport and restored the default viewport afterward
- browser-tested the initial geography-focused view, zoom controls, reset, cursor-centered wheel zoom, drag and keyboard panning, saved camera restoration after reload, and `Show on map` NPC centering
- browser-tested NPC history opening from the right-side list and current map markers
- browser-tested all three top-level history tabs, event loading, independent letter/thought rendering, modal close behavior, and reopening on the default Event History tab
- browser-tested marker history opening and the NPC-over-location hit priority
- no browser console warnings or errors during final interaction checks

## Deployment
- deployed the changed server UI assets to `/var/www/html/HerikaServer` for local testing
- deployed server UI assets match commit `63e59bcd83f2b2983c948eacc64292ed3a90a91e`

## Notes
- no database or API schema changes
- no map image or coordinate-system changes
- no game-plugin changes
- when multiple NPC markers overlap each other, the currently visible top NPC marker receives the click
