### PR TITLE
Prevent incremental event log cursor gaps

### DIFF
--- a/ui/api/eventlog.php
+++ b/ui/api/eventlog.php
@@ -69,14 +69,18 @@ if ($sinceGamets > 0) {
          LIMIT $limit"
     );
 } else if ($sinceRowId > 0) {
-    // Filter by rowid - for incremental updates
+    // Read the next contiguous rowid window so advancing the cursor cannot skip older rows in a burst.
     $results = $db->fetchAll(
         "SELECT type, data, people, gamets, localts, ts, rowid
-         FROM eventlog a
-         WHERE $typeFilter
-         AND rowid > $sinceRowId
-         ORDER BY gamets DESC, ts DESC, localts DESC, rowid DESC
-         LIMIT 50"
+         FROM (
+             SELECT type, data, people, gamets, localts, ts, rowid
+             FROM eventlog a
+             WHERE $typeFilter
+             AND rowid > $sinceRowId
+             ORDER BY rowid ASC
+             LIMIT $limit
+         ) incremental_events
+         ORDER BY gamets DESC, ts DESC, localts DESC, rowid DESC"
     );
 } else {
     // Normal paginated query - get most recent events by game timestamp (gamets)


### PR DESCRIPTION
Discord source: [Open Discord message](https://discord.com/channels/1109612896482246826/1431699495480987731/1534251931646562524)

## Summary

- fetch the next contiguous row-ID window for incremental Event Log reads
- preserve the existing game-time display order after selecting that window
- prevent the CHIM recent-context cursor from permanently skipping events during bursts larger than the fetch limit

## Root cause

The incremental query applied its limit after sorting by game time. CHIM advances the cursor to the highest row ID returned, so any lower row IDs omitted by that game-time slice could never be requested again.

## Validation

- `php -l ui/api/eventlog.php`
- `git diff --check origin/unstable..HEAD`
- PostgreSQL transaction probe: the prior query returned rows 111-160 from a 60-row burst; the patched query returned 101-150 and then 151-160, with all 60 row IDs unique
- `chim-unstable-push-guard` on `origin/unstable..HEAD`: deterministic checks passed

## Deployment and limits

Not deployed. The installed local deployment pipeline hardcodes the dirty canonical HerikaServer checkout and has no feature-worktree source option, so deploying it would not verify this branch safely.

Manual in-game validation is still needed for an event burst larger than 50 rows and the Events tab refresh path.