### PR TITLE
Fix Chrome STT request parsing

### DIFF
--- a/ui/addons/pmstt/PlayerSays.php
+++ b/ui/addons/pmstt/PlayerSays.php
@@ -27,10 +27,10 @@ require_once($enginePath . "lib" .DIRECTORY_SEPARATOR."rolemaster_helpers.php");
 
 $db = $GLOBALS["db"];
 
-if ($argv[1]) {
-    $speech=$db->escape($argv[1]);
-} else if ($_GET["speech"]) {
+if (isset($_GET["speech"]) && is_string($_GET["speech"]) && trim($_GET["speech"]) !== "") {
     $speech=$db->escape($_GET["speech"]);
+} else if (isset($argv) && is_array($argv) && isset($argv[1])) {
+    $speech=$db->escape($argv[1]);
 } else
     die("No speech".PHP_EOL);
 


### PR DESCRIPTION
## Problem
Chrome STT succeeds but emits PHP warnings because its HTTP endpoint reads the CLI-only `$argv` variable before checking the query-string speech value.

## Changes
- Prefer the HTTP `speech` query parameter when present.
- Retain the existing CLI argument fallback without reading an undefined variable.

## Validation
- `php -l ui/addons/pmstt/PlayerSays.php` passed.
- `git diff --check` passed.

## Deployment
Not deployed.

## Manual limits
The endpoint has not been exercised against a live game/database from this branch.

## Related
- CHIM runtime fix: https://github.com/Dwemer-Dynamics/CHIM/pull/111