### PR TITLE
Recover Background Life processor during active play

### DIFF
--- a/lib/background_processor.php
+++ b/lib/background_processor.php
@@ -129,3 +129,45 @@ function herikaEnsureBackgroundProcessorRunning(bool $logFailures = true): bool
 
     return false;
 }
+
+/**
+ * Periodically verify the processor while game requests are active.
+ *
+ * A shared lock file keeps concurrent PHP requests from probing or starting the
+ * daemon together. The timestamp is written before the probe so a failed start
+ * is retried on the next interval instead of causing a request storm.
+ */
+function herikaMaintainBackgroundProcessorRunning(int $intervalSeconds = 30): bool
+{
+    $intervalSeconds = max(5, min(300, $intervalSeconds));
+    $lockPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'herika_background_processor_maintenance.lock';
+    $lockHandle = @fopen($lockPath, 'c+');
+
+    if (!is_resource($lockHandle)) {
+        return herikaEnsureBackgroundProcessorRunning(true);
+    }
+
+    if (!@flock($lockHandle, LOCK_EX | LOCK_NB)) {
+        @fclose($lockHandle);
+        return true;
+    }
+
+    try {
+        @rewind($lockHandle);
+        $lastCheck = (int) trim((string) @stream_get_contents($lockHandle));
+        $now = time();
+        if ($lastCheck > 0 && ($now - $lastCheck) < $intervalSeconds) {
+            return true;
+        }
+
+        @ftruncate($lockHandle, 0);
+        @rewind($lockHandle);
+        @fwrite($lockHandle, (string) $now);
+        @fflush($lockHandle);
+
+        return herikaEnsureBackgroundProcessorRunning(true);
+    } finally {
+        @flock($lockHandle, LOCK_UN);
+        @fclose($lockHandle);
+    }
+}

--- a/main.php
+++ b/main.php
@@ -160,9 +160,9 @@ $db = $GLOBALS["db"] ?? new sql();
 $GLOBALS["db"] = $db;
 
 if (PHP_SAPI !== 'cli' && !getenv('PHPUNIT_TEST') && $gameRequest[0] !== 'request') {
-    $player2NewGameSession = chimPlayer2HealthMarkGameActivity();
-    if ($player2NewGameSession && function_exists('herikaEnsureBackgroundProcessorRunning')) {
-        herikaEnsureBackgroundProcessorRunning(false);
+    chimPlayer2HealthMarkGameActivity();
+    if (function_exists('herikaMaintainBackgroundProcessorRunning')) {
+        herikaMaintainBackgroundProcessorRunning();
     }
 }
 


### PR DESCRIPTION
## Problem
The Background Life processor could exit during a long play session and remain down. HerikaServer previously checked it only when detecting a new game session, so later game traffic did not recover the daemon.

## Changes
- Add a shared, throttled processor maintenance check.
- Run the check during normal active-game requests, not only session startup.
- Use a lock file to prevent concurrent requests from probing or starting the processor together.
- Retain the existing singleton and TCP health checks.

## Validation
- `php -l main.php`
- `php -l lib/background_processor.php`
- `BackgroundProcessorSingletonTest`: 2 tests, 8 assertions passed.
- Deployed with the related repetition/warning guard PR to local HerikaServer.
- Verified deployed hashes, Apache HTTP 200, and the processor listening on port 12345.

## Notes
PHPUnit also reports a pre-existing test-discovery warning because `OghmaContextRulesTest.php` does not contain the expected class.