### PR TITLE
Add exact event deletion endpoint for Prisma

### DIFF
--- a/lib/eventlog_helper.php
+++ b/lib/eventlog_helper.php
@@ -170,3 +170,44 @@ if (!function_exists('chimDeleteLatestVisibleEventLogRows')) {
         ];
     }
 }
+
+if (!function_exists('chimDeleteEventLogRow')) {
+    function chimDeleteEventLogRow($db, $rowId)
+    {
+        $rowId = intval($rowId);
+        if ($rowId <= 0) {
+            return [
+                'ok' => false,
+                'deleted_count' => 0,
+                'message' => 'Invalid event row.',
+            ];
+        }
+
+        $visibleWhereClause = chimBuildVisibleEventLogWhereClause($db);
+        $existing = $db->fetchOne("SELECT rowid FROM eventlog WHERE rowid={$rowId} AND {$visibleWhereClause} LIMIT 1");
+        if (!$existing) {
+            return [
+                'ok' => true,
+                'rowid' => $rowId,
+                'deleted_count' => 0,
+                'message' => 'Event is no longer available.',
+            ];
+        }
+
+        if (!$db->delete('eventlog', "rowid={$rowId}")) {
+            return [
+                'ok' => false,
+                'rowid' => $rowId,
+                'deleted_count' => 0,
+                'message' => 'Failed to delete event.',
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'rowid' => $rowId,
+            'deleted_count' => 1,
+            'message' => 'Event deleted.',
+        ];
+    }
+}

--- a/ui/cmd/action_delete_event.php
+++ b/ui/cmd/action_delete_event.php
@@ -1,0 +1,50 @@
+<?php
+
+error_reporting(E_ALL);
+ini_set('display_errors', 0);
+ini_set('log_errors', 1);
+header('Content-Type: application/json');
+
+$enginePath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+
+require_once($enginePath . 'lib' . DIRECTORY_SEPARATOR . 'runtime_bootstrap.php');
+chimRuntimeBootstrap($enginePath, [
+    'load_general_settings' => true,
+    'load_player_name' => true,
+    'load_narrator' => true,
+]);
+
+require_once($enginePath . 'lib' . DIRECTORY_SEPARATOR . 'eventlog_helper.php');
+
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+    http_response_code(405);
+    echo json_encode([
+        'ok' => false,
+        'message' => 'POST required.',
+    ]);
+    exit;
+}
+
+$rowId = intval($_POST['rowid'] ?? 0);
+if ($rowId <= 0) {
+    http_response_code(400);
+    echo json_encode([
+        'ok' => false,
+        'message' => 'Invalid event row.',
+    ]);
+    exit;
+}
+
+try {
+    $result = chimDeleteEventLogRow($GLOBALS['db'], $rowId);
+    if (empty($result['ok'])) {
+        http_response_code(500);
+    }
+    echo json_encode($result);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode([
+        'ok' => false,
+        'message' => 'Failed to delete event.',
+    ]);
+}

--- a/ui/cmd/action_delete_recent_events.php
+++ b/ui/cmd/action_delete_recent_events.php
@@ -26,7 +26,7 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
 }
 
 $deleteCount = intval($_POST['count'] ?? 0);
-if (!in_array($deleteCount, [20, 50, 100], true)) {
+if (!in_array($deleteCount, [5, 10, 20, 50, 100], true)) {
     http_response_code(400);
     echo json_encode([
         'ok' => false,

--- a/ui/events-memories.php
+++ b/ui/events-memories.php
@@ -410,7 +410,7 @@ if (isset($_GET["cleanlog"]) && $_GET["cleanlog"]) {
 // Handle delete_last for event log
 if (isset($_GET['delete_last'])) {
     $delCount = (int)$_GET['delete_last'];
-    if (in_array($delCount, [20, 50, 100])) {
+    if (in_array($delCount, [5, 10, 20, 50, 100], true)) {
         $deleteResult = chimDeleteLatestVisibleEventLogRows($db, $delCount, '', $eventLogHiddenTypes);
         $deletedCount = intval($deleteResult['deleted_count'] ?? 0);
         $redirectParams = $eventLogCurrentPageParams;
@@ -606,7 +606,8 @@ function getTimeColor($time) {
             echo "<button id='deleteSelectedBtn' onclick='deleteSelectedEvents()' class='btn-base btn-danger' style='padding: 6px 10px; font-size: 0.8em; display: none;'>🗑️ Delete Selected (<span id='selectedCount'>0</span>)</button>";
             echo "<div style='display: inline-flex; gap: 5px; align-items: center; flex-wrap: nowrap; white-space: nowrap;'>";
             echo "<select id='delete-action-select' style='padding: 5px 8px; border-radius: 4px; border: 1px solid #666; background: #2a2a2a; color: #f8f9fa; min-width: 170px; font-size: 0.8em;'>";
-            echo "<option value=''>Delete...</option>";
+            echo "<option value='5' selected>Delete Latest 5</option>";
+            echo "<option value='10'>Delete Latest 10</option>";
             echo "<option value='20'>Delete Latest 20</option>";
             echo "<option value='50'>Delete Latest 50</option>";
             echo "<option value='100'>Delete Latest 100</option>";
@@ -2090,7 +2091,7 @@ function handleDeletePresetAction() {
     }
 
     const deleteCount = parseInt(action, 10);
-    if (![20, 50, 100].includes(deleteCount)) {
+    if (![5, 10, 20, 50, 100].includes(deleteCount)) {
         if (select) {
             select.value = '';
         }


### PR DESCRIPTION
## Summary
- add a POST-only endpoint for deleting one persisted `eventlog` row by numeric `rowid`
- restrict individual deletion to event types exposed by CHIM's visible context APIs
- return idempotent JSON when a row has already disappeared
- add latest 5 and latest 10 bulk deletion presets to the PHP Event Log and in-game endpoint
- make latest 5 the default Event Log selection

## Compatibility
- no schema migration
- no diary or memory cascade; only selected `eventlog` rows are removed

## Paired CHIM PR
- https://github.com/Dwemer-Dynamics/CHIM/pull/114

## Validation
- `php -l` for all four event-log files
- `git diff --check`
- deployed from the exact feature commit to local WSL HerikaServer; source and destination hashes match
- PHP Event Log returned HTTP 200 and rendered latest 5 as selected with latest 10 available
- recent-delete endpoint rejected unsupported count 7 with HTTP 400
- disposable visible event row was deleted through HTTP and verified absent in PostgreSQL
- disposable hidden event row was refused and preserved, then manually cleaned up

## Limits
- Prisma interaction still requires in-game manual testing