### PR TITLE
Keep player input in context when game time is frozen

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -2591,8 +2591,9 @@ function buildHistoricContext($actor, $lastNelements = -10,$sqlfilter="") {
     )
     " : " ").
     //((false)?" and gamets>".($currentGameTs-(60*60*60*60)):"").
+    // Use insertion order because Skyrim game time can remain frozen while new dialogue arrives.
     " {$ext_sqlfilter2} 
-    ORDER BY gamets desc, ts desc, rowid desc LIMIT {$nRecordsLimit} OFFSET 0 ";
+    ORDER BY rowid desc LIMIT {$nRecordsLimit} OFFSET 0 ";
     
     // error_log("[BGL] $query");   
     // Keep generic far-away actors out of historic context. Shared narrator rows are flattened on write.


### PR DESCRIPTION
## Problem

When Skyrim's timescale is set to 0, `gamets` stops advancing while NPC `prechat` and `chat` rows retain their synthetic +1/+2 values. `buildHistoricContext()` therefore keeps ranking NPC rows above newer player input until the bounded history window excludes the player entirely.

Discord source: [Open Discord thread](https://discord.com/channels/1109612896482246826/1534586971077218334/1534586971077218334)

## Change

- Select historic-context rows by descending eventlog `rowid`, which represents server insertion order.
- Keep the existing reverse step so the final prompt remains chronological.

## Validation

- `php -l lib/data_functions.php`: passed.
- `git diff --check`: passed.
- Rollback-only PostgreSQL probe: the old ordering selected four older NPC rows; `rowid DESC` selected the latest player input first.
- Existing `HistoricContextTest.php`: blocked by a pre-existing `sql::escapeLiteral()` error; the same failure reproduces unchanged on current `origin/unstable`.
- Deployed the exact feature file to the local HerikaServer runtime; SHA-256 matched and the UI returned HTTP 200 on the configured Apache port.

## Coordination and limits

- PR #568 also edits `buildHistoricContext()` for listener filtering, but does not change history ordering or cover frozen timescale behavior.
- DialecticServer retains an analogous query, but this report and evidence are CHIM-specific, so no cross-product change is included.
- Not tested in Skyrim.