### PR TITLE
Reorder Background Life dashboard columns

### DIFF
--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -995,6 +995,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .map-section {
+        order: 1;
         flex: 0 0 35%;
         min-width: 0;
     }
@@ -1019,6 +1020,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .sidebar-section {
+        order: 3;
         flex: 0 0 20%;
         display: flex;
         flex-direction: column;
@@ -1026,6 +1028,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
     }
 
     .npc-list-section {
+        order: 2;
         flex: 0 0 calc(45% - 40px);
         min-width: 0;
     }


### PR DESCRIPTION
## Summary
- place the NPC list between the minimap and Background Life controls
- preserve existing panel widths, controls, and responsive stacking

## Validation
- `php -l ui/mapview.php`
- `git diff --check`

## Deployment
- Not deployed.

## Manual limits
- Not visually or in-game tested in this branch.

## Related
- CHIM PR: https://github.com/Dwemer-Dynamics/CHIM/pull/98
