### PR TITLE
Fix Background Life action and letter requests

### DIFF
--- a/lib/background_life_requests.php
+++ b/lib/background_life_requests.php
@@ -138,6 +138,39 @@ function chimBglSetEnabled(NpcMaster $npcMaster, array $npc, bool $enabled): arr
     return $status;
 }
 
+// Resolve the CLI interpreter when PHP is running under Apache rather than CLI.
+function chimBglPhpCliBinary(): string
+{
+    $binaryName = DIRECTORY_SEPARATOR === '\\' ? 'php.exe' : 'php';
+    $candidates = [];
+
+    $phpBindir = rtrim((string)(PHP_BINDIR ?? ''), '/\\');
+    if ($phpBindir !== '') {
+        $candidates[] = $phpBindir . DIRECTORY_SEPARATOR . $binaryName;
+    }
+
+    $phpBinary = trim((string)(PHP_BINARY ?? ''));
+    if ($phpBinary !== '') {
+        $phpBinaryName = basename(str_replace('\\', '/', $phpBinary));
+        if (preg_match('/^php(?:[0-9.]+)?(?:\.exe)?$/i', $phpBinaryName) === 1) {
+            $candidates[] = $phpBinary;
+        }
+    }
+
+    if (DIRECTORY_SEPARATOR !== '\\') {
+        $candidates[] = '/usr/bin/php';
+        $candidates[] = '/usr/local/bin/php';
+    }
+
+    foreach (array_unique($candidates) as $candidate) {
+        if (is_file($candidate) && is_executable($candidate)) {
+            return $candidate;
+        }
+    }
+
+    return $binaryName;
+}
+
 // Invoke the same one-shot action and letter runners used by the existing map UI.
 function chimBglRunRequest(string $enginePath, array $npc, string $requestType): array
 {
@@ -171,7 +204,7 @@ function chimBglRunRequest(string $enginePath, array $npc, string $requestType):
         throw new RuntimeException('Background Life request processor is unavailable');
     }
 
-    $command = array_merge([PHP_BINARY, $scriptPath], $arguments);
+    $command = array_merge([chimBglPhpCliBinary(), $scriptPath], $arguments);
     $pipes = [];
     $process = proc_open(
         $command,
@@ -211,7 +244,7 @@ function chimBglRunTrackingRequest(string $enginePath, string $npcName = ''): ar
     }
 
     $arguments = trim($npcName) === '' ? ['The Narrator', 'TrackAll'] : [trim($npcName), 'Track'];
-    $command = array_merge([PHP_BINARY, $scriptPath], $arguments);
+    $command = array_merge([chimBglPhpCliBinary(), $scriptPath], $arguments);
     $pipes = [];
     $process = proc_open(
         $command,


### PR DESCRIPTION
## Summary
- resolve a usable PHP CLI executable when Background Life requests run under Apache
- use the resolved executable for action, letter, and tracking workers
- preserve the existing Background Life request API and Prisma payloads

## Problem
Prisma `Trigger Action` and `Send Letter` requests reached the server, but Apache exposed an unusable `PHP_BINARY`. The worker launch then failed in `proc_open()` with `No such file or directory`, so neither request could run.

## Validation
- `php -l lib/background_life_requests.php`
- `git diff --check origin/unstable...HEAD`
- CHIM unstable push guard against the exact outgoing range: safe, 37 changed lines in one file
- deployed the exact rebased file to `/var/www/html/HerikaServer/lib/background_life_requests.php`; source and runtime SHA-256 match
- verified `/usr/bin/php` launches through `proc_open()` and returns exit code `0`
- verified the API still rejects a missing NPC with HTTP 404 before starting a worker

## Testing limit
No real NPC action or letter was triggered during automated validation to avoid mutating game/database state or consuming an LLM request. Manual in-game retesting of both buttons is still required.