### PR TITLE
Improve Background Life map activity display

### DIFF
--- a/lib/background_life_dashboard.php
+++ b/lib/background_life_dashboard.php
@@ -63,6 +63,70 @@ function chimBglHistoryCategory(string $activity): string
     return 'activity';
 }
 
+function chimBglActivityCategory(string $category, string $activity = ''): string
+{
+    $category = strtolower(trim($category));
+    if ($category === '') {
+        $category = chimBglHistoryCategory($activity);
+    }
+
+    return [
+        'rest' => 'sleep',
+        'social' => 'socialize',
+        'movement' => 'travel',
+    ][$category] ?? $category;
+}
+
+function chimBglActivityIcon(string $category, string $activity = ''): string
+{
+    $category = chimBglActivityCategory($category, $activity);
+
+    return [
+        'error' => '❌',
+        'work' => '🛠️',
+        'travel' => '👣',
+        'sleep' => '😴',
+        'produce_consume' => '🍽️',
+        'socialize' => '🥂',
+        'dialogue' => '💬',
+        'relax' => '🪑',
+        'trade' => '💰',
+        'guard' => '🛡️',
+        'move' => '🚶',
+        'return_home' => '🏠',
+        'find' => '🔎',
+        'give' => '🎁',
+        'letter' => '✉️',
+        'warning' => '⚠️',
+        'activity' => '✨',
+    ][$category] ?? '✨';
+}
+
+function chimBglActivityLabel(string $category, string $activity = ''): string
+{
+    $category = chimBglActivityCategory($category, $activity);
+
+    return [
+        'error' => 'Error',
+        'work' => 'Work',
+        'travel' => 'Travel',
+        'sleep' => 'Sleep',
+        'produce_consume' => 'Produce / Consume',
+        'socialize' => 'Socialize',
+        'dialogue' => 'Dialogue',
+        'relax' => 'Relax',
+        'trade' => 'Trade',
+        'guard' => 'Guard',
+        'move' => 'Move',
+        'return_home' => 'Return Home',
+        'find' => 'Find',
+        'give' => 'Give',
+        'letter' => 'Letter',
+        'warning' => 'Warning',
+        'activity' => 'Activity',
+    ][$category] ?? ucwords(str_replace('_', ' ', $category));
+}
+
 // Keep the dashboard usable while an existing install is waiting for migrations.
 function chimBglHistoryCategorySelect(sql $db): string
 {
@@ -179,6 +243,10 @@ function chimBglDashboardPayload(sql $db, string $enginePath, string $webRoot, b
     $where = $showAllCoords
         ? "master.metadata->>'last_coords' IS NOT NULL"
         : "COALESCE(master.extended_data->>'background_life_enabled', 'false') = 'true'";
+    $categorySelect = chimBglHistoryCategorySelect($db);
+    $latestCategorySelect = $categorySelect === ''
+        ? 'NULL::text AS category'
+        : 'history.category AS category';
     $rows = $db->fetchAll(
         "SELECT master.id,
                 master.npc_name,
@@ -187,10 +255,11 @@ function chimBglDashboardPayload(sql $db, string $enginePath, string $webRoot, b
                 master.metadata,
                 master.extended_data,
                 latest.data AS latest_activity,
-                latest.gamets AS latest_gamets
+                latest.gamets AS latest_gamets,
+                latest.category AS latest_category
          FROM core_npc_master master
          LEFT JOIN LATERAL (
-             SELECT history.data, history.gamets
+             SELECT history.data, history.gamets, {$latestCategorySelect}
              FROM bgl_history history
              WHERE history.npc = master.npc_name
              ORDER BY history.gamets DESC, history.ts DESC, history.rowid DESC
@@ -215,6 +284,11 @@ function chimBglDashboardPayload(sql $db, string $enginePath, string $webRoot, b
         $npcName = trim((string)($row['npc_name'] ?? 'Unknown NPC'));
         $refid = chimBglNormalizeRefId((string)($row['refid'] ?? ''));
         $latestGamets = (int)($row['latest_gamets'] ?? 0);
+        $latestActivity = trim((string)($row['latest_activity'] ?? ''));
+        $activityCategory = chimBglActivityCategory(
+            (string)($row['latest_category'] ?? ''),
+            $latestActivity
+        );
 
         $npcs[] = [
             'npc_id' => (int)($row['id'] ?? 0),
@@ -229,7 +303,10 @@ function chimBglDashboardPayload(sql $db, string $enginePath, string $webRoot, b
                 $npcName,
                 $metadata
             ),
-            'activity' => trim((string)($row['latest_activity'] ?? '')),
+            'activity' => $latestActivity,
+            'activity_category' => $activityCategory,
+            'activity_icon' => chimBglActivityIcon($activityCategory, $latestActivity),
+            'activity_label' => chimBglActivityLabel($activityCategory, $latestActivity),
             'tamrielic_time' => $latestGamets > 0 ? convert_gamets2skyrim_long_date2($latestGamets) : '',
             'gamets' => $latestGamets,
             'auto_actions' => chimBglBoolean($extended['background_life_commands'] ?? false),

--- a/ui/js/background_life_history.js
+++ b/ui/js/background_life_history.js
@@ -67,8 +67,7 @@
         function renderCamera() {
             clampPan();
             canvas.style.transform = 'translate3d(' + state.x + 'px, ' + state.y + 'px, 0) scale(' + state.scale + ')';
-            canvas.style.setProperty('--bgl-marker-scale', String(1 / state.zoom));
-            canvas.style.setProperty('--bgl-marker-hover-scale', String(1.1 / state.zoom));
+            canvas.style.setProperty('--bgl-info-scale', String(1 / state.zoom));
             zoomValue.textContent = Math.round(state.zoom * 100) + '%';
         }
 

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -28,6 +28,7 @@ require_once $enginePath . 'lib/rolemaster_helpers.php';
 require_once $enginePath . 'lib/scriptproxy_papyrus.php';
 require_once $enginePath . 'lib/background_life_requests.php';
 require_once $enginePath . 'lib/background_life_npc_creation.php';
+require_once $enginePath . 'lib/background_life_dashboard.php';
 require_once $enginePath . 'lib/core/player.class.php';
 require_once $enginePath . 'lib/core/npc_master.class.php';
 require_once $enginePath . 'lib/core/api_badge.class.php';
@@ -708,9 +709,13 @@ if ($bglBulkResult && ($bglBulkRow = pg_fetch_assoc($bglBulkResult))) {
     $whereClause = $showAllCoords
         ? "metadata->>'last_coords' IS NOT NULL"
         : "extended_data->>'background_life_enabled' = 'true'";
+    $categorySelect = chimBglHistoryCategorySelect($db);
+    $latestCategorySelect = $categorySelect === ''
+        ? 'NULL::text AS category'
+        : 'history.category AS category';
 
     $query = "
-    select A.*,B.content FROM 
+    select A.*,B.content,C.data as last_activity,C.gamets as last_activity_gamets,C.category as last_action_cat FROM
     (SELECT
         npc_name,metadata,extended_data,id,refid,race,extended_data->>'background_life_last_updated' as last_report,
         metadata->>'last_coords' as last_coords,metadata->>'last_coords_history' as last_coords_history
@@ -734,6 +739,13 @@ if ($bglBulkResult && ($bglBulkRow = pg_fetch_assoc($bglBulkResult))) {
         ) t
         WHERE rn = 1
     ) B ON (B.people=A.npc_name)
+    LEFT JOIN LATERAL (
+        SELECT history.data, history.gamets, {$latestCategorySelect}
+        FROM public.bgl_history history
+        WHERE history.npc = A.npc_name
+        ORDER BY history.gamets DESC, history.ts DESC, history.rowid DESC
+        LIMIT 1
+    ) C ON TRUE
     order by A.npc_name asc
 ";
     //error_log($query);
@@ -831,6 +843,12 @@ if ($bglBulkResult && ($bglBulkRow = pg_fetch_assoc($bglBulkResult))) {
                 }
             }
             
+            $lastActivity = trim((string)($row['last_activity'] ?? ''));
+            $lastActivityCategory = chimBglActivityCategory(
+                (string)($row['last_action_cat'] ?? ''),
+                $lastActivity
+            );
+
             $markers[] = [
                 'name'        => $row['npc_name'],
                 'ingame_x'    => (int) $x,
@@ -845,6 +863,10 @@ if ($bglBulkResult && ($bglBulkRow = pg_fetch_assoc($bglBulkResult))) {
                 'refid'       => $row["refid"],
                 'last_pos_ts' => $coordsData["last_updated"]?convert_gamets2skyrim_date($coordsData["last_updated"]).",hours ago:".round(($last_gamets-$coordsData["last_updated"]) *0.0000024,0):null,
                 'last_report' => convert_gamets2skyrim_date($row["last_report"]).",hours ago:".round(($last_gamets-$row["last_report"]) *0.0000024,0),
+                'last_activity' => $lastActivity,
+                'last_action_cat' => $lastActivityCategory,
+                'last_action_icon' => chimBglActivityIcon($lastActivityCategory, $lastActivity),
+                'last_action_label' => chimBglActivityLabel($lastActivityCategory, $lastActivity),
                 'coords_history' => $coordsHistory,
                 'background_life_enabled' => $backgroundLifeEnabled,
                 'bg_life_commands' => $bgLifeCommands,
@@ -923,6 +945,10 @@ if ($bglBulkResult && ($bglBulkRow = pg_fetch_assoc($bglBulkResult))) {
             'refid'       => $marker['refid'],
             'last_pos_ts' => $marker["last_pos_ts"],
             'last_report' => $marker["last_report"],
+            'last_activity' => $marker['last_activity'],
+            'last_action_cat' => $marker['last_action_cat'],
+            'last_action_icon' => $marker['last_action_icon'],
+            'last_action_label' => $marker['last_action_label'],
             'coords_history' => $translatedHistory,
             'bg_life_commands' => $marker['bg_life_commands'],
             'bg_life_letters' => $marker['bg_life_letters'],
@@ -1221,8 +1247,11 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         border-radius: 50%;
         border: 2px solid white;
         box-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+        display: flex;
         align-items: center;
         justify-content: center;
+        font-size: 11px;
+        line-height: 1;
         z-index: 10;
         position: relative;
         transform-origin: center;
@@ -1509,6 +1538,44 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         font-weight: 700;
         letter-spacing: 0.08em;
         text-transform: uppercase;
+    }
+
+    .marker-card-activity {
+        display: grid;
+        grid-template-columns: 28px minmax(0, 1fr);
+        gap: 8px;
+        align-items: center;
+        margin: 2px 0 8px;
+        padding: 7px 8px;
+        border: 1px solid #3f3f46;
+        border-radius: 6px;
+        background: #222227;
+    }
+
+    .marker-card-activity-icon {
+        font-size: 20px;
+        line-height: 1;
+        text-align: center;
+    }
+
+    .marker-card-activity-copy {
+        min-width: 0;
+    }
+
+    .marker-card-activity-title {
+        color: #fff;
+        font-size: 11px;
+        font-weight: 700;
+    }
+
+    .marker-card-activity-summary {
+        margin-top: 2px;
+        overflow: hidden;
+        color: #aaaab2;
+        font-size: 10px;
+        line-height: 1.3;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .marker-card-actions {
@@ -2415,6 +2482,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 
                     echo '<div class="marker" style="left: ' . $percentX . '%; top: ' . $percentY . '%; transform: translate(calc(-50% + ' . $offsetX . 'px), calc(-50% + ' . $offsetY . 'px));">';
                     echo '<div class="marker-dot" id="mkr_' . $marker['id'] . '" data-npc-name="' . $markerName . '" role="button" tabindex="0" title="View recent events for ' . $markerName . '" aria-label="View recent events for ' . $markerName . '" style="width: ' . ($marker['size'] * 2) . 'px; height: ' . ($marker['size'] * 2) . 'px; background-color: ' . $marker['color'] . '; opacity: 0.8;">';
+                    echo htmlspecialchars($marker['last_action_icon'], ENT_QUOTES, 'UTF-8');
                     echo '</div>';
                     echo '<div class="marker-label">' . PHP_EOL;
                     echo "<a style='color:white;text-decoration:none' href='#dtl_{$marker["id"]}'>{$marker["name"]} &nbsp; ↗️</a></br>";
@@ -2422,6 +2490,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                     echo '<img class="thumb" src="' . $marker['figure'] . '" />';
                     echo '<br/><small>Last reported:' . $marker['last_report'] . '</small>';
                     echo '<br/><small>Last tracked:' . $marker['last_pos_ts'] . '</small>';
+                    echo '<br/><small>Last activity: ' . htmlspecialchars($marker['last_action_icon'] . ' ' . $marker['last_action_label'], ENT_QUOTES, 'UTF-8') . '</small>';
                     echo '</div>';
                     echo '</div>' . PHP_EOL;
                     
@@ -2612,6 +2681,13 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
                                         <span class="marker-map-focus" data-map-focus role="button" tabindex="0" onclick="event.stopPropagation(); pulseAnimation('mkr_<?php echo $marker['id'] ?>')" aria-label="Show <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?> on map" title="Show on map">👀</span>
                                         <span class="marker-map-focus" data-map-focus role="button" tabindex="0" onclick="window.open('https://gamemap.uesp.net/sr/?world=skyrim&layer=day&x=<?php echo $marker['ingame_x'] ?>&y=<?php echo $marker['ingame_y'] ?>&zoom=8', '_blank'); event.stopPropagation();" aria-label="Show <?php echo htmlspecialchars($marker['name'], ENT_QUOTES, 'UTF-8'); ?> on map" title="UESP Map">🗺️</span>
                                     </h4>
+                                </div>
+                                <div class="marker-card-activity">
+                                    <span class="marker-card-activity-icon" aria-hidden="true"><?php echo htmlspecialchars($marker['last_action_icon'], ENT_QUOTES, 'UTF-8'); ?></span>
+                                    <div class="marker-card-activity-copy">
+                                        <div class="marker-card-activity-title">Last activity: <?php echo htmlspecialchars($marker['last_action_label'], ENT_QUOTES, 'UTF-8'); ?></div>
+                                        <div class="marker-card-activity-summary" title="<?php echo htmlspecialchars($marker['last_activity'], ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($marker['last_activity'] !== '' ? $marker['last_activity'] : 'No recent activity recorded.', ENT_QUOTES, 'UTF-8'); ?></div>
+                                    </div>
                                 </div>
                                 <div class="marker-card-row-label">Actions</div>
                                 <div class="marker-card-actions">

--- a/ui/mapview.php
+++ b/ui/mapview.php
@@ -1225,18 +1225,17 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         justify-content: center;
         z-index: 10;
         position: relative;
-        transform: scale(var(--bgl-marker-scale, 1));
         transform-origin: center;
         transition: transform 0.15s ease;
     }
 
     .marker:hover .marker-dot {
-        transform: scale(var(--bgl-marker-hover-scale, 1.1));
+        transform: scale(1.1);
     }
 
     .history-marker {
         position: absolute;
-        transform: translate(-50%, -50%) scale(var(--bgl-marker-scale, 1));
+        transform: translate(-50%, -50%);
         transform-origin: center;
         border-radius: 50%;
         border: 1px solid rgba(255, 255, 255, 0.6);
@@ -1250,7 +1249,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         opacity: 1;
         box-shadow: 0 0 10px rgba(255, 255, 255, 0.6);
         z-index: 15;
-        transform: translate(-50%, -50%) scale(var(--bgl-marker-hover-scale, 1.1));
+        transform: translate(-50%, -50%) scale(1.1);
     }
 
     .history-marker-label {
@@ -1261,10 +1260,11 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         border-radius: 4px;
         white-space: nowrap;
         font-size: 12px;
-        top: 12px;
+        top: calc(12px * var(--bgl-info-scale, 1));
         left: 50%;
-        transform: translateX(-50%);
-        margin-top: 3px;
+        transform: translateX(-50%) scale(var(--bgl-info-scale, 1));
+        transform-origin: top center;
+        margin-top: calc(3px * var(--bgl-info-scale, 1));
         border: 1px solid rgba(255, 255, 255, 0.4);
         display: none;
         z-index: 20;
@@ -1283,11 +1283,11 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         border-radius: 6px;
         white-space: nowrap;
         font-size: 14px;
-        top: calc(15px * var(--bgl-marker-scale, 1));
+        top: calc(15px * var(--bgl-info-scale, 1));
         left: 50%;
-        transform: translateX(-50%) scale(var(--bgl-marker-scale, 1));
+        transform: translateX(-50%) scale(var(--bgl-info-scale, 1));
         transform-origin: top center;
-        margin-top: calc(5px * var(--bgl-marker-scale, 1));
+        margin-top: calc(5px * var(--bgl-info-scale, 1));
         border: 2px solid rgb(242, 124, 17);
         display: none;
         z-index: 20;
@@ -2188,7 +2188,6 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         opacity: 0.8;
         transition: all 0.3s ease;
         border: none;
-        transform: scale(var(--bgl-marker-scale, 1));
         transform-origin: center;
     }
 
@@ -2202,9 +2201,9 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 
     .location-marker-caption {
         position: absolute;
-        top: calc(30px * var(--bgl-marker-scale, 1));
+        top: 30px;
         left: 50%;
-        transform: translateX(-50%) scale(var(--bgl-marker-scale, 1));
+        transform: translateX(-50%);
         transform-origin: top center;
         color: #ece7dc;
         font-size: 10px;
@@ -2220,7 +2219,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
 
     .location-marker:hover .location-marker-icon {
         opacity: 1;
-        transform: scale(var(--bgl-marker-hover-scale, 1.1));
+        transform: scale(1.1);
     }
 
     .location-marker:hover .location-marker-icon img {
@@ -2235,11 +2234,11 @@ include(__DIR__.DIRECTORY_SEPARATOR."tmpl/head.html");
         border-radius: 6px;
         white-space: nowrap;
         font-size: 14px;
-        top: calc(15px * var(--bgl-marker-scale, 1));
+        top: calc(15px * var(--bgl-info-scale, 1));
         left: 50%;
-        transform: translateX(-50%) scale(var(--bgl-marker-scale, 1));
+        transform: translateX(-50%) scale(var(--bgl-info-scale, 1));
         transform-origin: top center;
-        margin-top: calc(5px * var(--bgl-marker-scale, 1));
+        margin-top: calc(5px * var(--bgl-info-scale, 1));
         border: none;
         display: none;
         z-index: 30;


### PR DESCRIPTION
﻿## Summary
- classify recent Background Life activity and expose category-specific icons and labels
- show latest activity details on web map markers and NPC cards
- let NPC, history, and location marker graphics scale with map zoom
- keep hover information panels at a stable readable size

## Related PRs
- Prisma UI: [Dwemer-Dynamics/CHIM#123](https://github.com/Dwemer-Dynamics/CHIM/pull/123)
- Background Life enrollment hotfix: [abeiro/HerikaServer#681](https://github.com/abeiro/HerikaServer/pull/681)

## Validation
- `php -l lib/background_life_dashboard.php`
- `php -l ui/mapview.php`
- `node --check ui/js/background_life_history.js`
- `git diff --check`
- live dashboard API returned activity icons and labels for all 72 locally enrolled NPCs
- local browser verification confirmed map markers grow with zoom while information panels remain readable

## Deployment
- Equivalent files are active in the current local integrated HerikaServer deployment.
