### PR TITLE
CHIM profile, Background Life, and NPC editor improvements

### DIFF
--- a/lib/background_life_requests.php
+++ b/lib/background_life_requests.php
@@ -138,6 +138,39 @@ function chimBglSetEnabled(NpcMaster $npcMaster, array $npc, bool $enabled): arr
     return $status;
 }
 
+// Resolve the CLI interpreter when PHP is running under Apache rather than CLI.
+function chimBglPhpCliBinary(): string
+{
+    $binaryName = DIRECTORY_SEPARATOR === '\\' ? 'php.exe' : 'php';
+    $candidates = [];
+
+    $phpBindir = rtrim((string)(PHP_BINDIR ?? ''), '/\\');
+    if ($phpBindir !== '') {
+        $candidates[] = $phpBindir . DIRECTORY_SEPARATOR . $binaryName;
+    }
+
+    $phpBinary = trim((string)(PHP_BINARY ?? ''));
+    if ($phpBinary !== '') {
+        $phpBinaryName = basename(str_replace('\\', '/', $phpBinary));
+        if (preg_match('/^php(?:[0-9.]+)?(?:\.exe)?$/i', $phpBinaryName) === 1) {
+            $candidates[] = $phpBinary;
+        }
+    }
+
+    if (DIRECTORY_SEPARATOR !== '\\') {
+        $candidates[] = '/usr/bin/php';
+        $candidates[] = '/usr/local/bin/php';
+    }
+
+    foreach (array_unique($candidates) as $candidate) {
+        if (is_file($candidate) && is_executable($candidate)) {
+            return $candidate;
+        }
+    }
+
+    return $binaryName;
+}
+
 // Invoke the same one-shot action and letter runners used by the existing map UI.
 function chimBglRunRequest(string $enginePath, array $npc, string $requestType): array
 {
@@ -171,7 +204,7 @@ function chimBglRunRequest(string $enginePath, array $npc, string $requestType):
         throw new RuntimeException('Background Life request processor is unavailable');
     }
 
-    $command = array_merge([PHP_BINARY, $scriptPath], $arguments);
+    $command = array_merge([chimBglPhpCliBinary(), $scriptPath], $arguments);
     $pipes = [];
     $process = proc_open(
         $command,
@@ -211,7 +244,7 @@ function chimBglRunTrackingRequest(string $enginePath, string $npcName = ''): ar
     }
 
     $arguments = trim($npcName) === '' ? ['The Narrator', 'TrackAll'] : [trim($npcName), 'Track'];
-    $command = array_merge([PHP_BINARY, $scriptPath], $arguments);
+    $command = array_merge([chimBglPhpCliBinary(), $scriptPath], $arguments);
     $pipes = [];
     $process = proc_open(
         $command,

--- a/ui/api/chim_npc_manager.php
+++ b/ui/api/chim_npc_manager.php
@@ -274,6 +274,47 @@ function chimNpcManagerFindNpc(array $input): array
     throw new InvalidArgumentException('NPC not found');
 }
 
+function chimNpcManagerAction(array $input): array
+{
+    $row = chimNpcManagerFindNpc($input);
+    $action = strtolower(trim((string)($input['action'] ?? '')));
+    $npcName = trim((string)($row['npc_name'] ?? 'NPC'));
+
+    if ($action === 'bgl_inception') {
+        $idea = trim((string)($input['idea'] ?? ''));
+        if ($idea === '') {
+            throw new InvalidArgumentException('Background Life inception requires a thought');
+        }
+        if (!(new NpcMaster())->updateExtendedKeysByName($npcName, ['bgl_inception' => $idea])) {
+            throw new RuntimeException('Background Life inception could not be saved');
+        }
+        return ['message' => "Background Life thought set for {$npcName}."];
+    }
+
+    if (!in_array($action, ['visit', 'teleport'], true)) {
+        throw new InvalidArgumentException('Unsupported NPC action');
+    }
+
+    $refid = strtoupper(preg_replace('/^0X/i', '', trim((string)($row['refid'] ?? ''))));
+    if (!preg_match('/^[0-9A-F]{1,8}$/', $refid)) {
+        throw new InvalidArgumentException("{$npcName} does not have a valid RefID");
+    }
+    $npcRefid = '0x' . str_pad($refid, 8, '0', STR_PAD_LEFT);
+
+    require_once LIB_PATH . DIRECTORY_SEPARATOR . 'scriptproxy_papyrus.php';
+    $commandBuilder = new SkyrimCommandBuilder();
+    $command = $action === 'visit'
+        ? $commandBuilder->ObjectReference->MoveTo(PLAYER_REFID, $npcRefid)
+        : $commandBuilder->ObjectReference->MoveTo($npcRefid, PLAYER_REFID);
+    $commandBuilder->send($command);
+
+    return [
+        'message' => $action === 'visit'
+            ? "Visit command sent for {$npcName}."
+            : "Teleport command sent for {$npcName}.",
+    ];
+}
+
 function chimNpcManagerList(array $profiles): array
 {
     $page = max(1, (int)($_GET['page'] ?? 1));
@@ -490,6 +531,13 @@ try {
         $input = json_decode((string)file_get_contents('php://input'), true);
         if (!is_array($input)) {
             throw new InvalidArgumentException('Invalid JSON request');
+        }
+        $operation = strtolower(trim((string)($input['operation'] ?? 'save')));
+        if ($operation === 'action') {
+            chimNpcManagerRespond(['success' => true, 'data' => chimNpcManagerAction($input)]);
+        }
+        if ($operation !== 'save') {
+            throw new InvalidArgumentException('Unsupported NPC manager operation');
         }
         chimNpcManagerRespond(['success' => true, 'data' => chimNpcManagerSave($input, $profiles)]);
     }

--- a/ui/core/core_profiles.php
+++ b/ui/core/core_profiles.php
@@ -566,9 +566,40 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["update"])) {
         }
         $_POST['metadata'] = json_encode($base, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE);
     }
-    $profiles->update($_POST["id"], $_POST);
+    $updated = $profiles->update($_POST["id"], $_POST);
+    $syncedProfiles = null;
+
+    if ($updated !== false && isset($_POST['sync_diary_prompt'])) {
+        $metadata = json_decode($_POST['metadata'] ?? '{}', true);
+        $diaryPrompt = is_array($metadata) ? trim((string)($metadata['DIARY_PROMPT'] ?? '')) : '';
+
+        if ($diaryPrompt === '') {
+            $updated = false;
+            $syncError = 'Enter a diary prompt before applying it to all profiles.';
+        } else {
+            $encodedPrompt = json_encode($diaryPrompt, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            $escapedPrompt = $GLOBALS['db']->escape($encodedPrompt);
+            $syncResult = $GLOBALS['db']->execQuery(
+                "UPDATE core_profiles
+                 SET metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{DIARY_PROMPT}', '{$escapedPrompt}'::jsonb, true)"
+            );
+
+            if ($syncResult === false) {
+                $updated = false;
+                $syncError = 'The profile was saved, but the diary prompt could not be applied to all profiles.';
+            } else {
+                $syncedProfiles = $profiles->getProfileCount();
+            }
+        }
+    }
+
     if ((isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest')) {
-        echo json_encode(['ok'=>true,'id'=>$_POST['id'] ?? null]);
+        echo json_encode([
+            'ok' => $updated !== false,
+            'id' => $_POST['id'] ?? null,
+            'synced_profiles' => $syncedProfiles,
+            'error' => $updated === false ? ($syncError ?? $profiles->getLastError()) : null,
+        ]);
         exit;
     } else {
         header("Location: core_profiles.php");
@@ -1964,6 +1995,14 @@ $ittById = $byId($ittRows);
         if (basicBtn){ basicBtn.addEventListener('click', function(ev){ try{ if (typeof showToast==='function') showToast('Saving...'); saveProfileAjax(ev, 'core_profile_form'); }catch(_e){} }); }
 const saveAllBtn = document.getElementById('btn_save_all');
         if (saveAllBtn){ saveAllBtn.addEventListener('click', function(ev){ try{ if (typeof showToast==='function') showToast('Saving all settings...'); saveProfileAjax(ev, 'core_profile_form'); }catch(_e){} }); }
+        const syncDiaryPromptBtn = document.getElementById('btn_sync_diary_prompt');
+        if (syncDiaryPromptBtn){ syncDiaryPromptBtn.addEventListener('click', function(ev){
+            if (!window.confirm('Apply this diary prompt to every profile? Other profile settings will not change.')) return;
+            try {
+                if (typeof showToast === 'function') showToast('Applying diary prompt...');
+                saveProfileAjax(ev, 'core_profile_form', true);
+            } catch(_e){}
+        }); }
         const backTopBtn = document.getElementById('btn_back_to_top');
         if (backTopBtn){ backTopBtn.addEventListener('click', function(){
             try { window.scrollTo({ top: 0, behavior: 'smooth' }); }
@@ -2231,7 +2270,7 @@ const saveAllBtn = document.getElementById('btn_save_all');
     })();
 
     // Save handler that keeps the user on the same profile and shows a toast
-    async function saveProfileAjax(ev, formId){
+    async function saveProfileAjax(ev, formId, syncDiaryPrompt){
         try {
             if (typeof consolidation === 'function') {
                 const ok = consolidation(ev, formId);
@@ -2264,6 +2303,7 @@ const saveAllBtn = document.getElementById('btn_save_all');
         } else {
             if (!fd.has('create')) fd.append('create','1');
         }
+        if (syncDiaryPrompt === true) fd.append('sync_diary_prompt', '1');
         try {
             const res = await fetch('core_profiles.php', { method:'POST', headers:{ 'X-Requested-With': 'XMLHttpRequest' }, body: fd });
             let json = {};
@@ -2276,7 +2316,10 @@ const saveAllBtn = document.getElementById('btn_save_all');
                     idEl.value = String(json.id);
                     try { history.replaceState({}, '', 'core_profiles.php?edit='+encodeURIComponent(String(json.id))); } catch(_){ }
                 }
-                if (typeof showToast === 'function') showToast('Profile saved');
+                if (typeof showToast === 'function') {
+                    const synced = Number(json.synced_profiles || 0);
+                    showToast(synced > 0 ? ('Diary prompt applied to ' + synced + ' profiles') : 'Profile saved');
+                }
             } else {
                 if (typeof showToast === 'function') showToast('Save failed: ' + (json && json.error ? json.error : 'Unknown error'), true);
             }

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -3633,8 +3633,12 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
     gap:8px;
     flex-wrap:wrap;
 }
+.pagination.npc-toolbar .npc-toolbar-main {
+    align-items:flex-start;
+    flex-wrap:nowrap;
+}
 .pagination.npc-toolbar .npc-toolbar-actions {
-    flex:1 1 auto;
+    flex:1 1 0;
     min-width:0;
     flex-wrap:wrap;
 }
@@ -3828,6 +3832,9 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
     }
 }
 @media (max-width: 780px) {
+    .pagination.npc-toolbar .npc-toolbar-main {
+        flex-wrap:wrap;
+    }
     .pagination.npc-toolbar .npc-toolbar-tools,
     .pagination.npc-toolbar .npc-toolbar-actions,
     .pagination.npc-toolbar .npc-toolbar-pager,

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -287,9 +287,6 @@ h1.api-title {
     padding: 12px;
 }
 
-#npc_modal_dev_toggle {
-    zoom:0.75;
-}
 </style>
 
 <main>
@@ -2093,11 +2090,12 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="bios">📖 Roleplay</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="relationships">🤝 Relationships</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="info">🛠️ Info</button>
+    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="actions">⚡ Actions</button>
 </div>
 <style>
 .npc-editor-tabs {
     display:grid;
-    grid-template-columns:repeat(4, minmax(0, 1fr));
+    grid-template-columns:repeat(5, minmax(0, 1fr));
     gap:8px;
     margin-bottom:14px;
     padding:8px;
@@ -2129,7 +2127,30 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
 .npc-editor-panels { display:block; }
 .npc-editor-panel[hidden] { display:none !important; }
 .npc-editor-panel[data-npc-editor-panel="bios"] { grid-template-columns:minmax(0, 1fr); }
+.npc-editor-panel[data-npc-editor-panel="actions"] { grid-template-columns:minmax(0, 1fr); }
+.npc-editor-action-note { margin:0; color:#aaa; font-size:0.86rem; }
+.npc-editor-action-list { display:grid; gap:10px; }
+.npc-editor-action-card {
+    display:grid;
+    grid-template-columns:minmax(0, 1fr) auto;
+    align-items:center;
+    gap:14px;
+    padding:12px;
+    border:1px solid #444;
+    border-radius:7px;
+    background:#282828;
+}
+.npc-editor-action-card h3 { margin:0 0 4px; color:#f2bd7f; font-size:1rem; }
+.npc-editor-action-card p { margin:0; color:#aaa; font-size:0.82rem; }
+.npc-editor-action-card textarea { min-height:84px; resize:vertical; }
+.npc-editor-action-card.is-inception { grid-template-columns:minmax(220px, 0.8fr) minmax(280px, 1.2fr) auto; }
+.npc-editor-action-status { min-height:1.2rem; margin:0; color:#aaa; font-size:0.82rem; }
+.npc-editor-action-status.is-error { color:#ef8f96; }
 @media (max-width:700px) { .npc-editor-tabs { grid-template-columns:repeat(2, minmax(0, 1fr)); } }
+@media (max-width:850px) {
+    .npc-editor-action-card,
+    .npc-editor-action-card.is-inception { grid-template-columns:minmax(0, 1fr); }
+}
 </style>
 <script>
 (function(){
@@ -2137,7 +2158,8 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
         general: new Set(['npc_name','profile_id','lock_profile','npc_favorite','gender','race','base','refid','oghma_knowledge_tags','worldknowledge_tags','world_knowledge_tags','voiceid','faction','dynamic_profile','middle_term_enabled','individual_memory_enabled','auto_diary_enabled','auto_diary_wait_enabled','salutation_after_a_while','prompt_head']),
         bios: new Set(['core','npc_static_bio','appearance','personality','occupation','skills','speechstyle','goals']),
         relationships: new Set(['relationships','relationships_jsonb','middle_term_latest']),
-        info: new Set(['emote_moods','metadata','extended_data'])
+        info: new Set(['emote_moods','metadata','extended_data']),
+        actions: new Set()
     };
 
     function initNpcEditorTabs(){
@@ -2149,7 +2171,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
             tablist.dataset.initialized = '1';
 
             const panels = {};
-            ['general','bios','relationships','info'].forEach(function(section){
+            ['general','bios','relationships','info','actions'].forEach(function(section){
                 const panel = document.createElement('div');
                 panel.className = 'npc-editor-panel form-grid';
                 panel.dataset.npcEditorPanel = section;
@@ -2206,6 +2228,64 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
             grid.classList.remove('form-grid');
             grid.classList.add('npc-editor-panels');
             Object.values(panels).forEach(function(panel){ grid.appendChild(panel); });
+
+            const targetId = <?= (int)($editItem['id'] ?? 0) ?>;
+            panels.actions.innerHTML = `
+                <p class="npc-editor-action-note">The game must be running and unpaused for Visit and Teleport.</p>
+                <div class="npc-editor-action-list">
+                    <article class="npc-editor-action-card">
+                        <div><h3>Visit</h3><p>Move the player to this NPC's current position.</p></div>
+                        <button type="button" class="btn-cancel" data-npc-action="visit">Visit</button>
+                    </article>
+                    <article class="npc-editor-action-card">
+                        <div><h3>Teleport</h3><p>Move this NPC to the player's current position.</p></div>
+                        <button type="button" class="btn-cancel" data-npc-action="teleport">Teleport</button>
+                    </article>
+                    <article class="npc-editor-action-card is-inception">
+                        <div><h3>Background Life Inception</h3><p>Give this NPC a one-time thought for their next Background Life decision.</p></div>
+                        <textarea data-npc-inception-idea placeholder="Enter the thought to influence their next decision"></textarea>
+                        <button type="button" class="btn-cancel" data-npc-action="bgl_inception">Set Thought</button>
+                    </article>
+                </div>
+                <p class="npc-editor-action-status" data-npc-action-status role="status" aria-live="polite"></p>`;
+
+            const actionStatus = panels.actions.querySelector('[data-npc-action-status]');
+            panels.actions.querySelectorAll('[data-npc-action]').forEach(function(button){
+                button.disabled = targetId <= 0;
+                button.addEventListener('click', async function(){
+                    const action = button.dataset.npcAction;
+                    const ideaField = panels.actions.querySelector('[data-npc-inception-idea]');
+                    const idea = action === 'bgl_inception' ? ideaField.value.trim() : '';
+                    if (action === 'bgl_inception' && !idea) {
+                        actionStatus.textContent = 'Enter a thought before setting Background Life inception.';
+                        actionStatus.classList.add('is-error');
+                        return;
+                    }
+
+                    button.disabled = true;
+                    actionStatus.textContent = 'Sending action...';
+                    actionStatus.classList.remove('is-error');
+                    try {
+                        const response = await fetch('../api/chim_npc_manager.php', {
+                            method: 'POST',
+                            headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({operation:'action', action:action, id:targetId, idea:idea})
+                        });
+                        const payload = await response.json();
+                        if (!response.ok || !payload || !payload.success) {
+                            throw new Error((payload && payload.error) || ('HTTP ' + response.status));
+                        }
+                        actionStatus.textContent = (payload.data && payload.data.message) || 'Action sent.';
+                        if (action === 'bgl_inception') ideaField.value = '';
+                    } catch (error) {
+                        actionStatus.textContent = 'Action failed: ' + (error.message || error);
+                        actionStatus.classList.add('is-error');
+                    } finally {
+                        button.disabled = targetId <= 0;
+                    }
+                });
+            });
+            if (targetId <= 0) actionStatus.textContent = 'Save this NPC before using actions.';
 
             const storageKey = tablist.dataset.storageKey || 'npc-editor-tab';
             function activate(section){
@@ -3927,14 +4007,6 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
         <button id="npc_modal_regen" class="btn-cancel" title="Will use AI to regenerate this profile. Intended for custom NPCs without biography descriptions.">AI Generate Profile</button>
         <button id="npc_modal_close" class="btn-cancel">Close</button>
       </div>
-    </div>
-    <div class="modal-header-dev">
-        <span style="cursor:pointer" id="" onclick="document.getElementById('npc_modal_dev_toggle').style.display = (document.getElementById('npc_modal_dev_toggle').style.display === 'none' ? 'block' : 'none')">🐞</span>
-        <div id="npc_modal_dev_toggle" class="modal-dev-actions" style="font-size:8px;zoom:0.75px;display:none">
-            <button id="npc_modal_dev_visit" title="Teleport player to NPC">Visit</button>
-            <button id="npc_modal_dev_teleport" title="Teleport NPC to player">Teleport</button>
-            <button id="npc_modal_dev_bgl_inception" title="BgL Inception. Puts an ephemeral thought on BgL NPC">BgL Inception</button>
-        </div>
     </div>
     <div class="modal-body">
       <div id="npc_modal_tabs" style="display:flex; gap:8px; padding:8px; border-bottom:1px solid #4a4a4a; background:#2a2a2a; position:sticky; top:0; z-index:2;">
@@ -5817,81 +5889,6 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
     });
   }
   
-  const visitBtn = document.getElementById('npc_modal_dev_visit');
-  if (visitBtn) {
-    visitBtn.addEventListener('click', async function(){
-      
-        const formData = new FormData();
-        const id = window.CURRENT_NPC_ID;
-        if (!id) { alert('No NPC selected. Save the NPC first before importing.'); return; }
-
-        formData.append('dev_visit', '1');
-        formData.append('target_id', id);
-        
-        const res = await fetch('npc_master.php', { method: 'POST', body: formData });
-        const result = await res.json();
-        
-        if (result.ok) {
-            alert(result.message || 'Dev visit triggered successfully');
-        
-        } else {
-            alert('Error: ' + (result.error || 'Dev visit failed'));
-        }
-            
-    });
-  }
-
-  const bglInceptionBtn = document.getElementById('npc_modal_dev_bgl_inception');
-  if (bglInceptionBtn) {
-    bglInceptionBtn.addEventListener('click', async function(){
-      
-        const formData = new FormData();
-        const id = window.CURRENT_NPC_ID;
-        const idea=prompt('Enter the idea for BgL Inception:');
-
-        formData.append('bgl_inception', '1');
-        formData.append('idea', idea);
-        formData.append('target_id', id);
-        
-        const res = await fetch('npc_master.php', { method: 'POST', body: formData });
-        const result = await res.json();
-        
-        if (result.ok) {
-            alert(result.message || 'BgL Inception triggered successfully');
-            document.location.reload();
-        } else {
-            alert('Error: ' + (result.error || 'BgL Inception failed'));
-        }
-            
-    });
-  }
-
-  
-  const teleportBtn = document.getElementById('npc_modal_dev_teleport');
-  if (teleportBtn) {
-    teleportBtn.addEventListener('click', async function(){
-      
-        const formData = new FormData();
-        const id = window.CURRENT_NPC_ID;
-        if (!id) { alert('No NPC selected. Save the NPC first before importing.'); return; }
-
-        formData.append('dev_teleport', '1');
-        formData.append('target_id', id);
-        
-        const res = await fetch('npc_master.php', { method: 'POST', body: formData });
-        const result = await res.json();
-        
-        if (result.ok) {
-            alert(result.message || 'Dev teleport triggered successfully');
-        
-        } else {
-            alert('Error: ' + (result.error || 'Dev teleport failed'));
-        }
-            
-    });
-  }
-  
-
   // Import Bio to current NPC button in modal header (only for existing NPCs)
   const importToBtn = document.getElementById('npc_modal_import_to');
   if (importToBtn) {

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -3634,17 +3634,19 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
     flex-wrap:wrap;
 }
 .pagination.npc-toolbar .npc-toolbar-actions {
-    flex:1 1 1192px;
-    min-width:1192px;
-    flex-wrap:nowrap;
+    flex:1 1 auto;
+    min-width:0;
+    flex-wrap:wrap;
 }
 .pagination.npc-toolbar .npc-toolbar-tools {
-    flex:0 0 320px;
-    width:320px;
-    min-width:320px;
-    flex-direction:column;
-    align-items:stretch;
-    justify-content:flex-start;
+    flex:0 0 auto;
+    width:auto;
+    min-width:0;
+    margin-left:auto;
+    flex-direction:row;
+    align-items:center;
+    justify-content:flex-end;
+    flex-wrap:nowrap;
 }
 .pagination.npc-toolbar .npc-auto-lock-profile {
     display:flex;
@@ -3756,16 +3758,16 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
     font-size:13px;
 }
 .pagination.npc-toolbar .npc-toolbar-tools input[type="text"] {
-    flex:0 0 auto;
-    width:100%;
+    flex:0 0 220px;
+    width:220px;
     min-width:0;
-    max-width:none;
+    max-width:220px;
 }
 .pagination.npc-toolbar .npc-toolbar-tools select {
-    flex:0 0 auto;
-    width:100%;
+    flex:0 0 180px;
+    width:180px;
     min-width:0;
-    max-width:none;
+    max-width:180px;
 }
 .pagination.npc-toolbar .npc-page-link {
     display:inline-flex;
@@ -3845,6 +3847,9 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
         flex:1 1 100%;
         width:100%;
         min-width:0;
+        margin-left:0;
+        flex-wrap:wrap;
+        justify-content:flex-start;
     }
     .pagination.npc-toolbar .npc-toolbar-letter-row {
         align-items:flex-start;

--- a/ui/core/tmpl/metadata_json_editor.php
+++ b/ui/core/tmpl/metadata_json_editor.php
@@ -28,7 +28,7 @@ $localSchemaOverrides = [
     ],
     'DIARY_PROMPT' => [
         'type' => 'longstring',
-        'description' => 'Default profile only! Instructions for generating diary entries. You can adjust max tokens by changing MAX_TOKENS_MEMORY for the DIARY connector you are using.',
+        'description' => 'Instructions for generating diary entries for this profile. You can adjust max tokens by changing MAX_TOKENS_MEMORY for the DIARY connector you are using.',
     ],
     'LANG_LLM_XTTS' => [
         'type' => 'boolean',
@@ -245,6 +245,9 @@ function renderMetaSettingRow(string $key, array $schemaEntry, $value): string {
         $html .= '</label>';
     } else {
         $html .= renderMetaInput($key, $schemaEntry, $value, true);
+        if ($key === 'DIARY_PROMPT') {
+            $html .= '<button type="button" id="btn_sync_diary_prompt" class="btn-primary" style="margin-top:8px;">Apply to all profiles</button>';
+        }
     }
     $html .= '</div>';
     $html .= '</div>';


### PR DESCRIPTION
## Summary

This draft collects the current CHIM server-side work into one review surface.

### Profile diary prompt synchronization
- add an `Apply to all profiles` control beside the selected profile diary prompt
- require confirmation before the bulk update
- save the selected profile, then update only `DIARY_PROMPT` in every profile metadata record
- preserve unrelated profile settings and report how many profiles were updated

Discord source: [Open Discord thread](https://discord.com/channels/1109612896482246826/1533106635957080174/1533106635957080174)

### Background Life action and letter repair
- resolve a usable PHP CLI executable when requests run under Apache
- use the resolved executable for action, letter, and tracking workers
- preserve the existing Background Life API and Prisma payloads

The Prisma Trigger Action and Send Letter requests reached HerikaServer, but Apache exposed an unusable `PHP_BINARY`. `proc_open()` therefore failed before either worker ran.

### NPC editor actions
- add an Actions tab to the PHP NPC editor
- move Visit, Teleport, and Background Life Inception out of the hidden developer controls
- add short descriptions and inline status feedback instead of alerts and prompt dialogs
- expose the same action endpoint to the Prisma NPC editor
- use the existing Skyrim command builder for Visit and Teleport
- store Background Life Inception as the NPC one-time `bgl_inception` thought

### NPC toolbar layout
- restore Search and All Profiles to the upper-right side of the CHIM NPC toolbar
- keep both filters side-by-side while action buttons wrap within the left side
- preserve the existing stacked layout on narrow screens

## Compatibility
- no schema or migration changes
- no binary or generated artifacts
- existing multipart action handlers remain available for compatibility
- paired Prisma UI work: [Dwemer-Dynamics/CHIM#101](https://github.com/Dwemer-Dynamics/CHIM/pull/101)

## Validation
- `php -l ui/api/chim_npc_manager.php`
- `php -l ui/core/npc_master.php`
- `php -l ui/core/core_profiles.php`
- `php -l ui/core/tmpl/metadata_json_editor.php`
- `php -l lib/background_life_requests.php`
- `git diff --check origin/unstable...HEAD`
- browser verification confirmed the Actions tab is unique, opens, and contains the three controls; Close is present
- live NPC list and edit endpoints returned HTTP 200
- empty Background Life Inception returned HTTP 400 without changing NPC state
- PostgreSQL rollback probe confirmed diary prompts synchronize without changing unrelated metadata
- `/usr/bin/php` launched through `proc_open()` with exit code `0`
- browser verification at 1280px confirmed Search and All Profiles share the upper-right row
- exact changed server files deployed to local HerikaServer and matched source SHA-256
- no new test files added

## Testing limits
- no real Visit or Teleport command was executed automatically
- no real Background Life action or letter was triggered automatically to avoid changing save/database state or consuming LLM calls
- manual in-game retesting remains required