### PR TITLE
Add per-setting profile copy controls

### DIFF
--- a/ui/core/core_profiles.php
+++ b/ui/core/core_profiles.php
@@ -323,6 +323,20 @@ h1.api-title {
 .setting-control select,
 .setting-control textarea { width:100%; }
 .setting-control textarea { min-height: 88px; }
+.profile-setting-sync-btn {
+    display:block;
+    width:max-content;
+    margin:5px 0 0 auto;
+    padding:4px 8px;
+    border:1px solid #4b4b4b;
+    border-radius:5px;
+    background:#303030;
+    color:#f3f3f3;
+    font-size:11px;
+    line-height:1.2;
+    cursor:pointer;
+}
+.profile-setting-sync-btn:hover { border-color:#f27c11; background:#383838; }
 .range-pair { display:flex; align-items:center; gap:8px; }
 .range-pair input[type="range"] { flex:1; accent-color: rgb(242,124,17); }
 .range-pair input[type="number"] { width:86px; min-width:86px; text-align:right; }
@@ -504,6 +518,15 @@ $__rpgOptions = array_values(array_filter($__rpgOptionsRaw, function($v){ return
 $__dynOptions = is_array($__confSchema['DYNAMIC_PROFILE_FIELDS']['values'] ?? null) ? $__confSchema['DYNAMIC_PROFILE_FIELDS']['values'] : [];
 $__dynHelp = (string)($__confSchema['DYNAMIC_PROFILE_FIELDS']['description'] ?? '');
 
+// Only profile metadata fields rendered by the visual editor may be copied in bulk.
+$profileSyncableMetadataKeys = [
+    'RECHAT_H', 'RECHAT_P', 'CORE_LANG', 'BORED_EVENT',
+    'DIARY_PROMPT', 'LANG_LLM_XTTS', 'QUEST_COMMENT', 'DIARY_COOLDOWN', 'COMBAT_BARK_COOLDOWN',
+    'CONTEXT_HISTORY', 'MAX_WORDS_LIMIT',
+    'QUEST_COMMENT_CHANCE', 'RECHAT_ALLOW_ACTIONS', 'CONTEXT_HISTORY_DIARY', 'BORED_EVENT_SERVERSIDE',
+    'CONTEXT_HISTORY_DYNAMIC_PROFILE',
+];
+
 // Handle Create
 if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["create"])) {
     if ((isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest')) {
@@ -546,6 +569,10 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["update"])) {
         try { while (ob_get_level() > 0) { ob_end_clean(); } } catch (Throwable $e) {}
         header('Content-Type: application/json');
     }
+    $requestedSyncSetting = $_POST['sync_profile_setting'] ?? (isset($_POST['sync_diary_prompt']) ? 'DIARY_PROMPT' : null);
+    $syncSettingKey = is_string($requestedSyncSetting) ? trim($requestedSyncSetting) : null;
+    $syncRequestInvalid = $syncSettingKey !== null && !in_array($syncSettingKey, $profileSyncableMetadataKeys, true);
+
     // Server-side merge of visual metadata with JSON editor content
     if (isset($_POST['meta_vis'])) {
         $base = [];
@@ -566,30 +593,33 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["update"])) {
         }
         $_POST['metadata'] = json_encode($base, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE);
     }
-    $updated = $profiles->update($_POST["id"], $_POST);
+    $updated = $syncRequestInvalid ? false : $profiles->update($_POST["id"], $_POST);
     $syncedProfiles = null;
+    $syncError = $syncRequestInvalid ? 'This profile setting cannot be copied to all profiles.' : null;
 
-    if ($updated !== false && isset($_POST['sync_diary_prompt'])) {
+    if ($updated !== false && $syncSettingKey !== null) {
         $metadata = json_decode($_POST['metadata'] ?? '{}', true);
-        $diaryPrompt = is_array($metadata) ? trim((string)($metadata['DIARY_PROMPT'] ?? '')) : '';
+        $metadata = is_array($metadata) ? $metadata : [];
 
-        if ($diaryPrompt === '') {
-            $updated = false;
-            $syncError = 'Enter a diary prompt before applying it to all profiles.';
-        } else {
-            $encodedPrompt = json_encode($diaryPrompt, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-            $escapedPrompt = $GLOBALS['db']->escape($encodedPrompt);
+        if (array_key_exists($syncSettingKey, $metadata)) {
+            $encodedValue = json_encode($metadata[$syncSettingKey], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            $escapedValue = $GLOBALS['db']->escape($encodedValue);
             $syncResult = $GLOBALS['db']->execQuery(
                 "UPDATE core_profiles
-                 SET metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{DIARY_PROMPT}', '{$escapedPrompt}'::jsonb, true)"
+                 SET metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{{$syncSettingKey}}', '{$escapedValue}'::jsonb, true)"
             );
+        } else {
+            $syncResult = $GLOBALS['db']->execQuery(
+                "UPDATE core_profiles
+                 SET metadata = COALESCE(metadata, '{}'::jsonb) - '{$syncSettingKey}'"
+            );
+        }
 
-            if ($syncResult === false) {
-                $updated = false;
-                $syncError = 'The profile was saved, but the diary prompt could not be applied to all profiles.';
-            } else {
-                $syncedProfiles = $profiles->getProfileCount();
-            }
+        if ($syncResult === false) {
+            $updated = false;
+            $syncError = 'The profile was saved, but the selected setting could not be copied to all profiles.';
+        } else {
+            $syncedProfiles = $profiles->getProfileCount();
         }
     }
 
@@ -598,6 +628,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["update"])) {
             'ok' => $updated !== false,
             'id' => $_POST['id'] ?? null,
             'synced_profiles' => $syncedProfiles,
+            'synced_setting' => $syncSettingKey,
             'error' => $updated === false ? ($syncError ?? $profiles->getLastError()) : null,
         ]);
         exit;
@@ -1995,14 +2026,18 @@ $ittById = $byId($ittRows);
         if (basicBtn){ basicBtn.addEventListener('click', function(ev){ try{ if (typeof showToast==='function') showToast('Saving...'); saveProfileAjax(ev, 'core_profile_form'); }catch(_e){} }); }
 const saveAllBtn = document.getElementById('btn_save_all');
         if (saveAllBtn){ saveAllBtn.addEventListener('click', function(ev){ try{ if (typeof showToast==='function') showToast('Saving all settings...'); saveProfileAjax(ev, 'core_profile_form'); }catch(_e){} }); }
-        const syncDiaryPromptBtn = document.getElementById('btn_sync_diary_prompt');
-        if (syncDiaryPromptBtn){ syncDiaryPromptBtn.addEventListener('click', function(ev){
-            if (!window.confirm('Apply this diary prompt to every profile? Other profile settings will not change.')) return;
-            try {
-                if (typeof showToast === 'function') showToast('Applying diary prompt...');
-                saveProfileAjax(ev, 'core_profile_form', true);
-            } catch(_e){}
-        }); }
+        document.querySelectorAll('.profile-setting-sync-btn').forEach(btn => {
+            btn.addEventListener('click', function(ev){
+                const settingKey = btn.dataset.settingKey || '';
+                const settingLabel = btn.dataset.settingLabel || 'this setting';
+                if (!settingKey) return;
+                if (!window.confirm('Copy "' + settingLabel + '" from this profile to all profiles? Other profile settings will not change.')) return;
+                try {
+                    if (typeof showToast === 'function') showToast('Copying ' + settingLabel + '...');
+                    saveProfileAjax(ev, 'core_profile_form', settingKey, settingLabel);
+                } catch(_e){}
+            });
+        });
         const backTopBtn = document.getElementById('btn_back_to_top');
         if (backTopBtn){ backTopBtn.addEventListener('click', function(){
             try { window.scrollTo({ top: 0, behavior: 'smooth' }); }
@@ -2270,7 +2305,7 @@ const saveAllBtn = document.getElementById('btn_save_all');
     })();
 
     // Save handler that keeps the user on the same profile and shows a toast
-    async function saveProfileAjax(ev, formId, syncDiaryPrompt){
+    async function saveProfileAjax(ev, formId, syncSettingKey, syncSettingLabel){
         try {
             if (typeof consolidation === 'function') {
                 const ok = consolidation(ev, formId);
@@ -2303,7 +2338,9 @@ const saveAllBtn = document.getElementById('btn_save_all');
         } else {
             if (!fd.has('create')) fd.append('create','1');
         }
-        if (syncDiaryPrompt === true) fd.append('sync_diary_prompt', '1');
+        if (typeof syncSettingKey === 'string' && syncSettingKey !== '') {
+            fd.append('sync_profile_setting', syncSettingKey);
+        }
         try {
             const res = await fetch('core_profiles.php', { method:'POST', headers:{ 'X-Requested-With': 'XMLHttpRequest' }, body: fd });
             let json = {};
@@ -2318,7 +2355,8 @@ const saveAllBtn = document.getElementById('btn_save_all');
                 }
                 if (typeof showToast === 'function') {
                     const synced = Number(json.synced_profiles || 0);
-                    showToast(synced > 0 ? ('Diary prompt applied to ' + synced + ' profiles') : 'Profile saved');
+                    const label = syncSettingLabel || 'Setting';
+                    showToast(synced > 0 ? (label + ' copied to ' + synced + ' profiles') : 'Profile saved');
                 }
             } else {
                 if (typeof showToast === 'function') showToast('Save failed: ' + (json && json.error ? json.error : 'Unknown error'), true);

--- a/ui/core/core_profiles.php
+++ b/ui/core/core_profiles.php
@@ -323,20 +323,22 @@ h1.api-title {
 .setting-control select,
 .setting-control textarea { width:100%; }
 .setting-control textarea { min-height: 88px; }
-.profile-setting-sync-btn {
-    display:block;
-    width:max-content;
-    margin:5px 0 0 auto;
-    padding:4px 8px;
-    border:1px solid #4b4b4b;
-    border-radius:5px;
-    background:#303030;
-    color:#f3f3f3;
-    font-size:11px;
-    line-height:1.2;
+body .setting-key .profile-setting-sync-btn {
+    display:inline-flex;
+    flex:0 0 auto;
+    min-height:18px !important;
+    margin:0 !important;
+    padding:2px 5px !important;
+    border:1px solid #4b4b4b !important;
+    border-radius:4px !important;
+    background:#303030 !important;
+    color:#f3f3f3 !important;
+    font-size:9px !important;
+    font-weight:600;
+    line-height:1.1;
     cursor:pointer;
 }
-.profile-setting-sync-btn:hover { border-color:#f27c11; background:#383838; }
+body .setting-key .profile-setting-sync-btn:hover { border-color:#f27c11 !important; background:#383838 !important; }
 .range-pair { display:flex; align-items:center; gap:8px; }
 .range-pair input[type="range"] { flex:1; accent-color: rgb(242,124,17); }
 .range-pair input[type="number"] { width:86px; min-width:86px; text-align:right; }

--- a/ui/core/tmpl/metadata_json_editor.php
+++ b/ui/core/tmpl/metadata_json_editor.php
@@ -78,13 +78,15 @@ $localSchemaOverrides = [
 ];
 
 // Visual keys to expose (can be expanded easily)
-$visualKeys = [
-  "RECHAT_H","RECHAT_P","CORE_LANG","BORED_EVENT",
-  "DIARY_PROMPT","LANG_LLM_XTTS","QUEST_COMMENT","DIARY_COOLDOWN","COMBAT_BARK_COOLDOWN",
-  "CONTEXT_HISTORY","MAX_WORDS_LIMIT",
-  "QUEST_COMMENT_CHANCE","RECHAT_ALLOW_ACTIONS","CONTEXT_HISTORY_DIARY","BORED_EVENT_SERVERSIDE",
-  "CONTEXT_HISTORY_DYNAMIC_PROFILE"
-];
+$visualKeys = isset($profileSyncableMetadataKeys) && is_array($profileSyncableMetadataKeys)
+    ? $profileSyncableMetadataKeys
+    : [
+        "RECHAT_H","RECHAT_P","CORE_LANG","BORED_EVENT",
+        "DIARY_PROMPT","LANG_LLM_XTTS","QUEST_COMMENT","DIARY_COOLDOWN","COMBAT_BARK_COOLDOWN",
+        "CONTEXT_HISTORY","MAX_WORDS_LIMIT",
+        "QUEST_COMMENT_CHANCE","RECHAT_ALLOW_ACTIONS","CONTEXT_HISTORY_DIARY","BORED_EVENT_SERVERSIDE",
+        "CONTEXT_HISTORY_DYNAMIC_PROFILE"
+    ];
 
 // Organize visual keys into categories for display
 $visualGroups = [
@@ -245,10 +247,8 @@ function renderMetaSettingRow(string $key, array $schemaEntry, $value): string {
         $html .= '</label>';
     } else {
         $html .= renderMetaInput($key, $schemaEntry, $value, true);
-        if ($key === 'DIARY_PROMPT') {
-            $html .= '<button type="button" id="btn_sync_diary_prompt" class="btn-primary" style="margin-top:8px;">Apply to all profiles</button>';
-        }
     }
+    $html .= '<button type="button" class="profile-setting-sync-btn" data-setting-key="'.$safeKey.'" data-setting-label="'.$label.'" title="Copy this setting to every profile">Copy to all</button>';
     $html .= '</div>';
     $html .= '</div>';
     return $html;

--- a/ui/core/tmpl/metadata_json_editor.php
+++ b/ui/core/tmpl/metadata_json_editor.php
@@ -232,7 +232,8 @@ function renderMetaSettingRow(string $key, array $schemaEntry, $value): string {
     $safeKey = htmlspecialchars($key);
     $html = '<div class="setting-row">';
     $html .= '<div>';
-    $html .= '<div class="setting-key"><span class="setting-icon">'.$icon.'</span><span>'.$label.'</span></div>';
+    $html .= '<div class="setting-key"><span class="setting-icon">'.$icon.'</span><span>'.$label.'</span>';
+    $html .= '<button type="button" class="profile-setting-sync-btn" data-setting-key="'.$safeKey.'" data-setting-label="'.$label.'" title="Copy this setting to every profile">Copy to all</button></div>';
     if (!empty($desc)) {
         $html .= '<div class="setting-desc">'.$desc.'</div>';
     }
@@ -248,7 +249,6 @@ function renderMetaSettingRow(string $key, array $schemaEntry, $value): string {
     } else {
         $html .= renderMetaInput($key, $schemaEntry, $value, true);
     }
-    $html .= '<button type="button" class="profile-setting-sync-btn" data-setting-key="'.$safeKey.'" data-setting-label="'.$label.'" title="Copy this setting to every profile">Copy to all</button>';
     $html .= '</div>';
     $html .= '</div>';
     return $html;


### PR DESCRIPTION
﻿## Summary
- add a compact inline **Copy to all** control beside each visual profile setting title
- require field-specific confirmation before bulk updates
- preserve unrelated profile metadata and allow clearing an override across profiles
- reject non-allowlisted bulk-copy requests

## Validation
- `php -l ui/core/core_profiles.php`
- `php -l ui/core/tmpl/metadata_json_editor.php`
- `git diff --check`
- local WSL deploy: source/runtime SHA-256 matched; Profiles UI returned HTTP 200
- rendered all 16 controls inline at 18px height with no browser console warnings or errors
- runtime endpoint: valid diary copy succeeded; invalid keys were rejected; unrelated metadata remained unchanged
- rolled-back PostgreSQL probe verified clearing one override preserves other metadata

## Deployment
- deployed server-only to `/var/www/html/HerikaServer`
- no database migration required

## Limits
- no in-game testing was applicable
