### PR TITLE
Use eye icon for Background Life map focus

### DIFF
--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -2431,7 +2431,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                                     <h4>
                                         <span class="marker-item-color" style="background-color:                                                                                                                                                                         <?php echo $marker['color']; ?>;"></span>
                                         <span class="marker-npc-events" data-npc-events role="button" tabindex="0"><?php echo $marker['name']; ?></span>
-                                        <span class="marker-map-focus" data-map-focus role="button" tabindex="0" onclick="event.stopPropagation(); pulseAnimation('mkr_<?php echo $marker['id'] ?>')" aria-label="Show <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?> on map" title="Show on map">🗺️</span>
+                                        <span class="marker-map-focus" data-map-focus role="button" tabindex="0" onclick="event.stopPropagation(); pulseAnimation('mkr_<?php echo $marker['id'] ?>')" aria-label="Show <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?> on map" title="Show on map">👀</span>
                                         <span class="marker-map-focus" data-map-focus role="button" tabindex="0" onclick="window.open('https://gamemap.uesp.net/sr/?world=skyrim&layer=day&x=<?php echo $marker['ingame_x'] ?>&y=<?php echo $marker['ingame_y'] ?>&zoom=8', '_blank'); event.stopPropagation();" aria-label="Show <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?> on map" title="UESP Map">🗺️</span>
                                     </h4>
                                 </div>


### PR DESCRIPTION
## Summary
- change the Background Life NPC-card map-focus control from the map emoji to the eye emoji
- keep the adjacent external UESP map icon and all map behavior unchanged

## Validation
- `php -l ui/mapview.php`
- `git diff --check origin/unstable...HEAD`

## Deployment
- Not deployed; this is a presentation-only server change.

## Manual limits
- Not visually tested in a browser or in-game.