### PR TITLE
Handle array-wrapped OpenAI JSON actions

### DIFF
--- a/connector/openaijson.php
+++ b/connector/openaijson.php
@@ -1251,6 +1251,8 @@ class openaijson
         } else {
             $GLOBALS["DEBUG_DATA"]["RAW"]=$this->_buffer;
             $parsedResponse=__jpd_decode_lazy($this->_buffer);   // USE JPD_LAZY?
+            if (isset($parsedResponse[0]) && is_array($parsedResponse[0]))
+                $parsedResponse=$parsedResponse[0];
             if (is_array($parsedResponse)) {
                 if (!empty($parsedResponse["action"])) {
                     if (!isset($parsedResponse["target"]))    


### PR DESCRIPTION
## Problem

The OpenAI JSON connector can receive a valid structured response wrapped in a top-level array. Its speech path already unwraps that shape, but `processActions()` expected an object and silently skipped the action.

## Change

- unwrap a top-level array before reading the action payload
- preserve direct-object responses and the existing function-call path

## Validation

- `php -l connector/openaijson.php`
- `git diff --check`
- focused runtime probe passed for both direct and array-wrapped action payloads
- deployed the exact feature-worktree file to local WSL HerikaServer; source and deployed SHA-256 hashes match
- deployed PHP lint passed and the HerikaServer endpoint returned HTTP 200
- `chim-unstable-push-guard` deterministic checks passed for `origin/unstable..HEAD`; this remains a PR because it changes AI action dispatch

## Scope and limits

- HerikaServer only; StobeServer does not use this action parser, and no Dialectic report currently justifies a parity change
- no migration, generated artifacts, binaries, or new test files
- manual in-game confirmation is still required

Discord source: [Open Discord thread](https://discord.com/channels/1109612896482246826/1535952740545462312/1535952740545462312)