### PR TITLE
Expand NPC Background Life controls and actions

### DIFF
--- a/debug/simple_llm_request_with_context_life.php
+++ b/debug/simple_llm_request_with_context_life.php
@@ -157,6 +157,7 @@ $request = $argv[1];
 $dynamicBiography = buildDynamicBiography($GLOBALS, true, true);
 $npcMaster = new NpcMaster();
 $currentNpcData = $npcMaster->getByName($argv[1]);
+$dynamicBiography = $npcMaster->appendBackgroundLifeGoals($dynamicBiography, $currentNpcData);
 $extended_data = $npcMaster->getExtendedData($currentNpcData);
 $metadata = $npcMaster->getMetadata($currentNpcData);
 
@@ -403,6 +404,7 @@ This soliloquy should reflect what the character might have done over the last $
  * What activities they have engaged in. Detailed list.
  * What possible events or encounters might have occurred.
  * Intimate thoughts.
+ * Give special attention to <background_life_goals> when present; <goals> contains the character's general motivations.
 
 Always respect the character's last known location. If the character is currently in a specific place, generated content should occur in that same area or its surroundings.
 The character may express the intention to travel elsewhere, but such travel should only be described as a future plan, not an immediate action.

--- a/debug/simple_llm_request_with_context_life_v2.php
+++ b/debug/simple_llm_request_with_context_life_v2.php
@@ -330,6 +330,7 @@ $history = "";
 // ─── Dynamic Biography ────────────────────────────────────────────────────────
 
 $dynamicBiography = buildDynamicBiography($GLOBALS, true, true, true);
+$dynamicBiography = $npcMaster->appendBackgroundLifeGoals($dynamicBiography, $currentNpcData);
 
 if (isset($extdata['middle_term_memory'])) {
     $middleTermMemory = end($extdata['middle_term_memory']);
@@ -810,7 +811,7 @@ Rules:
 
 2. Working scenarios
    - If the NPC was in a working scenario,(and last intent was a production intent) determine whether any goods were produced during the last `$idleHours` hours.
-   - Inspect the `[production]` subsection inside `<goals>` to find:
+   - Inspect the `[production]` subsection inside `<background_life_goals>` first, then `<goals>` if no Background Life production rule is defined, to find:
      - what item(s) are produced
      - the production rate (units per hour)
    - Calculate production only for the last `$idleHours` hours.
@@ -965,6 +966,7 @@ Rules:
 
         // Refetch the NPC data to update the dynamic biography with the new inventory state
         $dynamicBiography = buildDynamicBiography($GLOBALS, true, true, true);
+        $dynamicBiography = $npcMaster->appendBackgroundLifeGoals($dynamicBiography, $currentNpcData);
 
         if (isset($extdata['middle_term_memory'])) {
             $middleTermMemory = end($extdata['middle_term_memory']);
@@ -1152,7 +1154,7 @@ and after last inner thoughts presented in the <context_history>:
 
 * Intimate thoughts.
 * Evolution of the character's state of mind based on latest inner thoughts (if any) and events.
-* Consider the character's goals, desires, and motivations. (Special attention to <goals> [Life Goals] section in the character sheet. )
+* Consider the character's goals, desires, and motivations. Give special attention to <background_life_goals> when present; <goals> contains their general motivations.
 * Short (2 paragraphs max), concise, and focused on the character's perspective.
 $innerThoughtEnforceSocialice
 

--- a/lib/background_life_npc_creation.php
+++ b/lib/background_life_npc_creation.php
@@ -306,6 +306,7 @@ function chimBglSpawnNpc(array $npcProfile, int $startingPoint, array $inventory
     $extendedData['background_life_enabled'] = true;
     $extendedData['background_life_last_updated'] = $lastGamets;
     $extendedData['background_life_player_unattached'] = true;
+    $extendedData['background_life_goals'] = $npcProfile['goal'];
     $extendedData['middle_term_enabled'] = 1;
 
     $metadata = $npcMaster->getMetadata($npc);
@@ -318,7 +319,7 @@ function chimBglSpawnNpc(array $npcProfile, int $startingPoint, array $inventory
     $npc['personality'] = $npcProfile['disposition'];
     $npc['occupation'] = $npcProfile['class'];
     $npc['speechstyle'] = $npcProfile['speechStyle'];
-    $npc['goals'] = $npcProfile['goal'];
+    $npc['goals'] = '';
     $npc['lock_profile'] = null;
     $npc = $npcMaster->setMetadata($npc, $metadata);
     $npc = $npcMaster->setExtendedData($npc, $extendedData);

--- a/lib/background_life_requests.php
+++ b/lib/background_life_requests.php
@@ -62,11 +62,15 @@ function chimBglNpcStatus(NpcMaster $npcMaster, ?array $npc, string $requestedRe
             'auto_actions' => false,
             'send_letters' => false,
             'hourly_tracking' => false,
+            'location' => '',
         ];
     }
 
     $extendedData = $npcMaster->getExtendedData($npc);
     $metadata = $npcMaster->getMetadata($npc);
+    $coordsValue = $metadata['last_coords'] ?? null;
+    $coords = is_array($coordsValue) ? $coordsValue : json_decode((string)$coordsValue, true);
+    $location = is_array($coords) ? trim((string)($coords[3] ?? '')) : '';
 
     return [
         'exists' => true,
@@ -77,6 +81,7 @@ function chimBglNpcStatus(NpcMaster $npcMaster, ?array $npc, string $requestedRe
         'auto_actions' => chimBglBoolean($extendedData['background_life_commands'] ?? false),
         'send_letters' => chimBglBoolean($extendedData['background_life_letters'] ?? false),
         'hourly_tracking' => chimBglBoolean($metadata['gps_track'] ?? false),
+        'location' => $location,
     ];
 }
 

--- a/lib/core/npc_master.class.php
+++ b/lib/core/npc_master.class.php
@@ -1122,7 +1122,7 @@ class NpcMaster
 
         // Apply extended_data overrides (highest precedence - NPC level)
         // Reserved keys are excluded (system fields managed by dedicated subsystems/toggles)
-        $reservedKeys = ['middle_term_memory', 'middle_term_enabled', 'individual_memory_enabled', 'chim_core_migrated'];
+        $reservedKeys = ['middle_term_memory', 'middle_term_enabled', 'individual_memory_enabled', 'background_life_goals', 'chim_core_migrated'];
         $extendedData = json_decode($currentNpcData['extended_data'] ?? '{}', true);
         if (is_array($extendedData)) {
             foreach ($extendedData as $key => $value) {
@@ -1162,6 +1162,17 @@ class NpcMaster
     public function getExtendedData($currentNpcData): array
     {
         return json_decode($currentNpcData['extended_data'] ?? '{}', true) ?: [];
+    }
+
+    public function appendBackgroundLifeGoals(string $biography, $currentNpcData): string
+    {
+        $extendedData = $this->getExtendedData($currentNpcData);
+        $backgroundLifeGoals = trim((string)($extendedData['background_life_goals'] ?? ''));
+        if ($backgroundLifeGoals === '') {
+            return $biography;
+        }
+
+        return $biography . "\n\n<background_life_goals>\n{$backgroundLifeGoals}\n</background_life_goals>";
     }
 
     public function setExtendedData($currentNpcData, array $data)

--- a/ui/api/background_life_npc.php
+++ b/ui/api/background_life_npc.php
@@ -84,16 +84,19 @@ try {
 
     $npc = chimBglResolveNpc($npcMaster, $refid, $npcName);
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-        if ($operation === 'disable') {
+        if ($operation === 'enable' || $operation === 'disable') {
             if (!$npc) {
                 http_response_code(404);
                 throw new RuntimeException('NPC has not been discovered by CHIM');
             }
 
-            $status = chimBglSetEnabled($npcMaster, $npc, false);
+            $enabled = $operation === 'enable';
+            $status = chimBglSetEnabled($npcMaster, $npc, $enabled);
             echo json_encode([
                 'success' => true,
-                'message' => 'NPC removed from Background Life',
+                'message' => $enabled
+                    ? 'NPC added to Background Life'
+                    : 'NPC removed from Background Life',
                 'data' => $status,
             ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
             exit;

--- a/ui/api/chim_npc_manager.php
+++ b/ui/api/chim_npc_manager.php
@@ -274,11 +274,37 @@ function chimNpcManagerFindNpc(array $input): array
     throw new InvalidArgumentException('NPC not found');
 }
 
+// Persist only the temporary return point without overwriting live NPC metadata updates.
+function chimNpcManagerSaveReturnLocation(int $npcId, ?array $returnLocation): bool
+{
+    if ($npcId <= 0) {
+        return false;
+    }
+
+    if ($returnLocation === null) {
+        return $GLOBALS['db']->execQuery(
+            "UPDATE core_npc_master SET metadata = COALESCE(metadata, '{}'::jsonb) - 'npc_manager_return_location' WHERE id = {$npcId}"
+        ) !== false;
+    }
+
+    $encoded = json_encode($returnLocation, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    if ($encoded === false) {
+        return false;
+    }
+    $locationLiteral = $GLOBALS['db']->escape($encoded);
+    return $GLOBALS['db']->execQuery(
+        "UPDATE core_npc_master SET metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{npc_manager_return_location}', '{$locationLiteral}'::jsonb, true) WHERE id = {$npcId}"
+    ) !== false;
+}
+
 function chimNpcManagerAction(array $input): array
 {
     $row = chimNpcManagerFindNpc($input);
     $action = strtolower(trim((string)($input['action'] ?? '')));
     $npcName = trim((string)($row['npc_name'] ?? 'NPC'));
+    $npcManager = new NpcMaster();
+    $metadata = $npcManager->getMetadata($row);
+    $returnLocationKey = 'npc_manager_return_location';
 
     if ($action === 'bgl_inception') {
         $idea = trim((string)($input['idea'] ?? ''));
@@ -291,7 +317,7 @@ function chimNpcManagerAction(array $input): array
         return ['message' => "Background Life thought set for {$npcName}."];
     }
 
-    if (!in_array($action, ['visit', 'teleport'], true)) {
+    if (!in_array($action, ['visit', 'teleport', 'return'], true)) {
         throw new InvalidArgumentException('Unsupported NPC action');
     }
 
@@ -300,6 +326,100 @@ function chimNpcManagerAction(array $input): array
         throw new InvalidArgumentException("{$npcName} does not have a valid RefID");
     }
     $npcRefid = '0x' . str_pad($refid, 8, '0', STR_PAD_LEFT);
+
+    if ($action === 'return') {
+        $returnLocation = $metadata[$returnLocationKey] ?? null;
+        if (!is_array($returnLocation)) {
+            throw new InvalidArgumentException("{$npcName} does not have a saved return location");
+        }
+
+        $locationName = trim((string)($returnLocation['name'] ?? ''));
+        $locationFormId = trim((string)($returnLocation['formid'] ?? ''));
+        if ($locationName === '' && $locationFormId === '') {
+            throw new InvalidArgumentException("{$npcName}'s saved return location is invalid");
+        }
+        if ($locationName === '' && $locationFormId !== '') {
+            $formIdLiteral = $GLOBALS['db']->escape($locationFormId);
+            $location = $GLOBALS['db']->fetchOne("SELECT name FROM locations WHERE formid = '{$formIdLiteral}' LIMIT 1");
+            $locationName = trim((string)($location['name'] ?? 'previous location'));
+        }
+
+        $targetName = str_replace('@', '', $npcName);
+        $locationName = str_replace('@', '', $locationName);
+        $roleCommand = $locationFormId !== ''
+            ? "rolecommand|TeleportNPCRaw@{$targetName}@{$locationFormId}@{$locationName}"
+            : "rolecommand|TeleportNPC@{$targetName}@{$locationName}";
+
+        $GLOBALS['db']->insert('responselog', [
+            'localts' => time(),
+            'sent' => 0,
+            'actor' => 'rolemaster',
+            'text' => '',
+            'action' => $roleCommand,
+            'tag' => '',
+        ]);
+
+        if (!chimNpcManagerSaveReturnLocation((int)$row['id'], null)) {
+            throw new RuntimeException('Saved return location could not be cleared');
+        }
+
+        return [
+            'message' => "Return command sent for {$npcName} to {$locationName}.",
+            'next_action' => 'teleport',
+            'return_location' => '',
+        ];
+    }
+
+    if ($action === 'teleport') {
+        if (is_array($metadata[$returnLocationKey] ?? null)) {
+            throw new InvalidArgumentException("Return {$npcName} before teleporting them again");
+        }
+
+        $lastCoords = $metadata['last_coords'] ?? null;
+        if (!is_array($lastCoords) && is_array($metadata['last_coords_history'] ?? null)) {
+            $history = $metadata['last_coords_history'];
+            $lastCoords = empty($history) ? null : end($history);
+        }
+        if (!is_array($lastCoords)) {
+            throw new InvalidArgumentException("{$npcName} does not have a tracked location to return to");
+        }
+
+        $locationName = trim((string)($lastCoords[3] ?? ''));
+        $locationFormId = trim((string)($lastCoords['location_formid'] ?? ''));
+        if ($locationFormId === '' && $locationName !== '') {
+            $locationLiteral = $GLOBALS['db']->escape($locationName);
+            $location = $GLOBALS['db']->fetchOne(
+                "SELECT name, formid FROM locations ORDER BY similarity(name, '{$locationLiteral}') DESC LIMIT 1"
+            );
+            if (is_array($location)) {
+                $locationName = trim((string)($location['name'] ?? $locationName));
+                $locationFormId = trim((string)($location['formid'] ?? ''));
+            }
+        }
+        if ($locationFormId === '' && is_numeric($lastCoords[0] ?? null) && is_numeric($lastCoords[1] ?? null)) {
+            $pointLiteral = $GLOBALS['db']->escape('(' . (float)$lastCoords[0] . ',' . (float)$lastCoords[1] . ')');
+            $location = $GLOBALS['db']->fetchOne(
+                "SELECT name, formid FROM locations WHERE coords IS NOT NULL ORDER BY coords <-> '{$pointLiteral}'::point LIMIT 1"
+            );
+            if (is_array($location)) {
+                $locationName = trim((string)($location['name'] ?? $locationName));
+                $locationFormId = trim((string)($location['formid'] ?? ''));
+            }
+        }
+        if ($locationName === '' && $locationFormId === '') {
+            throw new InvalidArgumentException("{$npcName}'s tracked return location is invalid");
+        }
+
+        $returnLocation = [
+            'name' => $locationName,
+            'formid' => $locationFormId,
+            'coords' => $lastCoords,
+            'saved_at' => time(),
+        ];
+        if (!chimNpcManagerSaveReturnLocation((int)$row['id'], $returnLocation)) {
+            throw new RuntimeException('Return location could not be saved');
+        }
+    }
 
     require_once LIB_PATH . DIRECTORY_SEPARATOR . 'scriptproxy_papyrus.php';
     $commandBuilder = new SkyrimCommandBuilder();
@@ -312,6 +432,8 @@ function chimNpcManagerAction(array $input): array
         'message' => $action === 'visit'
             ? "Visit command sent for {$npcName}."
             : "Teleport command sent for {$npcName}.",
+        'next_action' => $action === 'teleport' ? 'return' : null,
+        'return_location' => $action === 'teleport' ? $locationName : '',
     ];
 }
 

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -2171,13 +2171,84 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
 .npc-editor-action-card h3 { margin:0 0 4px; color:#f2bd7f; font-size:1rem; }
 .npc-editor-action-card p { margin:0; color:#aaa; font-size:0.82rem; }
 .npc-editor-action-card textarea { min-height:84px; resize:vertical; }
-.npc-editor-action-card.is-inception { grid-template-columns:minmax(220px, 0.8fr) minmax(280px, 1.2fr) auto; }
 .npc-editor-action-status { min-height:1.2rem; margin:0; color:#aaa; font-size:0.82rem; }
 .npc-editor-action-status.is-error { color:#ef8f96; }
+.npc-bgl-dashboard { display:grid; gap:12px; }
+.npc-bgl-section {
+    padding:14px;
+    border:1px solid #444;
+    border-radius:8px;
+    background:#252525;
+}
+.npc-bgl-section-header {
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:12px;
+    margin-bottom:10px;
+}
+.npc-bgl-section h3 { margin:0; color:#f2bd7f; font-size:1rem; }
+.npc-bgl-section p { margin:3px 0 0; color:#aaa; font-size:0.82rem; }
+.npc-bgl-summary {
+    display:grid;
+    grid-template-columns:repeat(3, minmax(0, 1fr));
+    gap:8px;
+}
+.npc-bgl-summary-item {
+    min-width:0;
+    padding:10px;
+    border:1px solid #3d3d3d;
+    border-radius:6px;
+    background:#1d1d1d;
+}
+.npc-bgl-summary-item span { display:block; margin-bottom:4px; color:#888; font-size:0.72rem; text-transform:uppercase; letter-spacing:0.04em; }
+.npc-bgl-summary-item strong { display:block; overflow-wrap:anywhere; color:#e7e7e7; font-size:0.9rem; }
+.npc-bgl-state-button,
+.npc-bgl-control,
+.npc-bgl-request {
+    border:1px solid #4a4a4a;
+    border-radius:6px;
+    background:#303030;
+    color:#eee;
+    cursor:pointer;
+}
+.npc-bgl-state-button { padding:8px 12px; font-weight:700; white-space:nowrap; }
+.npc-bgl-state-button.is-on { border-color:#4c9568; background:#294936; }
+.npc-bgl-control-grid,
+.npc-bgl-request-grid { display:grid; grid-template-columns:repeat(3, minmax(0, 1fr)); gap:8px; }
+.npc-bgl-control {
+    display:flex;
+    align-items:center;
+    gap:9px;
+    min-height:56px;
+    padding:10px;
+    text-align:left;
+}
+.npc-bgl-control-dot { width:9px; height:9px; flex:0 0 auto; border-radius:50%; background:#777; }
+.npc-bgl-control.is-on .npc-bgl-control-dot { background:#63c685; box-shadow:0 0 0 3px rgba(99,198,133,0.12); }
+.npc-bgl-control strong,
+.npc-bgl-control small { display:block; }
+.npc-bgl-control small { margin-top:2px; color:#999; font-size:0.72rem; }
+.npc-bgl-request { min-height:38px; padding:8px 10px; font-weight:700; }
+.npc-bgl-state-button:hover,
+.npc-bgl-control:hover,
+.npc-bgl-request:hover { border-color:rgba(242,124,17,0.75); background:#393939; }
+.npc-bgl-state-button:disabled,
+.npc-bgl-control:disabled,
+.npc-bgl-request:disabled { opacity:0.5; cursor:not-allowed; }
+.npc-bgl-inception { display:grid; grid-template-columns:minmax(0, 1fr) auto; gap:8px; margin-top:8px; }
+.npc-bgl-inception textarea { min-height:70px; resize:vertical; }
+.npc-bgl-events { display:grid; gap:7px; margin:0; padding:0; list-style:none; }
+.npc-bgl-event { padding:9px 10px; border-left:3px solid #666; background:#1d1d1d; color:#ddd; font-size:0.84rem; }
+.npc-bgl-event-time { display:block; margin-top:4px; color:#888; font-size:0.72rem; }
+.npc-bgl-empty { margin:0; padding:10px; color:#888; text-align:center; }
 @media (max-width:700px) { .npc-editor-tabs { grid-template-columns:repeat(2, minmax(0, 1fr)); } }
 @media (max-width:850px) {
-    .npc-editor-action-card,
-    .npc-editor-action-card.is-inception { grid-template-columns:minmax(0, 1fr); }
+    .npc-editor-action-card { grid-template-columns:minmax(0, 1fr); }
+    .npc-bgl-summary,
+    .npc-bgl-control-grid,
+    .npc-bgl-request-grid { grid-template-columns:minmax(0, 1fr); }
+    .npc-bgl-inception { grid-template-columns:minmax(0, 1fr); }
 }
 </style>
 <script>
@@ -2259,6 +2330,8 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
             Object.values(panels).forEach(function(panel){ grid.appendChild(panel); });
 
             const targetId = <?= (int)($editItem['id'] ?? 0) ?>;
+            const targetName = <?= json_encode((string)($editItem['npc_name'] ?? ''), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+            const targetRefId = <?= json_encode((string)($editItem['refid'] ?? ''), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
             panels.actions.innerHTML = `
                 <p class="npc-editor-action-note">The game must be running and unpaused for Visit and Teleport.</p>
                 <div class="npc-editor-action-list">
@@ -2270,11 +2343,6 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                         <div><h3>Teleport</h3><p>Move this NPC to the player's current position.</p></div>
                         <button type="button" class="btn-cancel" data-npc-action="teleport">Teleport</button>
                     </article>
-                    <article class="npc-editor-action-card is-inception">
-                        <div><h3>Background Life Inception</h3><p>Give this NPC a one-time thought for their next Background Life decision.</p></div>
-                        <textarea data-npc-inception-idea placeholder="Enter the thought to influence their next decision"></textarea>
-                        <button type="button" class="btn-cancel" data-npc-action="bgl_inception">Set Thought</button>
-                    </article>
                 </div>
                 <p class="npc-editor-action-status" data-npc-action-status role="status" aria-live="polite"></p>`;
 
@@ -2283,13 +2351,6 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                 button.disabled = targetId <= 0;
                 button.addEventListener('click', async function(){
                     const action = button.dataset.npcAction;
-                    const ideaField = panels.actions.querySelector('[data-npc-inception-idea]');
-                    const idea = action === 'bgl_inception' ? ideaField.value.trim() : '';
-                    if (action === 'bgl_inception' && !idea) {
-                        actionStatus.textContent = 'Enter a thought before setting Background Life inception.';
-                        actionStatus.classList.add('is-error');
-                        return;
-                    }
 
                     button.disabled = true;
                     actionStatus.textContent = 'Sending action...';
@@ -2298,14 +2359,13 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                         const response = await fetch('../api/chim_npc_manager.php', {
                             method: 'POST',
                             headers: {'Content-Type': 'application/json'},
-                            body: JSON.stringify({operation:'action', action:action, id:targetId, idea:idea})
+                            body: JSON.stringify({operation:'action', action:action, id:targetId})
                         });
                         const payload = await response.json();
                         if (!response.ok || !payload || !payload.success) {
                             throw new Error((payload && payload.error) || ('HTTP ' + response.status));
                         }
                         actionStatus.textContent = (payload.data && payload.data.message) || 'Action sent.';
-                        if (action === 'bgl_inception') ideaField.value = '';
                     } catch (error) {
                         actionStatus.textContent = 'Action failed: ' + (error.message || error);
                         actionStatus.classList.add('is-error');
@@ -2315,6 +2375,241 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                 });
             });
             if (targetId <= 0) actionStatus.textContent = 'Save this NPC before using actions.';
+
+            panels['background-life'].insertAdjacentHTML('beforeend', `
+                <div class="npc-bgl-dashboard span-2" data-npc-bgl-dashboard>
+                    <section class="npc-bgl-section">
+                        <div class="npc-bgl-section-header">
+                            <div><h3>Current Background Life</h3><p>Live status and most recently recorded activity for this NPC.</p></div>
+                            <button type="button" class="npc-bgl-state-button" data-bgl-enrollment disabled>Loading...</button>
+                        </div>
+                        <div class="npc-bgl-summary">
+                            <div class="npc-bgl-summary-item"><span>Status</span><strong data-bgl-summary="status">Loading...</strong></div>
+                            <div class="npc-bgl-summary-item"><span>Current Location</span><strong data-bgl-summary="location">Loading...</strong></div>
+                            <div class="npc-bgl-summary-item"><span>Latest Activity</span><strong data-bgl-summary="activity">Loading...</strong></div>
+                        </div>
+                    </section>
+                    <section class="npc-bgl-section">
+                        <div class="npc-bgl-section-header"><div><h3>Rules</h3><p>Per-NPC controls used by Background Life.</p></div></div>
+                        <div class="npc-bgl-control-grid">
+                            <button type="button" class="npc-bgl-control" data-bgl-setting="auto_actions" disabled><span class="npc-bgl-control-dot"></span><span><strong>Auto Actions</strong><small>Allow scheduled autonomous actions.</small></span></button>
+                            <button type="button" class="npc-bgl-control" data-bgl-setting="send_letters" disabled><span class="npc-bgl-control-dot"></span><span><strong>Send Letters</strong><small>Allow this NPC to send BgL letters.</small></span></button>
+                            <button type="button" class="npc-bgl-control" data-bgl-setting="hourly_tracking" disabled><span class="npc-bgl-control-dot"></span><span><strong>Hourly Tracking</strong><small>Keep the NPC's map location updated.</small></span></button>
+                        </div>
+                    </section>
+                    <section class="npc-bgl-section">
+                        <div class="npc-bgl-section-header"><div><h3>Immediate Actions</h3><p>The game should be running and unpaused when requesting live activity.</p></div></div>
+                        <div class="npc-bgl-request-grid">
+                            <button type="button" class="npc-bgl-request" data-bgl-request="action" disabled>Trigger Action</button>
+                            <button type="button" class="npc-bgl-request" data-bgl-request="letter" disabled>Send Letter</button>
+                            <button type="button" class="npc-bgl-request" data-bgl-request="track" disabled>Update Location</button>
+                        </div>
+                        <div class="npc-bgl-inception">
+                            <textarea data-bgl-inception-idea placeholder="Give this NPC a one-time thought for their next Background Life decision." disabled></textarea>
+                            <button type="button" class="npc-bgl-request" data-bgl-inception disabled>Set Thought</button>
+                        </div>
+                    </section>
+                    <section class="npc-bgl-section">
+                        <div class="npc-bgl-section-header"><div><h3>Recent Activity</h3><p>The five most recent Background Life events.</p></div></div>
+                        <ul class="npc-bgl-events" data-bgl-events><li class="npc-bgl-empty">Loading activity...</li></ul>
+                    </section>
+                    <p class="npc-editor-action-status" data-bgl-message role="status" aria-live="polite"></p>
+                </div>`);
+
+            const bglDashboard = panels['background-life'].querySelector('[data-npc-bgl-dashboard]');
+            const bglMessage = bglDashboard.querySelector('[data-bgl-message]');
+            const enrollmentButton = bglDashboard.querySelector('[data-bgl-enrollment]');
+            const settingButtons = Array.from(bglDashboard.querySelectorAll('[data-bgl-setting]'));
+            const requestButtons = Array.from(bglDashboard.querySelectorAll('[data-bgl-request]'));
+            const inceptionButton = bglDashboard.querySelector('[data-bgl-inception]');
+            const inceptionIdea = bglDashboard.querySelector('[data-bgl-inception-idea]');
+
+            async function npcBglRequest(url, options){
+                const response = await fetch(url, options);
+                let payload = null;
+                try { payload = await response.json(); } catch (_error) {}
+                if (!response.ok || !payload || !payload.success) {
+                    throw new Error((payload && payload.error) || ('HTTP ' + response.status));
+                }
+                return payload;
+            }
+
+            function npcBglPost(url, values){
+                const body = new FormData();
+                Object.entries(values).forEach(function(entry){ body.append(entry[0], entry[1]); });
+                return npcBglRequest(url, {method:'POST', body:body});
+            }
+
+            function setBglMessage(message, isError){
+                bglMessage.textContent = message || '';
+                bglMessage.classList.toggle('is-error', Boolean(isError));
+            }
+
+            function renderBglEvents(events){
+                const list = bglDashboard.querySelector('[data-bgl-events]');
+                list.replaceChildren();
+                if (!events.length) {
+                    const empty = document.createElement('li');
+                    empty.className = 'npc-bgl-empty';
+                    empty.textContent = 'No Background Life activity recorded yet.';
+                    list.appendChild(empty);
+                    return;
+                }
+                events.slice(0, 5).forEach(function(event){
+                    const item = document.createElement('li');
+                    item.className = 'npc-bgl-event';
+                    item.textContent = event.activity || 'Background Life activity';
+                    if (event.tamrielic_time) {
+                        const time = document.createElement('span');
+                        time.className = 'npc-bgl-event-time';
+                        time.textContent = event.tamrielic_time;
+                        item.appendChild(time);
+                    }
+                    list.appendChild(item);
+                });
+            }
+
+            function renderBglStatus(status, events){
+                const enabled = status.background_life_enabled === true;
+                const latest = events[0] || null;
+                bglDashboard.dataset.enabled = enabled ? '1' : '0';
+                enrollmentButton.dataset.enabled = enabled ? '1' : '0';
+                enrollmentButton.textContent = enabled ? 'Background Life On' : 'Background Life Off';
+                enrollmentButton.classList.toggle('is-on', enabled);
+                bglDashboard.querySelector('[data-bgl-summary="status"]').textContent = enabled ? 'Active' : 'Not active';
+                bglDashboard.querySelector('[data-bgl-summary="location"]').textContent = status.location || 'No tracked location';
+                bglDashboard.querySelector('[data-bgl-summary="activity"]').textContent = latest && latest.activity
+                    ? latest.activity
+                    : 'No activity recorded';
+
+                settingButtons.forEach(function(button){
+                    const active = status[button.dataset.bglSetting] === true;
+                    button.dataset.enabled = active ? '1' : '0';
+                    button.classList.toggle('is-on', active);
+                    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+                    button.disabled = !enabled;
+                });
+                requestButtons.forEach(function(button){ button.disabled = !enabled; });
+                inceptionButton.disabled = !enabled;
+                inceptionIdea.disabled = !enabled;
+                renderBglEvents(events);
+            }
+
+            async function loadBglData(){
+                if (targetId <= 0) {
+                    enrollmentButton.disabled = true;
+                    settingButtons.concat(requestButtons, [inceptionButton]).forEach(function(button){ button.disabled = true; });
+                    inceptionIdea.disabled = true;
+                    setBglMessage('Save this NPC before using Background Life controls.', false);
+                    renderBglStatus({background_life_enabled:false}, []);
+                    return;
+                }
+
+                const statusQuery = new URLSearchParams({refid:targetRefId, npc_name:targetName});
+                try {
+                    const statusPayload = await npcBglRequest('../api/background_life_npc.php?' + statusQuery.toString());
+                    let events = [];
+                    try {
+                        const detailQuery = new URLSearchParams({npc:targetName});
+                        const detailPayload = await npcBglRequest('../api/background_life_npc_detail.php?' + detailQuery.toString());
+                        events = Array.isArray(detailPayload.data && detailPayload.data.events) ? detailPayload.data.events : [];
+                    } catch (_error) {}
+                    enrollmentButton.disabled = false;
+                    renderBglStatus(statusPayload.data || {}, events);
+                } catch (error) {
+                    enrollmentButton.disabled = true;
+                    setBglMessage('Could not load Background Life: ' + (error.message || error), true);
+                }
+            }
+
+            enrollmentButton.addEventListener('click', async function(){
+                const enable = enrollmentButton.dataset.enabled !== '1';
+                enrollmentButton.disabled = true;
+                setBglMessage(enable ? 'Adding NPC to Background Life...' : 'Removing NPC from Background Life...', false);
+                try {
+                    const payload = await npcBglPost('../api/background_life_npc.php', {
+                        operation: enable ? 'enable' : 'disable',
+                        refid: targetRefId,
+                        npc_name: targetName
+                    });
+                    renderBglStatus(payload.data || {}, []);
+                    setBglMessage(payload.message || 'Background Life status saved.', false);
+                    await loadBglData();
+                } catch (error) {
+                    setBglMessage('Could not change Background Life: ' + (error.message || error), true);
+                } finally {
+                    enrollmentButton.disabled = false;
+                }
+            });
+
+            settingButtons.forEach(function(button){
+                button.addEventListener('click', async function(){
+                    const value = button.dataset.enabled !== '1';
+                    button.disabled = true;
+                    setBglMessage('Saving Background Life rule...', false);
+                    try {
+                        const payload = await npcBglPost('../api/background_life_npc.php', {
+                            operation:'toggle',
+                            refid:targetRefId,
+                            npc_name:targetName,
+                            setting:button.dataset.bglSetting,
+                            value:value ? '1' : '0'
+                        });
+                        renderBglStatus(payload.data || {}, []);
+                        setBglMessage(payload.message || 'Background Life rule saved.', false);
+                        await loadBglData();
+                    } catch (error) {
+                        setBglMessage('Could not save Background Life rule: ' + (error.message || error), true);
+                    } finally {
+                        button.disabled = bglDashboard.dataset.enabled !== '1';
+                    }
+                });
+            });
+
+            requestButtons.forEach(function(button){
+                button.addEventListener('click', async function(){
+                    button.disabled = true;
+                    setBglMessage('Processing Background Life request...', false);
+                    try {
+                        const payload = await npcBglPost('../api/background_life_request.php', {
+                            request_type:button.dataset.bglRequest,
+                            refid:targetRefId,
+                            npc_name:targetName
+                        });
+                        setBglMessage(payload.message || 'Background Life request processed.', false);
+                        await loadBglData();
+                    } catch (error) {
+                        setBglMessage('Background Life request failed: ' + (error.message || error), true);
+                    } finally {
+                        button.disabled = bglDashboard.dataset.enabled !== '1';
+                    }
+                });
+            });
+
+            inceptionButton.addEventListener('click', async function(){
+                const idea = inceptionIdea.value.trim();
+                if (!idea) {
+                    setBglMessage('Enter a thought before setting Background Life inception.', true);
+                    return;
+                }
+                inceptionButton.disabled = true;
+                setBglMessage('Setting Background Life thought...', false);
+                try {
+                    const payload = await npcBglRequest('../api/chim_npc_manager.php', {
+                        method:'POST',
+                        headers:{'Content-Type':'application/json'},
+                        body:JSON.stringify({operation:'action', action:'bgl_inception', id:targetId, idea:idea})
+                    });
+                    inceptionIdea.value = '';
+                    setBglMessage((payload.data && payload.data.message) || 'Background Life thought saved.', false);
+                } catch (error) {
+                    setBglMessage('Could not set Background Life thought: ' + (error.message || error), true);
+                } finally {
+                    inceptionButton.disabled = bglDashboard.dataset.enabled !== '1';
+                }
+            });
+
+            loadBglData();
 
             const storageKey = tablist.dataset.storageKey || 'npc-editor-tab';
             function activate(section){

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -2329,24 +2329,36 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
             grid.classList.add('npc-editor-panels');
             Object.values(panels).forEach(function(panel){ grid.appendChild(panel); });
 
+            <?php
+            $editorMetadata = json_decode((string)($editItem['metadata'] ?? '{}'), true);
+            $editorReturnLocation = is_array($editorMetadata) && is_array($editorMetadata['npc_manager_return_location'] ?? null)
+                ? $editorMetadata['npc_manager_return_location']
+                : null;
+            ?>
             const targetId = <?= (int)($editItem['id'] ?? 0) ?>;
             const targetName = <?= json_encode((string)($editItem['npc_name'] ?? ''), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
             const targetRefId = <?= json_encode((string)($editItem['refid'] ?? ''), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+            const savedReturnLocation = <?= json_encode($editorReturnLocation, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+            const initialTeleportAction = savedReturnLocation ? 'return' : 'teleport';
+            const initialReturnName = savedReturnLocation && savedReturnLocation.name ? String(savedReturnLocation.name) : '';
             panels.actions.innerHTML = `
-                <p class="npc-editor-action-note">The game must be running and unpaused for Visit and Teleport.</p>
+                <p class="npc-editor-action-note">The game must be running and unpaused for Visit, Teleport, and Return NPC.</p>
                 <div class="npc-editor-action-list">
                     <article class="npc-editor-action-card">
                         <div><h3>Visit</h3><p>Move the player to this NPC's current position.</p></div>
                         <button type="button" class="btn-cancel" data-npc-action="visit">Visit</button>
                     </article>
                     <article class="npc-editor-action-card">
-                        <div><h3>Teleport</h3><p>Move this NPC to the player's current position.</p></div>
-                        <button type="button" class="btn-cancel" data-npc-action="teleport">Teleport</button>
+                        <div><h3 data-npc-teleport-title>${initialTeleportAction === 'return' ? 'Return NPC' : 'Teleport'}</h3><p data-npc-teleport-description>${initialTeleportAction === 'return' ? 'Send this NPC back to ' + (initialReturnName || 'their previous location') + '.' : "Move this NPC to the player's current position and save their previous location."}</p></div>
+                        <button type="button" class="btn-cancel" data-npc-action="${initialTeleportAction}" data-npc-teleport-button>${initialTeleportAction === 'return' ? 'Return NPC' : 'Teleport'}</button>
                     </article>
                 </div>
                 <p class="npc-editor-action-status" data-npc-action-status role="status" aria-live="polite"></p>`;
 
             const actionStatus = panels.actions.querySelector('[data-npc-action-status]');
+            const teleportButton = panels.actions.querySelector('[data-npc-teleport-button]');
+            const teleportTitle = panels.actions.querySelector('[data-npc-teleport-title]');
+            const teleportDescription = panels.actions.querySelector('[data-npc-teleport-description]');
             panels.actions.querySelectorAll('[data-npc-action]').forEach(function(button){
                 button.disabled = targetId <= 0;
                 button.addEventListener('click', async function(){
@@ -2366,6 +2378,16 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                             throw new Error((payload && payload.error) || ('HTTP ' + response.status));
                         }
                         actionStatus.textContent = (payload.data && payload.data.message) || 'Action sent.';
+                        if (button === teleportButton && payload.data && payload.data.next_action) {
+                            const nextAction = payload.data.next_action;
+                            const returnName = payload.data.return_location ? String(payload.data.return_location) : '';
+                            button.dataset.npcAction = nextAction;
+                            button.textContent = nextAction === 'return' ? 'Return NPC' : 'Teleport';
+                            teleportTitle.textContent = nextAction === 'return' ? 'Return NPC' : 'Teleport';
+                            teleportDescription.textContent = nextAction === 'return'
+                                ? 'Send this NPC back to ' + (returnName || 'their previous location') + '.'
+                                : "Move this NPC to the player's current position and save their previous location.";
+                        }
                     } catch (error) {
                         actionStatus.textContent = 'Action failed: ' + (error.message || error);
                         actionStatus.classList.add('is-error');

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -509,6 +509,29 @@ if (!function_exists('chimNpcRelationshipSaveNeedsLock')) {
     }
 }
 
+if (!function_exists('chimMergeBackgroundLifeGoalsIntoPostedExtendedData')) {
+    function chimMergeBackgroundLifeGoalsIntoPostedExtendedData(): void
+    {
+        if (!array_key_exists('background_life_goals', $_POST)) {
+            return;
+        }
+
+        $extendedData = json_decode((string)($_POST['extended_data'] ?? '{}'), true);
+        if (!is_array($extendedData)) {
+            $extendedData = [];
+        }
+
+        $backgroundLifeGoals = trim((string)$_POST['background_life_goals']);
+        if ($backgroundLifeGoals === '') {
+            unset($extendedData['background_life_goals']);
+        } else {
+            $extendedData['background_life_goals'] = $backgroundLifeGoals;
+        }
+
+        $_POST['extended_data'] = json_encode($extendedData, JSON_UNESCAPED_UNICODE);
+    }
+}
+
 if (!function_exists('chimAcquireNpcRelationshipLock')) {
     function chimAcquireNpcRelationshipLock($npcId): ?int
     {
@@ -555,6 +578,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["create"])) {
     if (chimUiAutoLockProfileEnabled()) {
         $_POST['lock_profile'] = 1;
     }
+    chimMergeBackgroundLifeGoalsIntoPostedExtendedData();
     if (file_exists(__DIR__."/../../ext/relationship_system/npc_save_handler.php")) {
         include(__DIR__."/../../ext/relationship_system/npc_save_handler.php");
     }
@@ -580,6 +604,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["update"])) {
         if (chimUiAutoLockProfileEnabled()) {
             $_POST['lock_profile'] = 1;
         }
+        chimMergeBackgroundLifeGoalsIntoPostedExtendedData();
         if (file_exists(__DIR__."/../../ext/relationship_system/npc_save_handler.php")) {
             include(__DIR__."/../../ext/relationship_system/npc_save_handler.php");
         }
@@ -612,6 +637,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["inline_update_npc"]))
     try {
         $id = intval($_POST['id'] ?? 0);
         $relationshipLockId = chimAcquireNpcRelationshipLock($id);
+        chimMergeBackgroundLifeGoalsIntoPostedExtendedData();
 
         // Server-side: extended_data already has feature toggles synced by JS, just ensure it's valid JSON
         // The client-side JS only includes values that differ from profile defaults
@@ -2089,13 +2115,14 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
     <button type="button" class="npc-editor-tab is-active" role="tab" aria-selected="true" data-npc-editor-tab="general">🧭 General</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="bios">📖 Roleplay</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="relationships">🤝 Relationships</button>
+    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="background-life">🌍 Background Life</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="info">🛠️ Info</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="actions">⚡ Actions</button>
 </div>
 <style>
 .npc-editor-tabs {
     display:grid;
-    grid-template-columns:repeat(5, minmax(0, 1fr));
+    grid-template-columns:repeat(6, minmax(0, 1fr));
     gap:8px;
     margin-bottom:14px;
     padding:8px;
@@ -2127,6 +2154,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
 .npc-editor-panels { display:block; }
 .npc-editor-panel[hidden] { display:none !important; }
 .npc-editor-panel[data-npc-editor-panel="bios"] { grid-template-columns:minmax(0, 1fr); }
+.npc-editor-panel[data-npc-editor-panel="background-life"] { grid-template-columns:minmax(0, 1fr); }
 .npc-editor-panel[data-npc-editor-panel="actions"] { grid-template-columns:minmax(0, 1fr); }
 .npc-editor-action-note { margin:0; color:#aaa; font-size:0.86rem; }
 .npc-editor-action-list { display:grid; gap:10px; }
@@ -2158,6 +2186,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
         general: new Set(['npc_name','profile_id','lock_profile','npc_favorite','gender','race','base','refid','oghma_knowledge_tags','worldknowledge_tags','world_knowledge_tags','voiceid','faction','dynamic_profile','middle_term_enabled','individual_memory_enabled','auto_diary_enabled','auto_diary_wait_enabled','salutation_after_a_while','prompt_head']),
         bios: new Set(['core','npc_static_bio','appearance','personality','occupation','skills','speechstyle','goals']),
         relationships: new Set(['relationships','relationships_jsonb','middle_term_latest']),
+        'background-life': new Set(['background_life_goals']),
         info: new Set(['emote_moods','metadata','extended_data']),
         actions: new Set()
     };
@@ -2171,7 +2200,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
             tablist.dataset.initialized = '1';
 
             const panels = {};
-            ['general','bios','relationships','info','actions'].forEach(function(section){
+            ['general','bios','relationships','background-life','info','actions'].forEach(function(section){
                 const panel = document.createElement('div');
                 panel.className = 'npc-editor-panel form-grid';
                 panel.dataset.npcEditorPanel = section;
@@ -2199,7 +2228,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                 const label = unit.querySelector('label:not([for])');
                 if (label && label.textContent.replace(/\s+/g, ' ').trim() === 'Relationships') return 'relationships';
                 const tokens = tokensFor(unit);
-                for (const section of ['relationships','general','bios','info']) {
+                for (const section of ['relationships','general','bios','background-life','info']) {
                     if (tokens.some(function(token){ return fieldSections[section].has(token); })) return section;
                 }
                 return 'info';
@@ -2692,7 +2721,22 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
         <div class="form-item">
             <label for="goals">Goals</label>
             <textarea id="goals" name="goals" placeholder="Short and long-term objectives."><?= htmlspecialchars($editItem["goals"] ?? "") ?></textarea>
-            <small class="hint">Motivations and goals for the NPC.</small>
+            <small class="hint">General motivations and goals used during regular dialogue and Background Life.</small>
+        </div>
+
+        <?php
+        $backgroundLifeGoals = '';
+        if (!empty($editItem['extended_data'])) {
+            $backgroundLifeExtendedData = json_decode((string)$editItem['extended_data'], true);
+            if (is_array($backgroundLifeExtendedData)) {
+                $backgroundLifeGoals = trim((string)($backgroundLifeExtendedData['background_life_goals'] ?? ''));
+            }
+        }
+        ?>
+        <div class="form-item span-2">
+            <label for="background_life_goals">Background Life Goals</label>
+            <textarea id="background_life_goals" name="background_life_goals" placeholder="Goals, plans, or production rules for this NPC's Background Life."><?= htmlspecialchars($backgroundLifeGoals) ?></textarea>
+            <small class="hint">Used only for Background Life decisions. This content is not included in regular dialogue prompts.</small>
         </div>
 
 
@@ -3020,6 +3064,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                 'individual_memory_enabled',
                 'auto_diary_enabled',
                 'auto_diary_wait_enabled',
+                'background_life_goals',
                 'chim_core_migrated',
                 'salutation_after_a_while',
                 'relationships',


### PR DESCRIPTION
## Summary
- add a dedicated Background Life tab and goals field to the NPC editor
- show current Background Life enrollment, tracked location, latest activity, and five recent events
- expose per-NPC auto actions, letters, and hourly tracking controls
- expose trigger action, send letter, update location, and one-time inception controls
- inject dedicated Background Life goals only into Background Life prompt builders
- store newly generated Background Life NPC goals outside regular dialogue goals
- save an NPC's tracked location before Teleport and replace the action with Return NPC
- return teleported NPCs through the existing CHIM location-marker command, then restore the Teleport action

## Compatibility
- no database migration or CHIM DLL/Papyrus change
- return points are stored in existing NPC metadata and only the temporary key is updated
- existing profile import/export and NPC history retain the Background Life goals field through extended metadata
- existing general NPC goals remain available to Background Life
- existing goals are not automatically migrated

## Validation
- PHP lint passed for all changed PHP files
- BackgroundLifeCooldownTest.php passed: 5 tests, 6 assertions
- NPC editor, NPC manager API, and Background Life API endpoints returned HTTP 200
- live local UI loaded Background Life status and controls
- browser test confirmed saved return state renders an enabled Return NPC button with its destination and restores to Teleport after metadata restoration
- transaction-isolated API test confirmed Teleport saves the return point, Return NPC clears it, both queue commands, and the transaction rolls back cleanly
- Return NPC without a saved point fails cleanly with HTTP 400
- exact source/runtime hashes matched after local deployment
- browser console reported no warnings or errors

## Deployment
- deployed server-only to /var/www/html/HerikaServer

## Related CHIM PR
- Dwemer-Dynamics/CHIM#105

## Not Tested
- live in-game Teleport/Return NPC movement was not invoked
- Return NPC targets the saved Skyrim location marker rather than exact raw coordinates
- immediate Trigger Action, Send Letter, Update Location, and inception requests were not invoked against a running game/LLM
