### PR TITLE
Prevent autonomous Director dialogue from running out of order

### DIFF
--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -7662,6 +7662,34 @@ if ($checkVersion("prompts") < 20260727001) {
     }
 }
 
+if ($checkVersion("prompts") < 20260805001) {
+    Logger::debug("Applying prompts 20260805001 - keep bored Director dialogue chronological");
+
+    require_once(__DIR__ . "/../lib/rolemaster_bored.php");
+    $boredEventRules = $db->escape(chimRolemasterDefaultBoredEventRules());
+    $description = $db->escape(
+        "Additional Rolemaster rules used only for autonomous bored events. "
+        . "Supports {SEED_ACTOR_RULE}, {SEED_ACTOR}, {NEARBY_ACTORS}, and {PLAYER_NAME} placeholders. "
+        . "Used in: service/processors/rolemaster/cmd/instruction.php"
+    );
+
+    $migrationOk = $db->execQuery("
+        INSERT INTO public.prompts (prompt_key, default_prompt, description)
+        VALUES ('director_bored_event_rules', '{$boredEventRules}', '{$description}')
+        ON CONFLICT (prompt_key) DO UPDATE SET
+            default_prompt = EXCLUDED.default_prompt,
+            description = EXCLUDED.description,
+            updated_at = CURRENT_TIMESTAMP
+    ") !== false;
+
+    if ($migrationOk) {
+        $updateVersion("prompts", 20260805001);
+        Logger::info("Applied patch prompts 20260805001 - kept bored Director dialogue chronological");
+    } else {
+        Logger::error("Failed to apply patch prompts 20260805001");
+    }
+}
+
 if ($checkVersion("memory_summary") < 20260721001) {
     Logger::debug("Applying memory_summary 20260721001 - normalize diary memory owners");
 

--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -879,15 +879,22 @@ function DataDequeue($timestamp = 0)
     } else {
         $clause="";
     }
-    // Use atomic UPDATE...RETURNING to prevent race conditions where multiple concurrent
-    // requests could fetch the same dialogue before it's marked as sent
+    // Claim pending responses atomically, then return them in their original queue order.
     $results = $db->fetchAll(
-        "UPDATE responselog 
-         SET sent=1 
-         WHERE rowid IN (
-             SELECT rowid FROM responselog WHERE sent=0 $clause ORDER BY rowid ASC
+        "WITH queued AS (
+             SELECT rowid
+             FROM responselog
+             WHERE sent=0 $clause
+             ORDER BY rowid ASC
+             FOR UPDATE SKIP LOCKED
+         ), claimed AS (
+             UPDATE responselog AS response
+             SET sent=1
+             FROM queued
+             WHERE response.rowid=queued.rowid
+             RETURNING response.*
          )
-         RETURNING *, rowid"
+         SELECT * FROM claimed ORDER BY rowid ASC"
     );
     
     $finalData = array();

--- a/lib/rolemaster_bored.php
+++ b/lib/rolemaster_bored.php
@@ -38,7 +38,6 @@ function chimRolemasterBoredCanonicalActor(string $actorName, array $actorMap): 
 
 function chimRolemasterFilterBoredInstructions(array $instructions, array $actorMap, string $seedActor): array
 {
-    $valid = [];
     $seedInstruction = null;
 
     foreach ($instructions as $instruction) {
@@ -52,22 +51,12 @@ function chimRolemasterFilterBoredInstructions(array $instructions, array $actor
         }
 
         $instruction['character'] = $canonicalActor;
-        if ($seedActor !== '' && strcasecmp($canonicalActor, $seedActor) === 0) {
+        if ($seedActor !== '' && strcasecmp($canonicalActor, $seedActor) === 0 && $seedInstruction === null) {
             $seedInstruction = $instruction;
-        } else {
-            $valid[] = $instruction;
         }
     }
 
-    if ($seedActor !== '' && $seedInstruction === null) {
-        return [];
-    }
-
-    if ($seedInstruction !== null) {
-        array_unshift($valid, $seedInstruction);
-    }
-
-    return $valid;
+    return $seedInstruction === null ? [] : [$seedInstruction];
 }
 
 function chimRolemasterBoredListenerRequirement(string $target, array $actorMap): string
@@ -90,6 +79,7 @@ function chimRolemasterDefaultBoredEventRules(): string
 * Do not target or comment on {PLAYER_NAME} merely because time passed or the player is idle.
 * Prefer a natural NPC-to-NPC interaction or scene action. Involve the player only when recent player activity clearly requires a response.
 * When an instruction targets another nearby actor, direct the dialogue to that actor.
+* Do not generate the listener's reply. Normal dialogue routing will let the listener respond after the initiating actor speaks.
 PROMPT;
 }
 
@@ -106,7 +96,7 @@ function chimRolemasterRenderBoredEventRules(
     $seedActor = trim($seedActor);
     $seedActorRule = $seedActor === ''
         ? ''
-        : "* The first instruction must use the selected initiating actor: {$seedActor}.";
+        : "* Return exactly one instruction, using the selected initiating actor: {$seedActor}.";
     $nearbyActors = implode(', ', array_values($actorMap));
 
     $rendered = str_replace(

--- a/service/processors/rolemaster/cmd/instruction.php
+++ b/service/processors/rolemaster/cmd/instruction.php
@@ -300,9 +300,17 @@ user request: actor \"a\" leaves the place
             $instructionText = trim($response["instruction"] ?? 'No instruction text');
             $action = !empty($response["action"]) ? "{$response["action"]} " . ($response["target"] ?? "") : "";
             if (!empty($GLOBALS["ROLEMASTER_BORED_MODE"])) {
+                $canonicalListener = chimRolemasterBoredCanonicalActor(
+                    (string)($response["target"] ?? ""),
+                    $GLOBALS["ROLEMASTER_BORED_ALLOWED_ACTORS"] ?? []
+                );
                 $instructionText .= chimRolemasterBoredListenerRequirement(
                     (string)($response["target"] ?? ""),
                     $GLOBALS["ROLEMASTER_BORED_ALLOWED_ACTORS"] ?? []
+                );
+                Logger::info(
+                    "Queued bored rolemaster instruction for '{$characterName}'"
+                    . ($canonicalListener === null ? " without a valid listener" : " with listener '{$canonicalListener}'")
                 );
             }
         
@@ -379,7 +387,11 @@ user request: actor \"a\" leaves the place
                 if (empty($response["instructions"])) {
                     Logger::warn("Discarded bored rolemaster response because it omitted the selected actor or used no eligible nearby actors");
                 } elseif (count($response["instructions"]) !== $originalInstructionCount) {
-                    Logger::warn("Removed invalid or off-scene actors from bored rolemaster response");
+                    $discardedCount = $originalInstructionCount - count($response["instructions"]);
+                    Logger::info(
+                        "Discarded {$discardedCount} secondary or invalid bored rolemaster instruction(s); "
+                        . "the listener will respond through normal dialogue routing"
+                    );
                 }
             }
             $allOk=!empty($response["instructions"]);

--- a/unittests/tests/RolemasterBoredRoutingTest.php
+++ b/unittests/tests/RolemasterBoredRoutingTest.php
@@ -31,9 +31,9 @@ final class RolemasterBoredRoutingTest extends TestCase
 
         $filtered = chimRolemasterFilterBoredInstructions($instructions, $actors, 'Camilla Valerius');
 
-        $this->assertCount(2, $filtered);
+        $this->assertCount(1, $filtered);
         $this->assertSame('Camilla Valerius', $filtered[0]['character']);
-        $this->assertSame('Lucan Valerius', $filtered[1]['character']);
+        $this->assertSame('Answer Lucan', $filtered[0]['instruction']);
         $this->assertSame(
             [],
             chimRolemasterFilterBoredInstructions(
@@ -72,7 +72,11 @@ final class RolemasterBoredRoutingTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            'The first instruction must use the selected initiating actor: Camilla Valerius.',
+            'Return exactly one instruction, using the selected initiating actor: Camilla Valerius.',
+            $rules
+        );
+        $this->assertStringContainsString(
+            "Do not generate the listener's reply.",
             $rules
         );
         $this->assertStringContainsString(


### PR DESCRIPTION
## Problem
Autonomous Director/bored scenes could pre-generate both sides of an NPC exchange. Secondary instructions could be delivered before the selected initiating NPC, making a listener answer dialogue that had not appeared or been spoken.

## Root cause
- Bored Rolemaster responses retained instructions for the seed actor and additional actors.
- `DataDequeue()` selected pending rows by `rowid`, but PostgreSQL did not guarantee the order of rows returned by `UPDATE ... RETURNING`.

## Changes
- Keep exactly one autonomous bored-event instruction for the selected initiating actor.
- Preserve the intended nearby listener so normal dialogue routing/rechat generates the reply after the initiating line.
- Update the Prompt Manager default while preserving custom prompts.
- Claim and return pending `responselog` rows atomically in ascending `rowid` order.
- Add focused diagnostics for the initiating actor, listener, and discarded secondary instructions.

## Migration
Idempotent `prompts` migration `20260805001` updates only the default bored-event rules and description. Existing `custom_prompt` values are preserved.

## Validation
- PHP lint passed for all five changed PHP files.
- Existing `RolemasterBoredRoutingTest.php`: `OK (5 tests, 16 assertions)`.
- Rollback-only PostgreSQL probe returned queued rows in deterministic order: `10:first`, `20:second`, `30:third`.
- Focused local server deployment succeeded; migration applied and Apache restarted.
- Local HerikaServer UI probe returned HTTP 200.

## Limits
Not tested in-game. Manual, user-triggered multi-actor Director commands remain unchanged; this PR targets autonomous bored-event chronology.