### PR TITLE
Improve Background Life NPC management and add Prisma API

### DIFF
--- a/lib/background_life_npc_creation.php
+++ b/lib/background_life_npc_creation.php
@@ -228,6 +228,15 @@ function chimBglSpawnNpc(array $npcProfile, int $startingPoint, array $inventory
     $startRow = $GLOBALS['db']->fetchOne('SELECT COALESCE(MAX(rowid), 0) AS rowid FROM eventlog');
     $startRowId = (int)($startRow['rowid'] ?? 0);
 
+    $GLOBALS['db']->insert('responselog', [
+        'localts' => time(),
+        'sent' => 0,
+        'actor' => 'rolemaster',
+        'text' => '',
+        'action' => "rolecommand|DebugNotification@Creating {$npcProfile['name']}. Please keep the game running.",
+        'tag' => __FILE__ . ':' . __LINE__,
+    ]);
+
     npcProfileBase(
         $npcProfile['name'],
         $npcProfile['class'],
@@ -301,6 +310,7 @@ function chimBglSpawnNpc(array $npcProfile, int $startingPoint, array $inventory
 
     $metadata = $npcMaster->getMetadata($npc);
     $metadata['gps_track'] = true;
+    $metadata['background_life_created'] = true;
 
     $npc['core'] = "{$npcProfile['name']}. {$npcProfile['gender']} {$npcProfile['class']} {$npcProfile['race']}";
     $npc['npc_static_bio'] = "{$npcProfile['name']}. {$npcProfile['background']}";

--- a/ui/api/chim_npc_manager.php
+++ b/ui/api/chim_npc_manager.php
@@ -1,0 +1,511 @@
+<?php
+
+error_reporting(E_ERROR);
+session_start();
+
+define('BASE_PATH', dirname(dirname(__DIR__)));
+define('CONFIG_PATH', BASE_PATH . DIRECTORY_SEPARATOR . 'conf');
+define('LIB_PATH', BASE_PATH . DIRECTORY_SEPARATOR . 'lib');
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+if (!file_exists(CONFIG_PATH . DIRECTORY_SEPARATOR . 'conf.php')) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Configuration file not found']);
+    exit;
+}
+
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'profile_loader.php';
+require_once LIB_PATH . DIRECTORY_SEPARATOR . 'logger.php';
+require_once LIB_PATH . DIRECTORY_SEPARATOR . "{$GLOBALS['DBDRIVER']}.class.php";
+require_once LIB_PATH . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'npc_master.class.php';
+require_once LIB_PATH . DIRECTORY_SEPARATOR . 'relationship_manager.php';
+
+$db = new sql();
+$npcMaster = new NpcMaster();
+
+function chimNpcManagerRespond(array $payload, int $status = 200): void
+{
+    http_response_code($status);
+    echo json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function chimNpcManagerDecodeJson($value): array
+{
+    if (is_array($value)) {
+        return $value;
+    }
+    $decoded = json_decode((string)$value, true);
+    return is_array($decoded) ? $decoded : [];
+}
+
+function chimNpcManagerBool($value): bool
+{
+    if (is_bool($value)) {
+        return $value;
+    }
+    if (is_int($value) || is_float($value)) {
+        return (int)$value !== 0;
+    }
+    return in_array(strtolower(trim((string)$value)), ['1', 'true', 'yes', 'on'], true);
+}
+
+function chimNpcManagerProfiles(): array
+{
+    $rows = $GLOBALS['db']->fetchAll('SELECT id, label, metadata FROM core_profiles ORDER BY label ASC, id ASC');
+    $profiles = [];
+    foreach ((array)$rows as $row) {
+        $profiles[] = [
+            'id' => (int)($row['id'] ?? 0),
+            'label' => trim((string)($row['label'] ?? 'Unnamed Profile')),
+            'metadata' => chimNpcManagerDecodeJson($row['metadata'] ?? '{}'),
+        ];
+    }
+    return $profiles;
+}
+
+function chimNpcManagerProfileMap(array $profiles): array
+{
+    $map = [];
+    foreach ($profiles as $profile) {
+        $map[(string)$profile['id']] = $profile;
+    }
+    return $map;
+}
+
+function chimNpcManagerToggleState($override, array $profileMetadata, string $profileKey, bool $default = false): array
+{
+    if ($override !== null && $override !== '') {
+        return [
+            'value' => chimNpcManagerBool($override),
+            'source' => 'npc',
+            'profile_default' => array_key_exists($profileKey, $profileMetadata)
+                ? chimNpcManagerBool($profileMetadata[$profileKey])
+                : $default,
+        ];
+    }
+
+    $profileDefault = array_key_exists($profileKey, $profileMetadata)
+        ? chimNpcManagerBool($profileMetadata[$profileKey])
+        : $default;
+    return [
+        'value' => $profileDefault,
+        'source' => array_key_exists($profileKey, $profileMetadata) ? 'profile' : 'default',
+        'profile_default' => $profileDefault,
+    ];
+}
+
+function chimNpcManagerWebRoot(): string
+{
+    $scriptPath = str_replace('\\', '/', (string)($_SERVER['SCRIPT_NAME'] ?? ''));
+    $marker = '/HerikaServer/';
+    $position = stripos($scriptPath, $marker);
+    if ($position !== false) {
+        return substr($scriptPath, 0, $position + strlen('/HerikaServer'));
+    }
+    return '/HerikaServer';
+}
+
+function chimNpcManagerPortraitUrl(array $row, array $metadata): string
+{
+    $webRoot = chimNpcManagerWebRoot();
+    $portrait = ltrim(str_replace('\\', '/', trim((string)($metadata['portrait'] ?? ''))), '/');
+    if ($portrait !== '') {
+        $picturesRoot = realpath(BASE_PATH . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'pictures');
+        $portraitPath = realpath(BASE_PATH . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'pictures'
+            . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $portrait));
+        if ($picturesRoot !== false && $portraitPath !== false
+            && strncmp($portraitPath, $picturesRoot, strlen($picturesRoot)) === 0
+            && is_file($portraitPath)) {
+            return $webRoot . '/data/pictures/' . str_replace('%2F', '/', rawurlencode($portrait));
+        }
+    }
+
+    $profileDirectory = BASE_PATH . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'pictures'
+        . DIRECTORY_SEPARATOR . 'profile' . DIRECTORY_SEPARATOR;
+    $candidates = array_filter([
+        trim((string)($row['md5'] ?? '')),
+        strtoupper(trim((string)($row['refid'] ?? ''))),
+        preg_replace('/[^a-z0-9_-]+/i', '', strtolower((string)($row['npc_name'] ?? ''))),
+    ]);
+    foreach (array_unique($candidates) as $candidate) {
+        foreach (['png', 'jpg', 'jpeg', 'webp', 'gif'] as $extension) {
+            if (is_file($profileDirectory . $candidate . '.' . $extension)) {
+                return $webRoot . '/data/pictures/profile/' . rawurlencode($candidate . '.' . $extension);
+            }
+        }
+    }
+
+    $race = strtolower(trim((string)($row['race'] ?? '')));
+    $race = preg_replace('/[^a-z0-9]+/', '', $race);
+    $aliases = [
+        'highelf' => 'altmer', 'woodelf' => 'bosmer', 'darkelf' => 'dunmer',
+        'orsimer' => 'orc', 'khajit' => 'khajiit', 'oldpeople' => 'nord',
+        'oldpeoplerace' => 'nord',
+    ];
+    $race = $aliases[$race] ?? $race;
+    foreach (['png', 'jpg', 'jpeg', 'webp', 'gif', 'svg'] as $extension) {
+        $racePath = BASE_PATH . DIRECTORY_SEPARATOR . 'ui' . DIRECTORY_SEPARATOR . 'images'
+            . DIRECTORY_SEPARATOR . 'races' . DIRECTORY_SEPARATOR . $race . '.' . $extension;
+        if ($race !== '' && is_file($racePath)) {
+            return $webRoot . '/ui/images/races/' . rawurlencode($race . '.' . $extension);
+        }
+    }
+    return $webRoot . '/ui/images/races/default.png';
+}
+
+function chimNpcManagerCard(array $row, array $profileMap): array
+{
+    $metadata = chimNpcManagerDecodeJson($row['metadata'] ?? '{}');
+    $profile = $profileMap[(string)($row['profile_id'] ?? '')] ?? null;
+    return [
+        'id' => (int)($row['id'] ?? 0),
+        'name' => trim((string)($row['npc_name'] ?? 'Unknown NPC')),
+        'gender' => trim((string)($row['gender'] ?? '')),
+        'race' => trim((string)($row['race'] ?? '')),
+        'refid' => trim((string)($row['refid'] ?? '')),
+        'profile_id' => isset($row['profile_id']) ? (int)$row['profile_id'] : null,
+        'profile_label' => $profile['label'] ?? 'No Profile',
+        'favorite' => chimNpcManagerBool($row['npc_favorite'] ?? false),
+        'locked' => chimNpcManagerBool($row['lock_profile'] ?? false),
+        'portrait_url' => chimNpcManagerPortraitUrl($row, $metadata),
+    ];
+}
+
+function chimNpcManagerLatestMemory(array $extended): string
+{
+    $memory = $extended['middle_term_memory'] ?? [];
+    if (!is_array($memory) || empty($memory)) {
+        return '';
+    }
+    $latestKey = array_key_last($memory);
+    return $latestKey === null ? '' : trim((string)$memory[$latestKey]);
+}
+
+function chimNpcManagerDetail(array $row, array $profiles): array
+{
+    $metadata = chimNpcManagerDecodeJson($row['metadata'] ?? '{}');
+    $extended = chimNpcManagerDecodeJson($row['extended_data'] ?? '{}');
+    $profileMap = chimNpcManagerProfileMap($profiles);
+    $profile = $profileMap[(string)($row['profile_id'] ?? '')] ?? null;
+    $profileMetadata = $profile['metadata'] ?? [];
+
+    return [
+        'card' => chimNpcManagerCard($row, $profileMap),
+        'fields' => [
+            'npc_name' => (string)($row['npc_name'] ?? ''),
+            'profile_id' => isset($row['profile_id']) ? (int)$row['profile_id'] : null,
+            'lock_profile' => chimNpcManagerBool($row['lock_profile'] ?? false),
+            'npc_favorite' => chimNpcManagerBool($row['npc_favorite'] ?? false),
+            'gender' => (string)($row['gender'] ?? ''),
+            'race' => (string)($row['race'] ?? ''),
+            'base' => (string)($row['base'] ?? ''),
+            'refid' => (string)($row['refid'] ?? ''),
+            'voiceid' => (string)($row['voiceid'] ?? ''),
+            'oghma_knowledge_tags' => (string)($row['oghma_knowledge_tags'] ?? ''),
+            'tags' => (string)($row['tags'] ?? ''),
+            'prompt_head' => (string)($row['prompt_head'] ?? ''),
+            'core' => (string)($row['core'] ?? ''),
+            'npc_static_bio' => (string)($row['npc_static_bio'] ?? ''),
+            'appearance' => (string)($row['appearance'] ?? ''),
+            'personality' => (string)($row['personality'] ?? ''),
+            'occupation' => (string)($row['occupation'] ?? ''),
+            'skills' => (string)($row['skills'] ?? ''),
+            'speechstyle' => (string)($row['speechstyle'] ?? ''),
+            'goals' => (string)($row['goals'] ?? ''),
+            'emote_moods' => (string)($row['emote_moods'] ?? ''),
+            'middle_term_latest' => chimNpcManagerLatestMemory($extended),
+        ],
+        'toggles' => [
+            'dynamic_profile' => chimNpcManagerToggleState($row['dynamic_profile'] ?? null, $profileMetadata, 'DYNAMIC_PROFILE_ENABLED'),
+            'middle_term_enabled' => chimNpcManagerToggleState($extended['middle_term_enabled'] ?? null, $profileMetadata, 'MIDDLE_TERM_MEMORY_ENABLED'),
+            'individual_memory_enabled' => chimNpcManagerToggleState($extended['individual_memory_enabled'] ?? null, $profileMetadata, 'INDIVIDUAL_MEMORY_ENABLED'),
+            'auto_diary_enabled' => chimNpcManagerToggleState($extended['auto_diary_enabled'] ?? null, $profileMetadata, 'AUTO_DIARY_ENABLED'),
+            'auto_diary_wait_enabled' => chimNpcManagerToggleState($extended['auto_diary_wait_enabled'] ?? null, $profileMetadata, 'AUTO_DIARY_WAIT_ENABLED'),
+            'salutation_after_a_while' => chimNpcManagerToggleState($extended['salutation_after_a_while'] ?? null, $profileMetadata, 'SALUTATION_AFTER_A_WHILE'),
+        ],
+        'relationships' => RelationshipManager::normalizeRelationshipMap($extended['relationships'] ?? []),
+        'relationships_locked' => chimNpcManagerBool($extended['relationships_locked'] ?? false),
+        'metadata' => $metadata,
+        'profiles' => array_map(static function ($profile) {
+            return ['id' => $profile['id'], 'label' => $profile['label']];
+        }, $profiles),
+    ];
+}
+
+function chimNpcManagerFindNpc(array $input): array
+{
+    $id = (int)($input['id'] ?? 0);
+    if ($id > 0) {
+        $row = $GLOBALS['db']->fetchOne("SELECT * FROM core_npc_master WHERE id = {$id} LIMIT 1");
+        if ($row) {
+            return $row;
+        }
+    }
+
+    $refid = trim((string)($input['refid'] ?? ''));
+    if ($refid !== '') {
+        $escaped = $GLOBALS['db']->escape(strtolower($refid));
+        $row = $GLOBALS['db']->fetchOne("SELECT * FROM core_npc_master WHERE lower(refid) = '{$escaped}' ORDER BY gamets_last_updated DESC NULLS LAST LIMIT 1");
+        if ($row) {
+            return $row;
+        }
+    }
+
+    $name = trim((string)($input['name'] ?? $input['npc_name'] ?? ''));
+    if ($name !== '') {
+        $escaped = $GLOBALS['db']->escape($name);
+        $row = $GLOBALS['db']->fetchOne("SELECT * FROM core_npc_master WHERE npc_name = '{$escaped}' ORDER BY gamets_last_updated DESC NULLS LAST LIMIT 1");
+        if ($row) {
+            return $row;
+        }
+    }
+
+    throw new InvalidArgumentException('NPC not found');
+}
+
+function chimNpcManagerList(array $profiles): array
+{
+    $page = max(1, (int)($_GET['page'] ?? 1));
+    $limit = max(1, min(100, (int)($_GET['limit'] ?? 40)));
+    $offset = ($page - 1) * $limit;
+    $conditions = ["npc_name IS NOT NULL", "btrim(npc_name) <> ''"];
+
+    $search = trim((string)($_GET['search'] ?? ''));
+    if ($search !== '') {
+        $escaped = $GLOBALS['db']->escape('%' . $search . '%');
+        $conditions[] = "(npc_name ILIKE '{$escaped}' OR race ILIKE '{$escaped}' OR refid ILIKE '{$escaped}')";
+    }
+
+    $profileId = (int)($_GET['profile_id'] ?? 0);
+    if ($profileId > 0) {
+        $conditions[] = "profile_id = {$profileId}";
+    }
+
+    $refids = array_values(array_filter(array_map('trim', explode(',', (string)($_GET['refids'] ?? '')))));
+    $names = array_values(array_filter(array_map('trim', explode('|', (string)($_GET['names'] ?? '')))));
+    if (!empty($refids) || !empty($names)) {
+        $nearbyConditions = [];
+        if (!empty($refids)) {
+            $escapedRefids = array_map(static function ($value) {
+                return "'" . $GLOBALS['db']->escape(strtolower($value)) . "'";
+            }, $refids);
+            $nearbyConditions[] = 'lower(refid) IN (' . implode(',', $escapedRefids) . ')';
+        }
+        if (!empty($names)) {
+            $escapedNames = array_map(static function ($value) {
+                return "'" . $GLOBALS['db']->escape($value) . "'";
+            }, $names);
+            $nearbyConditions[] = 'npc_name IN (' . implode(',', $escapedNames) . ')';
+        }
+        $conditions[] = '(' . implode(' OR ', $nearbyConditions) . ')';
+    }
+
+    $where = implode(' AND ', $conditions);
+    $countRow = $GLOBALS['db']->fetchOne("SELECT COUNT(*) AS total FROM core_npc_master WHERE {$where}");
+    $total = (int)($countRow['total'] ?? 0);
+    $rows = $GLOBALS['db']->fetchAll(
+        "SELECT * FROM core_npc_master WHERE {$where} ORDER BY npc_favorite DESC NULLS LAST, npc_name ASC, id ASC LIMIT {$limit} OFFSET {$offset}"
+    );
+    $profileMap = chimNpcManagerProfileMap($profiles);
+
+    return [
+        'npcs' => array_map(static function ($row) use ($profileMap) {
+            return chimNpcManagerCard($row, $profileMap);
+        }, (array)$rows),
+        'profiles' => array_map(static function ($profile) {
+            return ['id' => $profile['id'], 'label' => $profile['label']];
+        }, $profiles),
+        'pagination' => [
+            'page' => $page,
+            'limit' => $limit,
+            'total' => $total,
+            'pages' => max(1, (int)ceil($total / $limit)),
+        ],
+    ];
+}
+
+function chimNpcManagerSave(array $input, array $profiles): array
+{
+    $row = chimNpcManagerFindNpc($input);
+    $id = (int)$row['id'];
+    $fields = is_array($input['fields'] ?? null) ? $input['fields'] : [];
+    $overrides = is_array($input['overrides'] ?? null) ? $input['overrides'] : [];
+    $update = [];
+
+    $allowedFields = [
+        'npc_name', 'profile_id', 'lock_profile', 'npc_favorite', 'gender', 'race', 'base',
+        'refid', 'voiceid', 'oghma_knowledge_tags', 'tags', 'prompt_head', 'core',
+        'npc_static_bio', 'appearance', 'personality', 'occupation', 'skills', 'speechstyle',
+        'goals', 'emote_moods',
+    ];
+    foreach ($allowedFields as $field) {
+        if (!array_key_exists($field, $fields)) {
+            continue;
+        }
+        if (in_array($field, ['lock_profile', 'npc_favorite'], true)) {
+            $update[$field] = chimNpcManagerBool($fields[$field]) ? 1 : 0;
+        } elseif ($field === 'profile_id') {
+            $profileId = (int)$fields[$field];
+            $profileExists = false;
+            foreach ($profiles as $profile) {
+                if ((int)$profile['id'] === $profileId) {
+                    $profileExists = true;
+                    break;
+                }
+            }
+            if (!$profileExists) {
+                throw new InvalidArgumentException('Selected profile does not exist');
+            }
+            $update[$field] = $profileId;
+        } else {
+            $update[$field] = trim((string)$fields[$field]);
+        }
+    }
+
+    if (array_key_exists('npc_name', $update)) {
+        if ($update['npc_name'] === '') {
+            throw new InvalidArgumentException('NPC name is required');
+        }
+        $update['md5'] = md5($update['npc_name']);
+    }
+
+    $extended = chimNpcManagerDecodeJson($row['extended_data'] ?? '{}');
+    $relationshipChanged = false;
+    $toggleMap = [
+        'middle_term_enabled' => 'middle_term_enabled',
+        'individual_memory_enabled' => 'individual_memory_enabled',
+        'auto_diary_enabled' => 'auto_diary_enabled',
+        'auto_diary_wait_enabled' => 'auto_diary_wait_enabled',
+        'salutation_after_a_while' => 'salutation_after_a_while',
+    ];
+    if (array_key_exists('dynamic_profile', $overrides)) {
+        $update['dynamic_profile'] = $overrides['dynamic_profile'] === null
+            ? null
+            : (chimNpcManagerBool($overrides['dynamic_profile']) ? 1 : 0);
+    }
+    foreach ($toggleMap as $requestKey => $extendedKey) {
+        if (!array_key_exists($requestKey, $overrides)) {
+            continue;
+        }
+        if ($overrides[$requestKey] === null) {
+            unset($extended[$extendedKey]);
+        } else {
+            $extended[$extendedKey] = chimNpcManagerBool($overrides[$requestKey]) ? 1 : 0;
+        }
+    }
+
+    if (array_key_exists('middle_term_latest', $fields)) {
+        $latest = trim((string)$fields['middle_term_latest']);
+        $memories = is_array($extended['middle_term_memory'] ?? null) ? $extended['middle_term_memory'] : [];
+        $latestKey = empty($memories) ? null : array_key_last($memories);
+        if ($latestKey !== null) {
+            if ($latest === '') {
+                unset($memories[$latestKey]);
+            } else {
+                $memories[$latestKey] = $latest;
+            }
+        } elseif ($latest !== '') {
+            $memories['0'] = $latest;
+        }
+        if (empty($memories)) {
+            unset($extended['middle_term_memory']);
+        } else {
+            $extended['middle_term_memory'] = $memories;
+        }
+    }
+
+    if (array_key_exists('relationships', $input)) {
+        $relationships = is_array($input['relationships']) ? $input['relationships'] : [];
+        foreach ($relationships as $target => &$relationship) {
+            if (!is_array($relationship)) {
+                $relationship = [];
+            }
+            $relationship['aff'] = max(-100, min(100, (int)($relationship['aff'] ?? 0)));
+            $relationship['type'] = strtolower(trim((string)($relationship['type'] ?? 'neutral')));
+            foreach (['relation', 'note', 'best', 'worst'] as $key) {
+                if (array_key_exists($key, $relationship)) {
+                    $relationship[$key] = trim((string)$relationship[$key]);
+                }
+            }
+        }
+        unset($relationship);
+        $extended['relationships'] = RelationshipManager::normalizeRelationshipMap($relationships);
+        $relationshipChanged = true;
+    }
+    if (array_key_exists('relationships_locked', $input)) {
+        $extended['relationships_locked'] = chimNpcManagerBool($input['relationships_locked']);
+        $relationshipChanged = true;
+    }
+
+    if (!array_key_exists('AUTO_LOCK_PROFILE', $GLOBALS) || chimNpcManagerBool($GLOBALS['AUTO_LOCK_PROFILE'])) {
+        $update['lock_profile'] = 1;
+    }
+
+    $update['extended_data'] = json_encode($extended, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    $lockId = $relationshipChanged ? 1001000000 + $id : null;
+    try {
+        if ($lockId !== null) {
+            $GLOBALS['db']->execQuery("SELECT pg_advisory_lock({$lockId})");
+        }
+        $save = static function () use ($id, $update) {
+            $manager = new NpcMaster();
+            return $manager->update($id, $update);
+        };
+        $saved = $relationshipChanged ? chimRunWithRelationshipExtendedDataWrite($save) : $save();
+        if ($saved === false) {
+            throw new RuntimeException('NPC update failed');
+        }
+        if ($relationshipChanged && function_exists('chimRelationshipTimelineStamp')) {
+            chimRelationshipTimelineStamp($id);
+        }
+        (new NpcMaster())->backupNpcById($id);
+    } finally {
+        if ($lockId !== null) {
+            $GLOBALS['db']->execQuery("SELECT pg_advisory_unlock({$lockId})");
+        }
+    }
+
+    $fresh = (new NpcMaster())->getById($id);
+    if (!$fresh) {
+        throw new RuntimeException('NPC could not be reloaded after saving');
+    }
+    return chimNpcManagerDetail($fresh, $profiles);
+}
+
+try {
+    $profiles = chimNpcManagerProfiles();
+    $method = strtoupper((string)($_SERVER['REQUEST_METHOD'] ?? 'GET'));
+    if ($method === 'POST') {
+        $input = json_decode((string)file_get_contents('php://input'), true);
+        if (!is_array($input)) {
+            throw new InvalidArgumentException('Invalid JSON request');
+        }
+        chimNpcManagerRespond(['success' => true, 'data' => chimNpcManagerSave($input, $profiles)]);
+    }
+
+    $operation = strtolower(trim((string)($_GET['operation'] ?? 'list')));
+    if ($operation === 'list') {
+        chimNpcManagerRespond(['success' => true, 'data' => chimNpcManagerList($profiles)]);
+    }
+    if ($operation === 'detail') {
+        $row = chimNpcManagerFindNpc($_GET);
+        chimNpcManagerRespond(['success' => true, 'data' => chimNpcManagerDetail($row, $profiles)]);
+    }
+    throw new InvalidArgumentException('Unsupported NPC manager operation');
+} catch (InvalidArgumentException $error) {
+    chimNpcManagerRespond(['success' => false, 'error' => $error->getMessage()], 400);
+} catch (Throwable $error) {
+    Logger::error('CHIM NPC manager API failed: ' . $error->getMessage());
+    chimNpcManagerRespond(['success' => false, 'error' => 'Unable to process NPC manager request'], 500);
+}

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -1212,6 +1212,7 @@ $lockOnly = (isset($_GET['lock']) && $_GET['lock'] === '1');
 $salOnly = (isset($_GET['sal']) && $_GET['sal'] === '1');
 $blcOnly = (isset($_GET['blc']) && $_GET['blc'] === '1');
 $gpsOnly = (isset($_GET['gps']) && $_GET['gps'] === '1');
+$createdOnly = (isset($_GET['created']) && $_GET['created'] === '1');
 
 // Preload profiles for filter dropdown
 $profileRows = $GLOBALS["db"]->fetchAll("SELECT id, label, metadata FROM core_profiles ORDER BY label ASC");
@@ -1321,6 +1322,9 @@ if ($blcOnly) {
 if ($gpsOnly) {
     $where .= " and coalesce(metadata::text,'') ~ '\"gps_track\"\\s*:\\s*(true|1)'";
 }
+if ($createdOnly) {
+    $where .= " and coalesce(metadata::text,'') ~ '\"background_life_created\"\\s*:\\s*(true|1)'";
+}
 
 // Default: The Narrator first, then favorites, then alphabetical by name
 $order = "order by (case when npc_name = 'The Narrator' then 0 else 1 end), coalesce(npc_favorite,0) desc, coalesce(gamets_last_updated,0) desc, lower(npc_name) ".$alpha.", id asc";
@@ -1427,6 +1431,7 @@ if (!function_exists('renderNpcToolbar')) {
                   <label><input type="checkbox" id="npc_filter_sal<?= $suffix ?>" <?= $salOnly ? 'checked' : '' ?>> 👋 Auto Greeting</label>
                   <label><input type="checkbox" id="npc_filter_blc<?= $suffix ?>" <?= $blcOnly ? 'checked' : '' ?>> 🎮 BGL: Auto Actions</label>
                   <label><input type="checkbox" id="npc_filter_gps<?= $suffix ?>" <?= $gpsOnly ? 'checked' : '' ?>> 📍 BGL: GPS track</label>
+                  <label><input type="checkbox" id="npc_filter_created<?= $suffix ?>" <?= $createdOnly ? 'checked' : '' ?>> 🧬 Created NPCs</label>
                 </div>
               </div>
               <div class="npc-total-pill" title="Total NPC profiles">
@@ -5309,6 +5314,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
       const sal = (document.getElementById('npc_filter_sal_top')||document.getElementById('npc_filter_sal'));
       const blc = (document.getElementById('npc_filter_blc_top')||document.getElementById('npc_filter_blc'));
       const gps = (document.getElementById('npc_filter_gps_top')||document.getElementById('npc_filter_gps'));
+      const created = (document.getElementById('npc_filter_created_top')||document.getElementById('npc_filter_created'));
       params.set('fav', fav && fav.checked ? '1' : '');
       params.set('dyn', dyn && dyn.checked ? '1' : '');
       params.set('mtm', mtm && mtm.checked ? '1' : '');
@@ -5316,6 +5322,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
       params.set('sal', sal && sal.checked ? '1' : '');
       params.set('blc', blc && blc.checked ? '1' : '');
       params.set('gps', gps && gps.checked ? '1' : '');
+      params.set('created', created && created.checked ? '1' : '');
     } catch(_e){}
     params.set('alpha', 'asc');
     if (page) params.set('page', String(page));

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -2371,7 +2371,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                             <strong>Control Buttons:</strong>
                             <ul>
                                 <li><strong>Trigger Action:</strong> Forces the NPC to generate an action immediately (may move or stay based on AI decision).</li>
-                                <li><strong>Request Letter:</strong> Forces the NPC to send you a letter about their current activities. You will need to be in a town so the courier can deliver it.</li>
+                                <li><strong>Send Letter:</strong> Forces the NPC to send you a letter about their current activities. You will need to be in a town so the courier can deliver it.</li>
                                 <li><strong>Update All NPC Coords:</strong> Refreshes position tracking for all Background Life NPC.s</li>
                             </ul>
                         </div>
@@ -2436,8 +2436,8 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                                     </h4>
                                 </div>
                                 <div class="marker-card-actions">
-                                    <button onclick="requestAction('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" title="Request a Background Life action from <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>">Action</button>
-                                    <button onclick="requestReporting('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" title="Request a letter from <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>" style="background: #4488ff;">Letter</button>
+                                    <button onclick="requestAction('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" title="Trigger a Background Life action for <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>">Trigger Action</button>
+                                    <button onclick="requestReporting('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" title="Send a letter from <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>" style="background: #4488ff;">Send Letter</button>
                                     <button onclick="updateCoords('<?php echo addslashes($marker['name']); ?>')" title="Request coords update now" class="marker-action-btn-trans" style="border: 2px solid #00ff00; background: #44ff44;">📍</button>
                                 </div>
                                 <div class="marker-card-toggles">

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -2350,6 +2350,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
             <div class="sidebar-section">
                 <div class="bgl-instructions-box collapsed">
                     <h3>📖 How Background Life Works</h3>
+                    <button class="toggle-instructions-btn" onclick="toggleInstructions()">Show Instructions</button>
                     <div class="bgl-instructions-content">
                         <div class="instruction-section">
                             <strong>Getting Started:</strong>
@@ -2389,7 +2390,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                             <strong>💡 Note:</strong> Events are triggered automatically based on the configured trigger period (Global Settings, default: 24 in-game hours). The buttons are mainly for testing or forcing immediate updates.
                         </div>
                     </div>
-                    <button class="toggle-instructions-btn" onclick="toggleInstructions()">Show Instructions</button>
                 </div>
                 <form id="background-life-settings" class="bgl-settings-card" method="post">
                     <input type="hidden" name="action" value="save_bgl_settings">

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -1403,6 +1403,15 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         opacity: 1;
     }
 
+    .marker-card-row-label {
+        margin: 6px 0 3px;
+        color: #9a9aa2;
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
     .marker-card-actions {
         display: grid;
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
@@ -2435,11 +2444,13 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                                         <span class="marker-map-focus" data-map-focus role="button" tabindex="0" onclick="window.open('https://gamemap.uesp.net/sr/?world=skyrim&layer=day&x=<?php echo $marker['ingame_x'] ?>&y=<?php echo $marker['ingame_y'] ?>&zoom=8', '_blank'); event.stopPropagation();" aria-label="Show <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?> on map" title="UESP Map">🗺️</span>
                                     </h4>
                                 </div>
+                                <div class="marker-card-row-label">Actions</div>
                                 <div class="marker-card-actions">
                                     <button onclick="requestAction('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" title="Trigger a Background Life action for <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>">Trigger Action</button>
                                     <button onclick="requestReporting('<?php echo addslashes($marker['name']); ?>')" class="marker-action-btn" title="Send a letter from <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?>" style="background: #4488ff;">Send Letter</button>
                                     <button onclick="updateCoords('<?php echo addslashes($marker['name']); ?>')" title="Request coords update now" class="marker-action-btn-trans" style="border: 2px solid #00ff00; background: #44ff44;">📍</button>
                                 </div>
+                                <div class="marker-card-row-label">Rules</div>
                                 <div class="marker-card-toggles">
                                     <button type="button"
                                             class="marker-setting-button <?php echo $marker['bg_life_commands'] ? 'is-enabled' : 'is-disabled'; ?>"


### PR DESCRIPTION
## Summary

- Tag NPCs created through Background Life with `metadata.background_life_created`.
- Add a `Created NPCs` filter to the CHIM NPC profile page.
- Queue an immediate in-game notice before creation starts: `Creating <name>. Please keep the game running.`
- Rename the web Background Life one-shot controls to `Trigger Action` and `Send Letter`.
- Group one-shot controls under `Actions` and persistent settings under `Rules` on each NPC card.
- Keep the `Show Instructions` / `Hide Instructions` toggle fixed above the expandable instructions content.
- Add a focused JSON API for the Prisma CHIM NPC manager to list nearby/all NPC profiles, load editable details, and save safe profile patches.

## NPC Manager API

- Returns profile-aware NPC cards, race/profile portraits, effective runtime-toggle inheritance, normalized relationships, recent middle-term memory, and read-only game metadata.
- Saves only an explicit allow-list of NPC fields and merges existing `extended_data` instead of replacing unrelated metadata.
- Uses the existing relationship normalization/write guard, advisory locking, timeline stamping, profile auto-lock behavior, and NPC backup flow.
- Does not expose destructive history/reset/import/export or AI-generation operations.
- Uses existing tables and JSON fields; no database migration is required.

## Compatibility

- Existing NPCs are not inferred from unrelated Background Life flags, so only newly created NPCs receive the dedicated tag.
- Both PHP and Prisma creation flows use the shared creation service and receive the same notification/tag behavior.
- Existing relationship, metadata, and profile data are preserved by patch saves.

## Validation

- `php -l lib/background_life_npc_creation.php`
- `php -l ui/core/npc_master.php`
- `php -l ui/mapview.php`
- `php -l ui/api/chim_npc_manager.php`
- `git diff --check`
- Live list endpoint: HTTP 200, 58 NPCs available, profiles returned.
- Live detail endpoint: HTTP 200 for an existing NPC with profile, toggle, relationship, memory, and metadata data.
- Background Life and Created NPC filter pages remain HTTP 200 from the existing PR validation.
- Deployed API SHA-256 matches this feature worktree.

## Deployment

- Deployed the new API locally to `/var/www/html/HerikaServer` without changing the database.
- No NPC profile was mutated during automated validation; save behavior still requires manual in-game confirmation through the paired CHIM PR.

## Related

- Dwemer-Dynamics/CHIM#100