### PR TITLE
Preserve complete routing snapshots in event history

### DIFF
--- a/data/database_default.sql
+++ b/data/database_default.sql
@@ -1051,7 +1051,7 @@ ALTER SEQUENCE public.dynamic_bio_id_seq OWNED BY public.dynamic_bio.id;
 CREATE TABLE public.eventlog (
     type character varying(128),
     data text,
-    sess character varying(1024),
+    sess text,
     gamets bigint NOT NULL,
     localts bigint NOT NULL,
     ts bigint,

--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -7861,6 +7861,21 @@ if ($checkVersion("default_npc_tags") < 20260805003) {
     }
 }
 
+if ($checkVersion("eventlog_session_payload") < 20260807001) {
+    Logger::debug("Applying eventlog_session_payload 20260807001 - allow complete routing snapshots");
+
+    $migrationOk = $db->execQuery(
+        "ALTER TABLE public.eventlog ALTER COLUMN sess TYPE text"
+    ) !== false;
+
+    if ($migrationOk) {
+        $updateVersion("eventlog_session_payload", 20260807001);
+        Logger::info("Applied patch eventlog_session_payload 20260807001");
+    } else {
+        Logger::error("Failed to apply patch eventlog_session_payload 20260807001");
+    }
+}
+
 //----------------------------------------------------
 // AUDIT REQUEST RESPONSE - Store the response text for audit requests
 // Version 20260806001


### PR DESCRIPTION
## Problem
NPC replies can be generated and spoken but fail to persist when player-routing metadata exceeds the 1,024-character `eventlog.sess` limit. Subsequent prompts then omit those replies, making NPCs appear to forget the immediately preceding turn.

## Fix
- Store `eventlog.sess` as `text` for fresh installations.
- Add an idempotent upgrade migration that widens existing installations in place without changing stored event data.

## Validation
- `php -l debug/db_updates.php`
- `git diff --check`
- PostgreSQL transaction probe verified an existing row survives the type change and a 1,600-character routing snapshot inserts successfully; the transaction was rolled back.
- Fresh-schema assertion confirmed only `eventlog.sess` is widened.

## Deployment
Not deployed locally.

## Limits
Not tested in-game. The supplied logs provide the runtime reproduction; this PR addresses the confirmed database insertion failure.