### PR TITLE
Add playable diary audio

### DIFF
--- a/ui/api/chim_diaries.php
+++ b/ui/api/chim_diaries.php
@@ -32,6 +32,18 @@ $mode = isset($_GET['list']) ? $_GET['list'] : null;
 $person = isset($_GET['person']) ? $_GET['person'] : null;
 $entryId = isset($_GET['entry']) ? intval($_GET['entry']) : null;
 
+function diaryAudioEndpoint(int $entryId): string
+{
+    $scriptPath = strval($_SERVER['SCRIPT_NAME'] ?? '');
+    $uiPosition = strpos($scriptPath, '/ui/');
+    $webRoot = $uiPosition !== false ? substr($scriptPath, 0, $uiPosition) : '';
+    $host = trim(strval($_SERVER['HTTP_HOST'] ?? ''));
+    $isHttps = !empty($_SERVER['HTTPS']) && strtolower(strval($_SERVER['HTTPS'])) !== 'off';
+    $origin = $host !== '' ? (($isHttps ? 'https' : 'http') . '://' . $host) : '';
+
+    return $origin . rtrim($webRoot, '/') . '/ui/api/chim_diary_audio.php?entry=' . $entryId;
+}
+
 if ($mode === 'people') {
     // Return list of all people with diary entry counts
     $query = "
@@ -177,7 +189,8 @@ if ($mode === 'people') {
                 'content' => $result['content'],
                 'date' => $tamrielicDate,
                 'author' => $author,
-                'location' => $location
+                'location' => $location,
+                'audio_endpoint' => diaryAudioEndpoint(intval($result['rowid']))
             ]
         ]);
     } else {

--- a/ui/api/chim_diary_audio.php
+++ b/ui/api/chim_diary_audio.php
@@ -1,5 +1,6 @@
 <?php
 
+ob_start();
 error_reporting(E_ERROR);
 
 header('Content-Type: application/json');
@@ -162,6 +163,22 @@ try {
     $isHttps = !empty($_SERVER['HTTPS']) && strtolower(strval($_SERVER['HTTPS'])) !== 'off';
     $origin = $host !== '' ? (($isHttps ? 'https' : 'http') . '://' . $host) : '';
     $audioUrl = $origin . rtrim($webRoot, '/') . '/soundcache/' . rawurlencode($expectedFile);
+
+    if (filter_input(INPUT_GET, 'raw', FILTER_VALIDATE_BOOLEAN)) {
+        $audioPath = $enginePath . 'soundcache' . DIRECTORY_SEPARATOR . $expectedFile;
+        if (!is_file($audioPath) || filesize($audioPath) < 1) {
+            throw new RuntimeException('The generated diary audio file is unavailable.');
+        }
+
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+        header('Content-Type: audio/wav');
+        header('Content-Length: ' . filesize($audioPath));
+        header('Content-Disposition: inline; filename="' . basename($expectedFile) . '"');
+        readfile($audioPath);
+        exit;
+    }
 
     echo json_encode([
         'success' => true,

--- a/ui/api/chim_diary_audio.php
+++ b/ui/api/chim_diary_audio.php
@@ -1,0 +1,185 @@
+<?php
+
+error_reporting(E_ERROR);
+
+header('Content-Type: application/json');
+header('Cache-Control: no-store');
+header('Access-Control-Allow-Origin: *');
+
+$enginePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+$GLOBALS['ENGINE_PATH'] = $enginePath;
+
+require_once($enginePath . 'lib' . DIRECTORY_SEPARATOR . 'runtime_bootstrap.php');
+
+try {
+    chimRuntimeBootstrap($enginePath, [
+        'load_general_settings' => true,
+        'load_stt_connector' => false,
+        'load_itt_connector' => false,
+        'load_tts_connector' => false,
+        'load_player_name' => true,
+        'load_narrator' => true,
+    ]);
+
+    require_once($enginePath . 'lib' . DIRECTORY_SEPARATOR . 'logger.php');
+    require_once($enginePath . 'lib' . DIRECTORY_SEPARATOR . 'model_dynmodel.php');
+    require_once($enginePath . 'lib' . DIRECTORY_SEPARATOR . 'data_functions.php');
+    require_once($enginePath . 'lib' . DIRECTORY_SEPARATOR . 'chat_helper_functions.php');
+    require_once($enginePath . 'lib' . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'core_profiles.class.php');
+    require_once($enginePath . 'lib' . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'narrator.class.php');
+    require_once($enginePath . 'lib' . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'npc_master.class.php');
+    require_once($enginePath . 'lib' . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'tts_connector.class.php');
+
+    if (function_exists('requireFilesRecursively')) {
+        requireFilesRecursively($enginePath . 'ext' . DIRECTORY_SEPARATOR, 'globals.php');
+    }
+    require_once($enginePath . 'prompt.includes.php');
+
+    $entryId = filter_input(INPUT_GET, 'entry', FILTER_VALIDATE_INT);
+    if (!$entryId || $entryId < 1) {
+        throw new InvalidArgumentException('A valid diary entry is required.');
+    }
+
+    $db = $GLOBALS['db'];
+    $entry = $db->fetchOne(
+        'SELECT rowid, content, people FROM public.diarylog WHERE rowid = ' . intval($entryId) . ' LIMIT 1'
+    );
+    if (!is_array($entry) || empty($entry)) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'Diary entry not found.']);
+        exit;
+    }
+
+    $content = trim(html_entity_decode(strip_tags(strval($entry['content'] ?? '')), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+    if ($content === '') {
+        throw new RuntimeException('This diary entry has no readable text.');
+    }
+
+    $people = array_values(array_filter(
+        array_map('trim', explode('|', trim(strval($entry['people'] ?? ''), '|'))),
+        static fn($value) => $value !== ''
+    ));
+    $author = strval($people[0] ?? '');
+    if ($author === '') {
+        throw new RuntimeException('The diary author could not be determined.');
+    }
+
+    $narratorManager = new Narrator();
+    $isNarrator = in_array($author, [Narrator::CANONICAL_NAME, $narratorManager->getRoleplayName()], true);
+    $npcManager = new NpcMaster();
+    $npcData = $isNarrator ? $narratorManager->getNarratorData() : $npcManager->getByName($author);
+    if (!is_array($npcData) || empty($npcData)) {
+        throw new RuntimeException("No CHIM NPC profile was found for {$author}.");
+    }
+
+    $profileManager = new CoreProfile();
+    $profileId = intval($npcData['profile_id'] ?? 0);
+    $profileData = $profileId > 0 ? $profileManager->getById($profileId) : null;
+    if (!is_array($profileData) || empty($profileData)) {
+        $profileData = $isNarrator ? $profileManager->getDefaultNarrator() : $profileManager->getDefaultNpc();
+    }
+    if (!is_array($profileData) || empty($profileData)) {
+        throw new RuntimeException("No TTS profile is available for {$author}.");
+    }
+
+    $connectorId = intval($profileData['tts_connector_id'] ?? 0);
+    $ttsConnector = new TTSConnector();
+    $connectorData = $connectorId > 0 ? $ttsConnector->getById($connectorId) : null;
+    $driver = $ttsConnector->normalizeDriverValue($connectorData['driver'] ?? 'none');
+    if (!is_array($connectorData) || empty($connectorData) || $driver === 'none' || $driver === '') {
+        throw new RuntimeException("TTS is not configured for {$author}'s profile.");
+    }
+
+    $GLOBALS['CHIM_CORE_CURRENT_PROFILE_DATA'] = $profileData;
+    $profileManager->setOldGlobals($profileData);
+    $GLOBALS['CHIM_CORE_CURRENT_NPC_DATA'] = $npcData;
+    if ($isNarrator) {
+        $narratorManager->loadCharacterIntoGlobals();
+    } else {
+        $npcManager->setOldGlobalsFromCurrentNpcData($npcData);
+    }
+
+    $voiceId = trim(strval($isNarrator
+        ? ($GLOBALS['PATCH_OVERRIDE_VOICE'] ?? '')
+        : ($GLOBALS['TTS_NPC_RESOLVED_VOICE'] ?? $GLOBALS['PATCH_OVERRIDE_VOICE'] ?? '')));
+    if ($voiceId === '') {
+        throw new RuntimeException("No TTS voice could be resolved for {$author}.");
+    }
+
+    $connectorSignature = json_encode([
+        'id' => $connectorId,
+        'driver' => $driver,
+        'url' => $connectorData['url'] ?? '',
+        'metadata' => $connectorData['metadata'] ?? '{}',
+        'api_badge_id' => $connectorData['api_badge_id'] ?? null,
+    ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    $cacheSeed = 'diary-audio|' . hash('sha256', implode('|', [
+        strval($entryId),
+        $content,
+        $author,
+        $voiceId,
+        strval($connectorSignature),
+    ]));
+    $expectedFile = md5(trim($cacheSeed)) . '.wav';
+    $soundCachePath = $enginePath . 'soundcache' . DIRECTORY_SEPARATOR . $expectedFile;
+    $wasCached = is_file($soundCachePath) && filesize($soundCachePath) > 0;
+
+    $lockPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'chim-diary-audio-' . md5($cacheSeed) . '.lock';
+    $lockHandle = fopen($lockPath, 'c');
+    if ($lockHandle === false || !flock($lockHandle, LOCK_EX)) {
+        throw new RuntimeException('The diary audio generator is currently unavailable.');
+    }
+
+    try {
+        $wasCached = is_file($soundCachePath) && filesize($soundCachePath) > 0;
+        if (!$wasCached) {
+            $GLOBALS['AVOID_TTS_CACHE'] = false;
+            $GLOBALS['PATCH_DONT_STORE_SPEECH_ON_DB'] = true;
+            $GLOBALS['HERIKA_ANIMATIONS'] = false;
+            $GLOBALS['SCRIPTLINE_LISTENER'] = '';
+            $GLOBALS['SCRIPTLINE_EXPRESSION'] = '';
+            $GLOBALS['TTS_FFMPEG_FILTERS'] = $GLOBALS['TTS_FFMPEG_FILTERS'] ?? [];
+            $GLOBALS['FEATURES'] = $GLOBALS['FEATURES'] ?? [];
+            $GLOBALS['FEATURES']['MISC'] = $GLOBALS['FEATURES']['MISC'] ?? [];
+            $GLOBALS['FEATURES']['MISC']['TTS_RANDOM_PITCH'] = false;
+
+            $ttsOutput = callNpcTtsWithFallback($content, 'default', $cacheSeed);
+            $generatedFile = basename(strval($ttsOutput));
+            if ($generatedFile === '' || !is_file($enginePath . 'soundcache' . DIRECTORY_SEPARATOR . $generatedFile)) {
+                throw new RuntimeException('The configured TTS service did not produce diary audio.');
+            }
+            $expectedFile = $generatedFile;
+        }
+    } finally {
+        flock($lockHandle, LOCK_UN);
+        fclose($lockHandle);
+    }
+
+    $scriptPath = strval($_SERVER['SCRIPT_NAME'] ?? '');
+    $uiPosition = strpos($scriptPath, '/ui/');
+    $webRoot = $uiPosition !== false ? substr($scriptPath, 0, $uiPosition) : '';
+    $host = trim(strval($_SERVER['HTTP_HOST'] ?? ''));
+    $isHttps = !empty($_SERVER['HTTPS']) && strtolower(strval($_SERVER['HTTPS'])) !== 'off';
+    $origin = $host !== '' ? (($isHttps ? 'https' : 'http') . '://' . $host) : '';
+    $audioUrl = $origin . rtrim($webRoot, '/') . '/soundcache/' . rawurlencode($expectedFile);
+
+    echo json_encode([
+        'success' => true,
+        'audio_url' => $audioUrl,
+        'author' => $author,
+        'voice' => $voiceId,
+        'connector' => strval($connectorData['label'] ?? $driver),
+        'cached' => $wasCached,
+    ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+} catch (InvalidArgumentException $e) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+} catch (Throwable $e) {
+    if (class_exists('Logger')) {
+        Logger::error('[DIARY AUDIO] ' . $e->getMessage());
+    } else {
+        error_log('[DIARY AUDIO] ' . $e->getMessage());
+    }
+    http_response_code(422);
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}

--- a/ui/css/diary_adventure.css
+++ b/ui/css/diary_adventure.css
@@ -472,6 +472,8 @@ body.modal-open {
     padding: 0 !important;
     height: calc(100vh - 220px);
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
 }
 
 #entryModal .entry-content {
@@ -482,9 +484,46 @@ body.modal-open {
     color: #000;
     font-family: SkyrimBooks_Handwritten_Bold, Arial, sans-serif !important;
     font-size: 1.2em;
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     overflow-y: auto;
     overflow-x: hidden;
+}
+
+.diary-audio-button {
+    background: var(--log-accent, #f27c11) !important;
+    background-image: none !important;
+    border: 1px solid var(--log-accent-hover, #ff963d) !important;
+    border-radius: 4px;
+    color: #fff !important;
+    cursor: pointer;
+    font-weight: 600;
+    padding: 6px 10px;
+}
+
+.diary-audio-button:hover:not(:disabled) {
+    background: var(--log-accent-hover, #ff963d) !important;
+}
+
+.diary-audio-button:disabled {
+    cursor: wait;
+    opacity: 0.7;
+}
+
+#entryModal .diary-audio-controls {
+    align-items: center;
+    background: #202024;
+    border: 1px solid rgba(242, 124, 17, 0.55);
+    border-top: 0;
+    border-radius: 0 0 6px 6px;
+    display: flex;
+    gap: 12px;
+    padding: 10px 14px;
+}
+
+.diary-audio-status {
+    color: #ddd;
+    font-size: 0.9rem;
 }
 
 #entryModal .entry-content::-webkit-scrollbar {

--- a/ui/diarylog.php
+++ b/ui/diarylog.php
@@ -1168,6 +1168,7 @@ if ($shouldFetchEvents) {
                                 <td>{$gameTimeDisplay}</td>
                                 <td>{$timeDisplay}</td>
                                 <td>
+                                    <button type='button' data-diary-audio-entry='{$row['rowid']}' onclick='event.stopPropagation(); toggleDiaryAudio(this, {$row['rowid']})' class='action-button diary-audio-button'>&#9654; Play</button>
                                     <button onclick='openEditModal(" . json_encode([
                                         'rowid' => $row['rowid'],
                                         'topic' => $topic,
@@ -1240,6 +1241,7 @@ if ($shouldFetchEvents) {
                             <td>{$gameTimeDisplay}</td>
                             <td>{$timeDisplay}</td>
                             <td>
+                                <button type='button' data-diary-audio-entry='{$row['rowid']}' onclick='event.stopPropagation(); toggleDiaryAudio(this, {$row['rowid']})' class='action-button diary-audio-button'>&#9654; Play</button>
                                 <button onclick='openEditModal(" . json_encode([
                                     'rowid' => $row['rowid'],
                                     'topic' => $topic,
@@ -1295,10 +1297,105 @@ if ($shouldFetchEvents) {
         <div id="entryModal" class="modal-backdrop">
             <div class="modal-container">
                 <div id="entryModalContent" class="entry-content"></div>
+                <div class="diary-audio-controls">
+                    <button type="button" id="entryModalAudioButton" class="diary-audio-button" onclick="toggleDiaryAudio(this, Number(this.dataset.diaryAudioEntry))">&#9654; Play Audio</button>
+                    <span id="diaryAudioStatus" class="diary-audio-status" aria-live="polite"></span>
+                </div>
             </div>
         </div>
 
         <script>
+            const diaryAudioEndpoint = <?php echo json_encode($webRoot . '/ui/api/chim_diary_audio.php'); ?>;
+            const diaryAudio = new Audio();
+            let activeDiaryEntryId = null;
+            let diaryAudioRequest = null;
+
+            function updateDiaryAudioControls(entryId, label, disabled = false) {
+                document.querySelectorAll(`[data-diary-audio-entry="${entryId}"]`).forEach(button => {
+                    const isModalButton = button.id === 'entryModalAudioButton';
+                    if (label === 'Play') {
+                        button.innerHTML = isModalButton ? '&#9654; Play Audio' : '&#9654; Play';
+                    } else {
+                        button.innerHTML = label;
+                    }
+                    button.disabled = disabled;
+                });
+            }
+
+            function setDiaryAudioStatus(message) {
+                const status = document.getElementById('diaryAudioStatus');
+                if (status) status.textContent = message || '';
+            }
+
+            function stopDiaryAudio() {
+                if (diaryAudioRequest) {
+                    diaryAudioRequest.abort();
+                    diaryAudioRequest = null;
+                }
+                diaryAudio.pause();
+                diaryAudio.removeAttribute('src');
+                diaryAudio.load();
+                if (activeDiaryEntryId !== null) {
+                    updateDiaryAudioControls(activeDiaryEntryId, 'Play');
+                }
+                activeDiaryEntryId = null;
+                setDiaryAudioStatus('');
+            }
+
+            async function toggleDiaryAudio(button, entryId) {
+                if (!entryId) return;
+
+                if (activeDiaryEntryId === entryId && diaryAudio.src) {
+                    if (diaryAudio.paused) {
+                        await diaryAudio.play();
+                        updateDiaryAudioControls(entryId, '&#10074;&#10074; Pause');
+                        setDiaryAudioStatus('Playing');
+                    } else {
+                        diaryAudio.pause();
+                        updateDiaryAudioControls(entryId, 'Play');
+                        setDiaryAudioStatus('Paused');
+                    }
+                    return;
+                }
+
+                stopDiaryAudio();
+                activeDiaryEntryId = entryId;
+                diaryAudioRequest = new AbortController();
+                updateDiaryAudioControls(entryId, 'Generating...', true);
+                setDiaryAudioStatus('Generating audio with the NPC voice...');
+
+                try {
+                    const response = await fetch(`${diaryAudioEndpoint}?entry=${encodeURIComponent(entryId)}`, {
+                        cache: 'no-store',
+                        signal: diaryAudioRequest.signal
+                    });
+                    const result = await response.json();
+                    if (!response.ok || !result.success || !result.audio_url) {
+                        throw new Error(result.error || 'Diary audio could not be generated.');
+                    }
+
+                    diaryAudioRequest = null;
+                    diaryAudio.src = result.audio_url;
+                    await diaryAudio.play();
+                    updateDiaryAudioControls(entryId, '&#10074;&#10074; Pause');
+                    setDiaryAudioStatus(`Playing ${result.author || 'NPC'} with ${result.connector || 'configured TTS'}`);
+                } catch (error) {
+                    if (error.name === 'AbortError') return;
+                    console.error('Diary audio failed:', error);
+                    updateDiaryAudioControls(entryId, 'Play');
+                    setDiaryAudioStatus(error.message || 'Diary audio failed.');
+                    activeDiaryEntryId = null;
+                }
+            }
+
+            diaryAudio.addEventListener('ended', () => {
+                if (activeDiaryEntryId !== null) {
+                    updateDiaryAudioControls(activeDiaryEntryId, 'Play');
+                }
+                activeDiaryEntryId = null;
+                setDiaryAudioStatus('');
+            });
+
             // Debug function to help us see what data we're receiving
             function debugLog(data) {
                 console.log('Data received:', data);
@@ -1317,6 +1414,10 @@ if ($shouldFetchEvents) {
                 try {
                     const entryData = typeof data === 'string' ? JSON.parse(data) : data;
                     content.innerHTML = entryData.content || '';
+                    const audioButton = document.getElementById('entryModalAudioButton');
+                    audioButton.dataset.diaryAudioEntry = entryData.rowid;
+                    const isCurrentEntryPlaying = activeDiaryEntryId === Number(entryData.rowid) && !diaryAudio.paused;
+                    updateDiaryAudioControls(Number(entryData.rowid), isCurrentEntryPlaying ? '&#10074;&#10074; Pause' : 'Play');
                     modal.style.display = 'block';
                     document.body.classList.add('modal-open');
                     // Focus on the modal content
@@ -1327,6 +1428,7 @@ if ($shouldFetchEvents) {
             }
 
             function closeEntryModal() {
+                stopDiaryAudio();
                 const modal = document.getElementById('entryModal');
                 if (modal) {
                     modal.style.display = 'none';


### PR DESCRIPTION
## Summary
- add Play Audio controls to diary tables and the parchment entry modal
- generate diary narration with the author NPC's configured profile TTS connector and resolved voice
- cache generated audio and stream a clean WAV response for native CHIM playback

## Implementation
- adds a focused diary-audio endpoint with profile, narrator, connector, and voice resolution
- serializes generation per diary entry and reuses sound-cache output
- preserves the JSON response used by the web UI and adds `raw=1` WAV streaming for the game plugin
- clears bootstrap output before raw streaming so the response begins with a valid RIFF/WAVE header

## Validation
- `php -l ui/api/chim_diary_audio.php` passed
- JSON mode returned a successful cached Pocket TTS response for diary entry 219
- raw mode returned HTTP 200, `audio/wav`, 3,927,918 bytes, and a clean `RIFF...WAVE` header
- deployed endpoint hash matches `/var/www/html/HerikaServer/ui/api/chim_diary_audio.php`
- `git diff --check` passed

## Deployment
Deployed locally to `/var/www/html/HerikaServer` for testing.

## Manual limits
- PHP playback controls were endpoint-tested but not visually exercised in every table mode
- audible in-game playback still requires a Skyrim runtime test with the related CHIM PR

## Related PR
- CHIM: https://github.com/Dwemer-Dynamics/CHIM/pull/104