### PR TITLE
Hide addbgnpc from default Event Log

### DIFF
--- a/lib/eventlog_helper.php
+++ b/lib/eventlog_helper.php
@@ -10,6 +10,7 @@ if (!function_exists('chimGetVisibleEventLogExcludedTypes')) {
             'request',
             'infonpc_close',
             'addnpc',
+            'addbgnpc',
             'user_input',
             'infosave',
             'init',


### PR DESCRIPTION
## Summary
- Hide `addbgnpc` events from the default Event Log view.
- Keep the events stored in the database for runtime use and diagnostics.
- Apply the exclusion through the shared Event Log helper so the page, live refresh, pagination, and visible-row operations stay consistent.

## Validation
- `php -l lib/eventlog_helper.php`
- Focused helper probe confirmed the generated default Event Log SQL excludes `addbgnpc`.
- `git diff --check`

## Deployment
- Not deployed; this is a server-side display filter only.