### PR TITLE
Fix diary calendar button contrast

### DIFF
--- a/ui/css/diary_adventure.css
+++ b/ui/css/diary_adventure.css
@@ -378,12 +378,13 @@ main.container {
     font-weight: bold;
 }
 
-.pdf-export-btn {
+.pdf-export-btn,
+.pdf-export-btn:visited {
     padding: 10px 18px;
-    background-color: var(--log-accent);
-    border: 2px solid var(--log-accent-hover);
+    background-color: var(--log-accent) !important;
+    border: 2px solid var(--log-accent-hover) !important;
     border-radius: 6px;
-    color: var(--log-button-text);
+    color: #ffffff !important;
     font-size: 16px;
     font-weight: 600;
     cursor: pointer;
@@ -396,8 +397,12 @@ main.container {
     box-shadow: 0 2px 6px rgba(0,0,0,0.25);
 }
 
-.pdf-export-btn:hover {
-    background-color: var(--log-accent-hover);
+.pdf-export-btn:hover,
+.pdf-export-btn:focus-visible {
+    background-color: var(--log-accent-hover) !important;
+    border-color: var(--log-accent-hover) !important;
+    color: #ffffff !important;
+    text-decoration: none;
     transform: translateY(-1px);
     box-shadow: 0 4px 10px rgba(0,0,0,0.3);
 }

--- a/ui/css/diary_adventure.css
+++ b/ui/css/diary_adventure.css
@@ -224,16 +224,17 @@ body .calendar-mode-toggle form button.btn-primary[type="submit"]:hover {
 
 .csv-buttons .btn-save,
 body .csv-buttons button.log-action-button[type="submit"] {
-    background: var(--log-accent) !important;
+    background: #2f714b !important;
     background-image: none !important;
-    border-color: var(--log-accent-hover) !important;
-    color: var(--log-button-text) !important;
+    border-color: #4c996b !important;
+    color: #ffffff !important;
 }
 
 .csv-buttons .btn-save:hover,
 body .csv-buttons button.log-action-button[type="submit"]:hover {
-    background: var(--log-accent-hover) !important;
-    color: var(--log-button-text) !important;
+    background: #2f714b !important;
+    border-color: #4c996b !important;
+    color: #ffffff !important;
 }
 
 /* Event Table Styles */

--- a/ui/css/diary_adventure.css
+++ b/ui/css/diary_adventure.css
@@ -80,6 +80,15 @@
     color: var(--log-button-text);
 }
 
+.diary-calendar td.has-event > a,
+.diary-calendar td.has-event > a:visited,
+.diary-calendar td.has-event > a:hover,
+.diary-calendar td.has-event > a:focus-visible {
+    color: #ffffff !important;
+    font-weight: 700;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.65);
+}
+
 .calendar td.has-event a:hover::after {
     content: attr(data-event-count) " entries";
     position: absolute;
@@ -147,6 +156,21 @@
     background-color: var(--log-accent-hover);
     transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.diary-calendar-navigation .diary-calendar-nav,
+.diary-calendar-navigation .diary-calendar-nav:visited {
+    background-color: var(--log-accent);
+    border: 2px solid var(--log-accent-hover);
+    color: #ffffff !important;
+    font-weight: 600;
+}
+
+.diary-calendar-navigation .diary-calendar-nav:hover,
+.diary-calendar-navigation .diary-calendar-nav:focus-visible {
+    background-color: var(--log-accent-hover);
+    border-color: var(--log-accent-hover);
+    color: #ffffff !important;
 }
 
 /* Calendar Mode Toggle */

--- a/ui/css/diary_adventure.css
+++ b/ui/css/diary_adventure.css
@@ -180,33 +180,32 @@
     margin: 20px 0;
 }
 
-.calendar-mode-toggle .btn-base {
+body .calendar-mode-toggle form button.btn-base[type="submit"] {
     padding: 10px 20px;
     font-size: 1.1em;
     border-radius: 5px;
     cursor: pointer;
     transition: all 0.3s ease;
+    background: #3b3b3b !important;
+    border: 2px solid #565656 !important;
+    color: #f5f1e8 !important;
 }
 
-.calendar-mode-toggle .btn-primary {
-    background-color: var(--log-accent);
-    color: var(--log-button-text);
-    border: 2px solid var(--log-accent-hover);
+body .calendar-mode-toggle form button.btn-primary[type="submit"] {
+    border-color: var(--log-accent) !important;
 }
 
-.calendar-mode-toggle .btn-secondary {
-    background-color: #6c757d;
-    color: var(--log-button-text);
-    border: 2px solid #545b62;
+body .calendar-mode-toggle form button.btn-secondary[type="submit"] {
+    border-color: #565656 !important;
 }
 
-.calendar-mode-toggle .btn-base:hover {
+body .calendar-mode-toggle form button.btn-base[type="submit"]:hover {
     transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
-.calendar-mode-toggle .btn-primary:hover {
-    background-color: var(--log-accent-hover);
+body .calendar-mode-toggle form button.btn-primary[type="submit"]:hover {
+    background: #484848 !important;
 }
 
 /* CSV Buttons Container */
@@ -347,13 +346,13 @@ main.container {
     margin: 8px 0;
 }
 
-.people-item {
+body .people-list form button.people-item[type="submit"] {
     width: 100%;
     padding: 12px 20px;
-    background-color: #4a4a4a;
-    border: 2px solid #555555;
+    background: #3b3b3b !important;
+    border: 2px solid #565656 !important;
     border-radius: 6px;
-    color: #f8f9fa;
+    color: #f5f1e8 !important;
     font-size: 16px;
     text-align: left;
     cursor: pointer;
@@ -363,9 +362,9 @@ main.container {
     align-items: center;
 }
 
-.people-item:hover {
-    background-color: #555555;
-    border-color: var(--log-accent);
+body .people-list form button.people-item[type="submit"]:hover {
+    background: #484848 !important;
+    border-color: var(--log-accent) !important;
     transform: translateX(5px);
 }
 

--- a/ui/diarylog.php
+++ b/ui/diarylog.php
@@ -807,7 +807,7 @@ function renderCalendarHTML($calendar, $useTamrielicTime) {
     global $gregorianDays, $tamrielicDays;
     
     $daysOfWeek = $useTamrielicTime ? $tamrielicDays : $gregorianDays;
-    $html = "<table class='calendar'>";
+    $html = "<table class='calendar diary-calendar'>";
     
     // Render header
     $html .= "<tr>";
@@ -1039,7 +1039,7 @@ if ($shouldFetchEvents) {
         <!-- Calendar Container -->
         <div class="calendar-container <?php echo (isset($_GET['filter']) && $_GET['filter'] === 'people') ? 'hidden' : ''; ?>">
             <!-- Calendar Navigation -->
-            <div class="calendar-navigation">
+            <div class="calendar-navigation diary-calendar-navigation">
                 <?php
                 // Calculate previous and next month and year
                 if ($useTamrielicTime) {
@@ -1067,13 +1067,13 @@ if ($shouldFetchEvents) {
                     $nextMonthName = $tamrielicMonths[$nextMonthNum];
                     
                     // Link to previous month
-                    echo "<a href='?month={$prevMonthNum}&year={$prevYear}&tamrielic=true' class='btn-primary'>&laquo; {$prevMonthName}</a>";
+                    echo "<a href='?month={$prevMonthNum}&year={$prevYear}&tamrielic=true' class='diary-calendar-nav'>&laquo; {$prevMonthName}</a>";
                     
                     // Display current month and year
                     echo "<span><b>{$currentTamrielicMonth}, 4E {$currentTamrielicYear}</b></span>";
                     
                     // Link to next month
-                    echo "<a href='?month={$nextMonthNum}&year={$nextYear}&tamrielic=true' class='btn-primary'>{$nextMonthName} &raquo;</a>";
+                    echo "<a href='?month={$nextMonthNum}&year={$nextYear}&tamrielic=true' class='diary-calendar-nav'>{$nextMonthName} &raquo;</a>";
                 } else {
                     // Original Gregorian calendar navigation
                     $prevMonth = $month - 1;
@@ -1095,9 +1095,9 @@ if ($shouldFetchEvents) {
                     $nextMonthName = date('F', strtotime("$nextYear-$nextMonth-01 UTC"));
                     $currentMonthName = date('F', strtotime("$year-$month-01 UTC"));
 
-                    echo "<a href='?month={$prevMonth}&year={$prevYear}' class='btn-primary'>&laquo; {$prevMonthName}</a>";
+                    echo "<a href='?month={$prevMonth}&year={$prevYear}' class='diary-calendar-nav'>&laquo; {$prevMonthName}</a>";
                     echo "<span><b>{$currentMonthName} {$year}</b></span>";
-                    echo "<a href='?month={$nextMonth}&year={$nextYear}' class='btn-primary'>{$nextMonthName} &raquo;</a>";
+                    echo "<a href='?month={$nextMonth}&year={$nextYear}' class='diary-calendar-nav'>{$nextMonthName} &raquo;</a>";
                 }
                 ?>
             </div>


### PR DESCRIPTION
## Summary
- force filled diary-calendar dates to render with true white, bold text and a subtle contrast shadow
- give month navigation dedicated diary styles so it uses the correct CHIM orange instead of inheriting the generic button theme
- keep the `Open The Diary of...` button on the standard diary orange with white text across normal, visited, hover, and keyboard-focus states
- replace green calendar-mode and person-list buttons with the site's neutral grey button theme
- retain an orange border on the selected calendar mode for clear active-state feedback
- use the site's green success style for `Download Current Diaries` and `Download All Diary Entries`
- scope the calendar selectors to the diary page to avoid changing unrelated controls or the adventure log

## Validation
- `php -l ui/diarylog.php`
- `git diff --check`
- local HTTP probe returned `200`
- deployed file hashes match the PR worktree
- live browser verification confirmed white text on filled dates, month navigation, and the diary-book button
- live browser verification confirmed neutral grey mode/person buttons and an orange border only on the selected mode
- live browser verification confirmed both diary download buttons use green `rgb(47, 113, 75)` with white text

## Deployment
- Deployed locally to `/var/www/html/HerikaServer` from commit `9bb16ee0` for visual verification.

## Manual limits
- No in-game behavior is affected or required for this server UI-only change.
