### PR TITLE
Prevent save restores from disabling Background Life NPCs

### DIFF
--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -7861,6 +7861,37 @@ if ($checkVersion("default_npc_tags") < 20260805003) {
     }
 }
 
+if ($checkVersion("background_life_enrollment") < 20260806001) {
+    Logger::debug("Applying background_life_enrollment 20260806001 - restore enrollment implied by active rules");
+
+    $migrationOk = $db->execQuery(
+        "UPDATE public.core_npc_master
+         SET extended_data = jsonb_set(
+             COALESCE(extended_data, '{}'::jsonb),
+             '{background_life_enabled}',
+             'true'::jsonb,
+             true
+         )
+         WHERE LOWER(COALESCE(extended_data->>'background_life_enabled', 'false'))
+                   NOT IN ('true', '1', 't', 'on')
+           AND (
+               LOWER(COALESCE(extended_data->>'background_life_commands', 'false'))
+                   IN ('true', '1', 't', 'on')
+               OR LOWER(COALESCE(extended_data->>'background_life_letters', 'false'))
+                   IN ('true', '1', 't', 'on')
+               OR LOWER(COALESCE(metadata->>'gps_track', 'false'))
+                   IN ('true', '1', 't', 'on')
+           )"
+    ) !== false;
+
+    if ($migrationOk) {
+        $updateVersion("background_life_enrollment", 20260806001);
+        Logger::info("Applied patch background_life_enrollment 20260806001");
+    } else {
+        Logger::error("Failed to apply patch background_life_enrollment 20260806001");
+    }
+}
+
 //----------------------------------------------------
 // AUDIT REQUEST RESPONSE - Store the response text for audit requests
 // Version 20260806001

--- a/lib/core/npc_master.class.php
+++ b/lib/core/npc_master.class.php
@@ -1480,17 +1480,6 @@ FROM restore
             error_log("[NPC RESTORE] Failed to restore NPC relationships: " . $e->getMessage());
         }
 
-        $bglife_q="UPDATE public.core_npc_master
-        SET extended_data = jsonb_set(
-            extended_data,
-            '{background_life_enabled}',   -- JSON path
-            'false'::jsonb,                -- new value
-            true                           -- create if missing (optional)
-        )
-        WHERE (extended_data ->> 'background_life_enabled')::boolean = true";
-
-        $GLOBALS["db"]->execQuery($bglife_q);
-
         // RELATIONSHIP SYSTEM: Clear "future" relationship data from NPCs that weren't restored
         // NPCs added AFTER the save timestamp don't have history entries, so they keep their
         // current (future) state. We need to clear their relationship data to prevent paradoxes.


### PR DESCRIPTION
﻿## Problem
Loading/restoring a save forcibly set `background_life_enabled` to false for every enrolled NPC. Their database rows remained, but they disappeared from the active Background Life roster.

## Fix
- stop save restoration from disabling all Background Life NPCs
- add an idempotent migration that re-enrolls affected NPCs which still have automatic actions, letters, or tracking enabled

## Related PR
- `unstable`: #681

## Validation
- `php -l debug/db_updates.php`
- `php -l lib/core/npc_master.class.php`
- `git diff --check`
- patch verified identical to the focused `unstable` hotfix
- local migration completed successfully in `chim.log`
- live Background Life API returned 72 enrolled NPCs after repair

## Deployment
- The exact hotfix is active in the local HerikaServer runtime through the current integrated deployment.
