### PR TITLE
Add Prisma settings APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# HerikaServer Agent Notes
+
+- Global Settings and Profiles must remain feature-equivalent between their PHP pages and the in-game Prisma Settings hub.
+- When adding, removing, renaming, or changing a setting in `ui/global_settings.php` or `ui/core/core_profiles.php`, update `lib/core/prisma_settings_catalog.php` in the same change.
+- Keep structural fields in `ui/api/chim_global_settings.php` and `ui/api/chim_profile_manager.php` allowlisted and typed. Preserve unknown profile metadata for plugin compatibility, but never map arbitrary client keys to database columns.
+- Validate both the PHP page and the Prisma API response when changing either settings menu.

--- a/lib/core/prisma_settings_catalog.php
+++ b/lib/core/prisma_settings_catalog.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Shared field catalog for the web and Prisma Global Settings/Profile editors.
+ * Keep presentation metadata here so both interfaces expose the same settings.
+ */
+function chimPrismaGlobalSettingsSections(): array
+{
+    return [
+        'Prompt & Rechat' => [
+            ['name' => 'PROMPT_HEAD', 'type' => 'longstring'],
+            ['name' => 'EMOTEMOODS', 'type' => 'longstring'],
+            ['name' => 'RECHAT_MODE', 'type' => 'select', 'values' => ['tight', 'conversational', 'group', 'random']],
+            ['name' => 'ENFORCE_STRICT_RECHAT_RESPONSE', 'type' => 'boolean'],
+        ],
+        'Oghma' => [
+            ['name' => 'OGHMA_INFINIUM', 'type' => 'boolean'],
+            ['name' => 'OGHMA_AMOUNT', 'type' => 'select', 'values' => ['1', '2', '3']],
+            ['name' => 'RACIAL_OGHMA', 'type' => 'boolean'],
+            ['name' => 'LOCATION_OGHMA', 'type' => 'boolean'],
+            ['name' => 'CORE_CONNECTOR_OGHMA_CUSTOM', 'type' => 'foreign:core_llm_connector:id:label'],
+            ['name' => 'OGHMA_CUSTOM', 'type' => 'boolean'],
+        ],
+        'Memory' => [
+            ['name' => 'FEATURES@MEMORY_EMBEDDING@ENABLED', 'type' => 'boolean'],
+            ['name' => 'FEATURES@MEMORY_EMBEDDING@TXTAI_URL', 'type' => 'url'],
+            ['name' => 'FEATURES@MEMORY_EMBEDDING@USE_TEXT2VEC', 'type' => 'boolean'],
+            ['name' => 'FEATURES@MEMORY_EMBEDDING@AUTO_CREATE_SUMMARY_INTERVAL', 'type' => 'integer'],
+            [
+                'name' => 'PLAYER_WORST_MEMORY_GAME_DAYS',
+                'type' => 'integer',
+                'min' => 0,
+                'max' => 365,
+                'default' => 7,
+                'help' => 'How long the player\'s worst memory of an NPC lingers before it fades, in in-game days (0 = never forget). Default 7 (one game-week). NPC-to-NPC worst memories are always permanent.',
+            ],
+            ['name' => 'SCENE_CLASSIFIER_ENABLED', 'type' => 'boolean'],
+            ['name' => 'RELATIONSHIP_SYSTEM_ENABLED', 'type' => 'boolean'],
+        ],
+        'Misc' => [
+            ['name' => 'AUTO_LOCK_PROFILE', 'type' => 'boolean'],
+            ['name' => 'AUTOFILL_CUSTOM_PROFILES', 'type' => 'boolean'],
+            ['name' => 'AUTOFILL_CUSTOM_PROFILES_TRIGGER', 'type' => 'integer', 'min' => 10, 'max' => 100],
+            ['name' => 'BGL_TRIGGER_HOURS', 'type' => 'number', 'min' => 1, 'max' => 720, 'step' => 0.1, 'default' => 24],
+            ['name' => 'END_CONVERSATION_COOLDOWN', 'type' => 'integer', 'min' => 0, 'max' => 300],
+        ],
+        'Quests' => [
+            ['name' => 'CHIM_AI_QUEST_PROGRESSION', 'type' => 'boolean'],
+            ['name' => 'CHIM_PLAYER_ONLY_QUEST_ADVANCEMENT', 'type' => 'boolean'],
+        ],
+        'Global Connectors' => [
+            ['name' => 'CORE_CONNECTOR_PLAYER', 'type' => 'foreign:core_llm_connector:id:label'],
+            ['name' => 'CORE_CONNECTOR_SUMMARY', 'type' => 'foreign:core_llm_connector:id:label'],
+            ['name' => 'CORE_CONNECTOR_MEDIUMTERM', 'type' => 'foreign:core_llm_connector:id:label'],
+            ['name' => 'CORE_CONNECTOR_SCENECLASSIFIER', 'type' => 'foreign:core_llm_connector:id:label'],
+            ['name' => 'CORE_CONNECTOR_PROFILES', 'type' => 'foreign:core_llm_connector:id:label'],
+            ['name' => 'CORE_CONNECTOR_DIRECTOR', 'type' => 'foreign:core_llm_connector:id:label'],
+            ['name' => 'CORE_CONNECTOR_BGL', 'type' => 'foreign:core_llm_connector:id:label'],
+            ['name' => 'RELLLM_CONNECTOR', 'type' => 'foreign:core_llm_connector:id:label'],
+        ],
+        'Context' => [
+            ['name' => 'DETECT_MAGIC_EVENT', 'type' => 'boolean'],
+            ['name' => 'GROUND_ITEMS_DESCRIPTIONS_ONLY', 'type' => 'boolean'],
+            ['name' => 'INVENTORY_ITEMS_DESCRIPTIONS_ONLY', 'type' => 'boolean'],
+            ['name' => 'HIDE_AMBIENT_COMBAT', 'type' => 'boolean'],
+            ['name' => 'DISABLE_REANIMATION_TRACKING', 'type' => 'boolean', 'action' => 'clear_reanimation'],
+            ['name' => 'TRANSFORMATION_DETECTION', 'type' => 'boolean'],
+            ['name' => 'POWER_AWARENESS_ENABLED', 'type' => 'boolean'],
+            ['name' => 'CHIM_ITEM_PICKUP_EVENTLOG_MIN_VALUE', 'type' => 'integer', 'min' => 0],
+            ['name' => 'PROMPT_TIMESTAMP', 'type' => 'boolean'],
+        ],
+        'Context Selections' => [
+            ['name' => 'MAGIC_EVENT_BLACKLIST', 'type' => 'longstring'],
+            ['name' => 'LOCATION_BLACKLIST', 'type' => 'longstring'],
+            ['name' => 'ITEM_BLACKLIST', 'type' => 'longstring'],
+            ['name' => 'EVENT_TYPE_FILTER', 'type' => 'longstring'],
+        ],
+        'Translation' => [
+            ['name' => 'TRANSLATION_FUNCTION', 'type' => 'select', 'values' => ['none', 'DeepL']],
+            ['name' => 'TRANSLATION@settings@translate_audio', 'type' => 'boolean'],
+            ['name' => 'TRANSLATION@settings@translate_text', 'type' => 'boolean'],
+            ['name' => 'TRANSLATION@settings@save_translated_text', 'type' => 'boolean'],
+            ['name' => 'TRANSLATION@settings@translate_player_audio', 'type' => 'boolean'],
+            ['name' => 'TRANSLATION@settings@save_translated_player_text', 'type' => 'boolean'],
+            ['name' => 'TRANSLATION@DeepL@source_language', 'type' => 'string'],
+            ['name' => 'TRANSLATION@DeepL@target_language', 'type' => 'string'],
+            ['name' => 'TRANSLATION@DeepL@url', 'type' => 'url'],
+            ['name' => 'TRANSLATION@DeepL@player_source_language', 'type' => 'string'],
+            ['name' => 'TRANSLATION@DeepL@player_target_language', 'type' => 'string'],
+        ],
+    ];
+}
+
+function chimPrismaGlobalSettingsTabs(): array
+{
+    return [
+        'prompt-rechat' => '💬 Prompt & Rechat',
+        'ai-memory' => '🧠 Memory & Others',
+        'context-knowledge' => '📚 Context & Knowledge',
+        'global-connectors' => '🔌 Global Connectors',
+    ];
+}
+
+function chimPrismaGlobalSettingsSectionTabs(): array
+{
+    return [
+        'Prompt & Rechat' => 'prompt-rechat',
+        'Memory' => 'ai-memory', 'Misc' => 'ai-memory', 'Quests' => 'ai-memory', 'Translation' => 'ai-memory',
+        'Oghma' => 'context-knowledge', 'Context' => 'context-knowledge', 'Context Selections' => 'context-knowledge',
+        'Global Connectors' => 'global-connectors',
+    ];
+}
+
+function chimPrismaProfileMetadataCatalog(): array
+{
+    return [
+        'Profiles & Memories' => [
+            ['name' => 'DYNAMIC_PROFILE_ENABLED', 'type' => 'boolean'],
+            ['name' => 'DYNAMIC_PROFILE_FIELDS', 'type' => 'multiselect', 'schema' => 'DYNAMIC_PROFILE_FIELDS'],
+            ['name' => 'MIDDLE_TERM_MEMORY_ENABLED', 'type' => 'boolean'],
+            ['name' => 'CONTEXT_HISTORY_DYNAMIC_PROFILE', 'type' => 'integer', 'min' => 0, 'max' => 400],
+            ['name' => 'RPG_COMMENTS', 'type' => 'multiselect', 'schema' => 'RPG_COMMENTS'],
+            ['name' => 'RPG_COMMENTS_CHANCE', 'type' => 'integer', 'min' => 0, 'max' => 100],
+        ],
+        'Diary' => [
+            ['name' => 'AUTO_DIARY_ENABLED', 'type' => 'boolean'],
+            ['name' => 'AUTO_DIARY_WAIT_ENABLED', 'type' => 'boolean'],
+            ['name' => 'MATERIALIZE_DIARY_ENABLED', 'type' => 'boolean'],
+            ['name' => 'LATEST_DIARY_CONTEXT_ENABLED', 'type' => 'boolean'],
+            ['name' => 'DIARY_PROMPT', 'type' => 'longstring', 'copyable' => true],
+            ['name' => 'DIARY_COOLDOWN', 'type' => 'integer', 'min' => 10, 'max' => 1200, 'copyable' => true],
+            ['name' => 'CONTEXT_HISTORY_DIARY', 'type' => 'integer', 'min' => 0, 'max' => 400, 'copyable' => true],
+        ],
+        'LLM' => [
+            ['name' => 'LLM_RANDOMIZER_ENABLED', 'type' => 'boolean'],
+            ['name' => 'LLM_FALLBACK_ENABLED', 'type' => 'boolean'],
+            ['name' => 'CORE_LANG', 'type' => 'select', 'values' => ['en', 'de', 'es', 'fr', 'jp'], 'copyable' => true],
+            ['name' => 'LANG_LLM_XTTS', 'type' => 'boolean', 'copyable' => true],
+            ['name' => 'MAX_WORDS_LIMIT', 'type' => 'integer', 'copyable' => true],
+        ],
+        'Rechat' => [
+            ['name' => 'RECHAT_H', 'type' => 'integer', 'min' => 1, 'max' => 10, 'copyable' => true],
+            ['name' => 'RECHAT_P', 'type' => 'integer', 'min' => 0, 'max' => 100, 'copyable' => true],
+            ['name' => 'RECHAT_ALLOW_ACTIONS', 'type' => 'boolean', 'copyable' => true],
+        ],
+        'Bored Event' => [
+            ['name' => 'BORED_EVENT', 'type' => 'integer', 'min' => 0, 'max' => 100, 'copyable' => true],
+            ['name' => 'BORED_EVENT_SERVERSIDE', 'type' => 'boolean', 'copyable' => true],
+        ],
+        'Context' => [
+            ['name' => 'CONTEXT_HISTORY', 'type' => 'integer', 'min' => 0, 'max' => 200, 'copyable' => true],
+        ],
+        'Combat' => [
+            ['name' => 'COMBAT_BARK_COOLDOWN', 'type' => 'integer', 'min' => 10, 'max' => 600, 'copyable' => true],
+        ],
+        'Quest' => [
+            ['name' => 'QUEST_COMMENT', 'type' => 'boolean', 'copyable' => true],
+            ['name' => 'QUEST_COMMENT_CHANCE', 'type' => 'select', 'values' => ['10%', '25%', '50%', '75%', '100%'], 'copyable' => true],
+        ],
+    ];
+}
+
+function chimPrismaProfileSyncableMetadataKeys(): array
+{
+    $keys = [];
+    foreach (chimPrismaProfileMetadataCatalog() as $fields) {
+        foreach ($fields as $field) {
+            if (!empty($field['copyable'])) {
+                $keys[] = $field['name'];
+            }
+        }
+    }
+    return $keys;
+}
+
+function chimPrismaProfileConnectorCatalog(): array
+{
+    return [
+        'Response Connectors' => [
+            ['name' => 'llm_primary_id', 'label' => '🧠 Standard LLM', 'source' => 'llm'],
+            ['name' => 'llm_secondary_id', 'label' => '⚡ Fast LLM', 'source' => 'llm'],
+            ['name' => 'llm_tertiary_id', 'label' => '💪 Powerful LLM', 'source' => 'llm'],
+            ['name' => 'llm_quaternary_id', 'label' => '🧪 Experimental LLM', 'source' => 'llm'],
+        ],
+        'Other Connectors' => [
+            ['name' => 'tts_connector_id', 'label' => '🔊 TTS Connector', 'source' => 'tts'],
+            ['name' => 'diary_connector_id', 'label' => '📙 Diary Connector', 'source' => 'llm'],
+            ['name' => 'llm_formatter_id', 'label' => '🧹 Formatter Connector', 'source' => 'llm'],
+            ['name' => 'llm_fallback_id', 'label' => '🛟 Fallback Connector', 'source' => 'llm'],
+        ],
+    ];
+}

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -500,6 +500,7 @@ if (!function_exists('chimGetOverrideableGeneralSettingsCatalog')) {
                 'description' => trim(strval($rowMap[$id]['description'] ?? ($descriptions[$id] ?? chimGetSchemaDescription($id)))),
                 'category' => chimGetOverrideableGeneralSettingCategory($id),
                 'ui_label' => chimPrettySettingLabel($id),
+                'global_value' => $rowMap[$id]['value'] ?? ($definition['default'] ?? ''),
             ];
 
             if (!empty($definition['values']) && is_array($definition['values'])) {

--- a/ui/api/chim_global_settings.php
+++ b/ui/api/chim_global_settings.php
@@ -1,0 +1,150 @@
+<?php
+
+error_reporting(E_ERROR);
+session_start();
+
+define('BASE_PATH', dirname(dirname(__DIR__)));
+define('LIB_PATH', BASE_PATH . DIRECTORY_SEPARATOR . 'lib');
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+require_once LIB_PATH . DIRECTORY_SEPARATOR . 'runtime_bootstrap.php';
+chimRuntimeBootstrap(BASE_PATH . DIRECTORY_SEPARATOR, [
+    'load_general_settings' => true,
+    'load_stt_connector' => false,
+    'load_itt_connector' => false,
+]);
+require_once LIB_PATH . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'prisma_settings_catalog.php';
+
+function chimGlobalSettingsRespond(array $payload, int $status = 200): void
+{
+    http_response_code($status);
+    echo json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function chimGlobalSettingsLabel(string $name): string
+{
+    $custom = [
+        'PROMPT_HEAD' => 'Prompt Head', 'EMOTEMOODS' => 'Emote Moods', 'RECHAT_MODE' => 'Rechat Mode',
+        'CORE_CONNECTOR_PLAYER' => 'Player Respeech', 'CORE_CONNECTOR_SUMMARY' => 'Summaries',
+        'CORE_CONNECTOR_MEDIUMTERM' => 'Middle Term Memory', 'CORE_CONNECTOR_SCENECLASSIFIER' => 'Scene Classifier',
+        'CORE_CONNECTOR_PROFILES' => 'Dynamic Profile', 'CORE_CONNECTOR_DIRECTOR' => 'Director Mode',
+        'CORE_CONNECTOR_BGL' => 'Background Life', 'RELLLM_CONNECTOR' => 'Relationship Manager',
+        'BGL_TRIGGER_HOURS' => 'Background Life Trigger Time', 'OGHMA_INFINIUM' => 'Oghma Infinium',
+        'OGHMA_AMOUNT' => 'Oghma Articles Amount', 'RACIAL_OGHMA' => 'Force Racial Oghma',
+        'LOCATION_OGHMA' => 'Force Location Oghma', 'DETECT_MAGIC_EVENT' => 'Detect Magic Events',
+    ];
+    if (isset($custom[$name])) {
+        return $custom[$name];
+    }
+    $parts = explode('@', $name);
+    return ucwords(strtolower(str_replace('_', ' ', end($parts) ?: $name)));
+}
+
+function chimGlobalSettingsFieldMap(): array
+{
+    $map = [];
+    foreach (chimPrismaGlobalSettingsSections() as $section => $fields) {
+        foreach ($fields as $field) {
+            $field['section'] = $section;
+            $map[$field['name']] = $field;
+        }
+    }
+    return $map;
+}
+
+function chimGlobalSettingsNormalize($value, array $field)
+{
+    $type = strtolower((string)($field['type'] ?? 'string'));
+    if ($type === 'boolean') {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false';
+    }
+    if ($type === 'integer') {
+        if (!is_numeric($value)) throw new InvalidArgumentException('Expected an integer.');
+        $value = (int)$value;
+    } elseif ($type === 'number') {
+        if (!is_numeric($value)) throw new InvalidArgumentException('Expected a number.');
+        $value = (float)$value;
+    } elseif (strpos($type, 'foreign:') === 0) {
+        if ($value === '' || $value === null) return '';
+        if (!is_numeric($value) || (int)$value < 1) throw new InvalidArgumentException('Invalid connector.');
+        $value = (int)$value;
+    } else {
+        $value = (string)$value;
+    }
+    if (isset($field['values']) && !in_array((string)$value, array_map('strval', $field['values']), true)) {
+        throw new InvalidArgumentException('Value is not allowed.');
+    }
+    if (isset($field['min']) && $value < $field['min']) $value = $field['min'];
+    if (isset($field['max']) && $value > $field['max']) $value = $field['max'];
+    return $value;
+}
+
+try {
+    $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+    if ($method === 'POST') {
+        $body = json_decode(file_get_contents('php://input'), true);
+        if (!is_array($body)) $body = $_POST;
+        $settings = $body['settings'] ?? null;
+        if (!is_array($settings)) chimGlobalSettingsRespond(['success' => false, 'error' => 'Settings payload is required.'], 400);
+
+        $fields = chimGlobalSettingsFieldMap();
+        $saved = [];
+        foreach ($settings as $name => $value) {
+            if (!isset($fields[$name])) {
+                throw new InvalidArgumentException("Unknown setting: {$name}");
+            }
+            $normalized = chimGlobalSettingsNormalize($value, $fields[$name]);
+            if (!chimSetGeneralSetting($name, $normalized)) {
+                throw new RuntimeException("Could not save {$name}.");
+            }
+            $saved[] = $name;
+        }
+        if (isset($body['prompt_context_options'])) {
+            $normalized = chimNormalizePromptContextOptions($body['prompt_context_options']);
+            if (!chimSetGeneralSetting('PROMPT_CONTEXT_OPTIONS', json_encode($normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE))) {
+                throw new RuntimeException('Could not save prompt context selections.');
+            }
+            $saved[] = 'PROMPT_CONTEXT_OPTIONS';
+        }
+        chimGlobalSettingsRespond(['success' => true, 'saved' => $saved]);
+    }
+
+    $connectorRows = $GLOBALS['db']->fetchAll('SELECT id, COALESCE(NULLIF(label, \'\'), model, id::text) AS label FROM core_llm_connector ORDER BY label ASC, id ASC');
+    $connectors = array_map(static fn($row) => ['value' => (int)$row['id'], 'label' => (string)$row['label']], (array)$connectorRows);
+    $descriptionMap = chimGetManagedGeneralSettingDescriptions();
+    $sections = [];
+    foreach (chimPrismaGlobalSettingsSections() as $section => $fields) {
+        $items = [];
+        foreach ($fields as $field) {
+            $name = $field['name'];
+            $field['label'] = chimGlobalSettingsLabel($name);
+            $field['description'] = (string)($descriptionMap[$name] ?? $field['description'] ?? $field['help'] ?? '');
+            $field['value'] = chimReadLegacyGlobalValue($name, $field['default'] ?? '');
+            if (($field['type'] ?? '') === 'boolean') {
+                $field['value'] = filter_var($field['value'], FILTER_VALIDATE_BOOLEAN);
+            }
+            if (strpos((string)$field['type'], 'foreign:') === 0) $field['options'] = $connectors;
+            $items[] = $field;
+        }
+        $sections[] = ['name' => $section, 'tab' => chimPrismaGlobalSettingsSectionTabs()[$section] ?? 'ai-memory', 'fields' => $items];
+    }
+    chimGlobalSettingsRespond(['success' => true, 'data' => [
+        'tabs' => chimPrismaGlobalSettingsTabs(),
+        'sections' => $sections,
+        'prompt_context_catalog' => chimGetPromptContextOptionCatalog(),
+        'prompt_context_options' => chimGetPromptContextOptions(),
+    ]]);
+} catch (Throwable $e) {
+    chimGlobalSettingsRespond(['success' => false, 'error' => $e->getMessage()], $e instanceof InvalidArgumentException ? 400 : 500);
+}

--- a/ui/api/chim_profile_manager.php
+++ b/ui/api/chim_profile_manager.php
@@ -131,6 +131,7 @@ function chimProfileManagerDetail(CoreProfile $profiles, int $id): array
             'description' => (string)($definition['description'] ?? ''),
             'enabled' => array_key_exists($name, $metadata),
             'value' => $metadata[$name] ?? '',
+            'global_value' => $definition['global_value'] ?? '',
         ];
         if ($field['type'] === 'boolean' && $field['enabled']) $field['value'] = chimProfileManagerBool($field['value']);
         if (!empty($definition['values'])) {

--- a/ui/api/chim_profile_manager.php
+++ b/ui/api/chim_profile_manager.php
@@ -1,0 +1,244 @@
+<?php
+
+error_reporting(E_ERROR);
+session_start();
+
+define('BASE_PATH', dirname(dirname(__DIR__)));
+define('LIB_PATH', BASE_PATH . DIRECTORY_SEPARATOR . 'lib');
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+require_once LIB_PATH . DIRECTORY_SEPARATOR . 'runtime_bootstrap.php';
+chimRuntimeBootstrap(BASE_PATH . DIRECTORY_SEPARATOR, ['load_general_settings' => true]);
+require_once LIB_PATH . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'core_profiles.class.php';
+require_once LIB_PATH . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'prisma_settings_catalog.php';
+require_once BASE_PATH . DIRECTORY_SEPARATOR . 'conf' . DIRECTORY_SEPARATOR . 'conf_loader.php';
+
+$profiles = new CoreProfile();
+
+function chimProfileManagerRespond(array $payload, int $status = 200): void
+{
+    http_response_code($status);
+    echo json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function chimProfileManagerJson($value): array
+{
+    if (is_array($value)) return $value;
+    $decoded = json_decode((string)$value, true);
+    return is_array($decoded) ? $decoded : [];
+}
+
+function chimProfileManagerBool($value): bool
+{
+    if (is_bool($value)) return $value;
+    return in_array(strtolower(trim((string)$value)), ['1', 'true', 'yes', 'on'], true);
+}
+
+function chimProfileManagerLabel(string $name): string
+{
+    $custom = [
+        'DYNAMIC_PROFILE_ENABLED' => 'Dynamic Profile', 'DYNAMIC_PROFILE_FIELDS' => 'Dynamic Profile Fields',
+        'MIDDLE_TERM_MEMORY_ENABLED' => 'Middle Term Memory', 'AUTO_DIARY_ENABLED' => 'Auto Diary',
+        'AUTO_DIARY_WAIT_ENABLED' => 'Auto Diary Wait', 'MATERIALIZE_DIARY_ENABLED' => 'Physical In-game Diary',
+        'LATEST_DIARY_CONTEXT_ENABLED' => 'Include Latest Diary Entry', 'LLM_RANDOMIZER_ENABLED' => 'Random LLM Selection',
+        'LLM_FALLBACK_ENABLED' => 'Fallback LLM', 'RECHAT_H' => 'Rechat Probability',
+        'RECHAT_P' => 'Player Rechat Probability', 'RECHAT_ALLOW_ACTIONS' => 'Allow Rechat Actions',
+        'CORE_LANG' => 'Language', 'LANG_LLM_XTTS' => 'LLM/TTS Language',
+        'BORED_EVENT' => 'Bored Event', 'BORED_EVENT_SERVERSIDE' => 'Server-side Bored Event',
+        'CONTEXT_HISTORY' => 'Context History', 'CONTEXT_HISTORY_DIARY' => 'Diary Context History',
+        'CONTEXT_HISTORY_DYNAMIC_PROFILE' => 'Dynamic Profile Context History', 'MAX_WORDS_LIMIT' => 'Maximum Words',
+        'QUEST_COMMENT' => 'Quest Commentary', 'QUEST_COMMENT_CHANCE' => 'Quest Commentary Chance',
+        'COMBAT_BARK_COOLDOWN' => 'Combat Bark Cooldown', 'DIARY_PROMPT' => 'Diary Prompt',
+        'DIARY_COOLDOWN' => 'Diary Cooldown', 'RPG_COMMENTS' => 'RPG Comments',
+        'RPG_COMMENTS_CHANCE' => 'RPG Comments Chance',
+    ];
+    return $custom[$name] ?? ucwords(strtolower(str_replace('_', ' ', $name)));
+}
+
+function chimProfileManagerOptions(string $table): array
+{
+    $rows = $GLOBALS['db']->fetchAll("SELECT id, COALESCE(NULLIF(label, ''), id::text) AS label FROM {$table} ORDER BY label ASC, id ASC");
+    return array_map(static fn($row) => ['value' => (int)$row['id'], 'label' => (string)$row['label']], (array)$rows);
+}
+
+function chimProfileManagerList(CoreProfile $profiles): array
+{
+    $rows = [];
+    foreach ((array)$profiles->readAll() as $row) {
+        $metadata = chimProfileManagerJson($row['metadata'] ?? '{}');
+        $rows[] = [
+            'id' => (int)$row['id'], 'label' => (string)$row['label'],
+            'slot' => $row['slot'] === null ? null : (int)$row['slot'],
+            'default_npc' => chimProfileManagerBool($row['default_npc'] ?? false),
+            'npc_count' => (int)($GLOBALS['db']->fetchOne('SELECT COUNT(*) AS c FROM core_npc_master WHERE profile_id=' . (int)$row['id'])['c'] ?? 0),
+            'dynamic_profile' => chimProfileManagerBool($metadata['DYNAMIC_PROFILE_ENABLED'] ?? false),
+            'auto_diary' => chimProfileManagerBool($metadata['AUTO_DIARY_ENABLED'] ?? false),
+        ];
+    }
+    return $rows;
+}
+
+function chimProfileManagerDetail(CoreProfile $profiles, int $id): array
+{
+    $row = $profiles->readOne($id);
+    if (!$row) throw new RuntimeException('Profile not found.');
+    $metadata = chimProfileManagerJson($row['metadata'] ?? '{}');
+    $schema = conf_loader_load_schema();
+    $sections = [];
+    foreach (chimPrismaProfileMetadataCatalog() as $section => $fields) {
+        $items = [];
+        foreach ($fields as $field) {
+            $name = $field['name'];
+            $field['label'] = chimProfileManagerLabel($name);
+            $field['value'] = $metadata[$name] ?? ($field['type'] === 'boolean' ? false : '');
+            if (($field['type'] ?? '') === 'boolean') {
+                $field['value'] = chimProfileManagerBool($field['value']);
+            }
+            if (!isset($field['description']) && isset($schema[$name]['description'])) {
+                $field['description'] = (string)$schema[$name]['description'];
+            }
+            if (($field['type'] ?? '') === 'multiselect') {
+                $values = $schema[$field['schema']]['values'] ?? [];
+                $field['options'] = array_values(array_filter((array)$values, static fn($value) => strtolower((string)$value) !== 'keepmechecked'));
+            }
+            $items[] = $field;
+        }
+        $sections[] = ['name' => $section, 'fields' => $items];
+    }
+    $reservedOverrideKeys = [];
+    foreach (chimPrismaProfileMetadataCatalog() as $fields) {
+        foreach ($fields as $field) $reservedOverrideKeys[$field['name']] = true;
+    }
+    $overrideSections = [];
+    foreach (chimGetOverrideableGeneralSettingsCatalog() as $name => $definition) {
+        if (isset($reservedOverrideKeys[$name])) continue;
+        $category = trim((string)($definition['category'] ?? 'Other')) ?: 'Other';
+        $field = [
+            'name' => $name,
+            'label' => (string)($definition['ui_label'] ?? chimProfileManagerLabel($name)),
+            'type' => (string)($definition['type'] ?? 'string'),
+            'description' => (string)($definition['description'] ?? ''),
+            'enabled' => array_key_exists($name, $metadata),
+            'value' => $metadata[$name] ?? '',
+        ];
+        if ($field['type'] === 'boolean' && $field['enabled']) $field['value'] = chimProfileManagerBool($field['value']);
+        if (!empty($definition['values'])) {
+            $labels = (array)($definition['value_labels'] ?? []);
+            $field['options'] = array_map(static fn($value) => [
+                'value' => (string)$value,
+                'label' => (string)($labels[(string)$value] ?? $value),
+            ], (array)$definition['values']);
+        }
+        $overrideSections[$category][] = $field;
+    }
+    return [
+        'core' => [
+            'id' => (int)$row['id'], 'label' => (string)$row['label'],
+            'slot' => $row['slot'] === null ? '' : (int)$row['slot'],
+            'default_npc' => chimProfileManagerBool($row['default_npc'] ?? false),
+            'prompt' => (string)($row['prompt'] ?? ''),
+        ],
+        'connectors' => array_intersect_key($row, array_flip([
+            'llm_primary_id', 'llm_secondary_id', 'llm_tertiary_id', 'llm_quaternary_id',
+            'tts_connector_id', 'diary_connector_id', 'llm_formatter_id', 'llm_fallback_id',
+        ])),
+        'connector_catalog' => chimPrismaProfileConnectorCatalog(),
+        'metadata_sections' => $sections,
+        'override_sections' => array_map(static fn($name, $fields) => ['name' => $name, 'fields' => $fields], array_keys($overrideSections), $overrideSections),
+        'metadata' => $metadata,
+    ];
+}
+
+function chimProfileManagerSave(CoreProfile $profiles, array $body): array
+{
+    $id = (int)($body['id'] ?? 0);
+    $existing = $profiles->readOne($id);
+    if (!$existing) throw new RuntimeException('Profile not found.');
+    $core = is_array($body['core'] ?? null) ? $body['core'] : [];
+    $connectors = is_array($body['connectors'] ?? null) ? $body['connectors'] : [];
+    $metadata = array_key_exists('metadata', $body) ? $body['metadata'] : chimProfileManagerJson($existing['metadata'] ?? '{}');
+    if (!is_array($metadata)) throw new InvalidArgumentException('Profile metadata must be an object.');
+
+    $data = [
+        'label' => trim((string)($core['label'] ?? $existing['label'])),
+        'slot' => ($core['slot'] ?? '') === '' ? null : (int)$core['slot'],
+        'default_npc' => 0,
+        'prompt' => (string)($core['prompt'] ?? $existing['prompt']),
+        'metadata' => json_encode($metadata, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+    ];
+    if ($data['label'] === '') throw new InvalidArgumentException('Profile name is required.');
+    foreach (['llm_primary_id', 'llm_secondary_id', 'llm_tertiary_id', 'llm_quaternary_id', 'tts_connector_id', 'diary_connector_id', 'llm_formatter_id', 'llm_fallback_id'] as $field) {
+        if (array_key_exists($field, $connectors)) {
+            $data[$field] = ($connectors[$field] === '' || $connectors[$field] === null)
+                ? null
+                : (int)$connectors[$field];
+        }
+    }
+    if (!$profiles->update($id, $data)) throw new RuntimeException($profiles->getLastError() ?: 'Could not save profile.');
+    if (chimProfileManagerBool($core['default_npc'] ?? false)) $profiles->promoteToDefaultNpc($id);
+    return chimProfileManagerDetail($profiles, $id);
+}
+
+try {
+    $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+    if ($method === 'POST') {
+        $body = json_decode(file_get_contents('php://input'), true);
+        if (!is_array($body)) $body = $_POST;
+        $operation = (string)($body['operation'] ?? 'save');
+        if ($operation === 'save') {
+            chimProfileManagerRespond(['success' => true, 'data' => chimProfileManagerSave($profiles, $body)]);
+        }
+        if ($operation === 'create') {
+            $id = $profiles->create(['label' => trim((string)($body['label'] ?? 'New Profile'))]);
+            if (!$id) throw new RuntimeException($profiles->getLastError() ?: 'Could not create profile.');
+            chimProfileManagerRespond(['success' => true, 'data' => chimProfileManagerDetail($profiles, (int)$id)]);
+        }
+        if ($operation === 'delete') {
+            if (!$profiles->delete((int)($body['id'] ?? 0))) throw new RuntimeException($profiles->getLastError() ?: 'Could not delete profile.');
+            chimProfileManagerRespond(['success' => true, 'data' => ['profiles' => chimProfileManagerList($profiles)]]);
+        }
+        if ($operation === 'copy_setting') {
+            $id = (int)($body['id'] ?? 0);
+            $key = trim((string)($body['key'] ?? ''));
+            if (!in_array($key, chimPrismaProfileSyncableMetadataKeys(), true)) throw new InvalidArgumentException('This profile setting cannot be copied.');
+            $source = $profiles->readOne($id);
+            if (!$source) throw new RuntimeException('Profile not found.');
+            $sourceMetadata = chimProfileManagerJson($source['metadata'] ?? '{}');
+            foreach ((array)$profiles->readAll() as $target) {
+                if ((int)$target['id'] === $id) continue;
+                $targetMetadata = chimProfileManagerJson($target['metadata'] ?? '{}');
+                if (array_key_exists($key, $sourceMetadata)) $targetMetadata[$key] = $sourceMetadata[$key];
+                else unset($targetMetadata[$key]);
+                if (!$profiles->update((int)$target['id'], ['metadata' => json_encode($targetMetadata, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)])) {
+                    throw new RuntimeException('Could not copy setting to all profiles.');
+                }
+            }
+            chimProfileManagerRespond(['success' => true, 'data' => ['copied' => $key]]);
+        }
+        throw new InvalidArgumentException('Unknown operation.');
+    }
+
+    $id = (int)($_GET['id'] ?? 0);
+    $data = [
+        'profiles' => chimProfileManagerList($profiles),
+        'connector_options' => [
+            'llm' => chimProfileManagerOptions('core_llm_connector'),
+            'tts' => chimProfileManagerOptions('core_tts_connector'),
+        ],
+    ];
+    if ($id > 0) $data['detail'] = chimProfileManagerDetail($profiles, $id);
+    chimProfileManagerRespond(['success' => true, 'data' => $data]);
+} catch (Throwable $e) {
+    chimProfileManagerRespond(['success' => false, 'error' => $e->getMessage()], $e instanceof InvalidArgumentException ? 400 : 500);
+}

--- a/ui/core/core_profiles.php
+++ b/ui/core/core_profiles.php
@@ -21,6 +21,7 @@ require_once "{$enginePath}/lib/core/tts_connector.class.php";
 require_once "{$enginePath}/lib/core/itt_connector.class.php";
 require_once "{$enginePath}/lib/core/api_badge.class.php";
 require_once "{$enginePath}/lib/core/import_rules.class.php";
+require_once "{$enginePath}/lib/core/prisma_settings_catalog.php";
 
 //function renderSelect($obj, $fieldName, $labelText, $selectedValue = "") 
 //function include from below file
@@ -521,13 +522,7 @@ $__dynOptions = is_array($__confSchema['DYNAMIC_PROFILE_FIELDS']['values'] ?? nu
 $__dynHelp = (string)($__confSchema['DYNAMIC_PROFILE_FIELDS']['description'] ?? '');
 
 // Only profile metadata fields rendered by the visual editor may be copied in bulk.
-$profileSyncableMetadataKeys = [
-    'RECHAT_H', 'RECHAT_P', 'CORE_LANG', 'BORED_EVENT',
-    'DIARY_PROMPT', 'LANG_LLM_XTTS', 'QUEST_COMMENT', 'DIARY_COOLDOWN', 'COMBAT_BARK_COOLDOWN',
-    'CONTEXT_HISTORY', 'MAX_WORDS_LIMIT',
-    'QUEST_COMMENT_CHANCE', 'RECHAT_ALLOW_ACTIONS', 'CONTEXT_HISTORY_DIARY', 'BORED_EVENT_SERVERSIDE',
-    'CONTEXT_HISTORY_DYNAMIC_PROFILE',
-];
+$profileSyncableMetadataKeys = chimPrismaProfileSyncableMetadataKeys();
 
 // Handle Create
 if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["create"])) {

--- a/ui/core/core_profiles.php
+++ b/ui/core/core_profiles.php
@@ -304,6 +304,11 @@ h1.api-title {
 .provider-grid { display:grid; grid-template-columns: 1fr; gap:12px; align-items:start; }
 .provider-card { background:#2a2a2a; border:1px solid #4a4a4a; border-radius:8px; padding:12px; }
 .provider-head { display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
+.profile-global-overrides > summary { cursor:pointer; list-style:none; margin-bottom:0; }
+.profile-global-overrides > summary::-webkit-details-marker { display:none; }
+.profile-global-overrides > summary::after { content:'\25B8'; color:rgb(242, 124, 17); font-size:18px; }
+.profile-global-overrides[open] > summary { margin-bottom:8px; }
+.profile-global-overrides[open] > summary::after { content:'\25BE'; }
 .provider-title { display:flex; align-items:center; gap:10px; color:#e0e0e0; }
 .provider-icon { width:28px; height:28px; border-radius:6px; background:#3a3a3a; display:flex; align-items:center; justify-content:center; font-size:16px; }
 .provider-body { display:flex; gap:8px; align-items:center; }
@@ -2234,13 +2239,13 @@ const saveAllBtn = document.getElementById('btn_save_all');
     </div>
     
     <!-- Global Settings Overrides -->
-    <div class="provider-card" style="margin-bottom:8px;">
-        <div class="provider-head">
+    <details class="provider-card profile-global-overrides" style="margin-bottom:8px;">
+        <summary class="provider-head">
             <div class="provider-title">
                 <div class="provider-icon">&#x1F310;</div>
                 <div>Global Settings Overrides</div>
             </div>
-        </div>
+        </summary>
         <div class="provider-body" style="display:block;">
             <small style="color:#9fb1c9; display:block; margin-bottom:8px;">Override global settings for this profile. Changes here take precedence over global configurations.</small>
             <?php
@@ -2277,7 +2282,7 @@ const saveAllBtn = document.getElementById('btn_save_all');
             include(__DIR__."/tmpl/override_editor.php");
             ?>
         </div>
-    </div>
+    </details>
     
     <!-- JSON Editor (second chunk) in collapsible -->
     <details id="metadata_section" class="collapsible">

--- a/ui/core/tmpl/override_editor.php
+++ b/ui/core/tmpl/override_editor.php
@@ -86,6 +86,129 @@ $schema = is_array($settingsCatalog) ? $settingsCatalog : [];
     <?php if ($isNpcMode): ?>margin-bottom: 12px;<?php endif; ?>
 }
 
+<?php if ($isProfileMode): ?>
+.prof-ovr-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.prof-ovr-category {
+    min-width: 0;
+    padding: 10px;
+    border: 1px solid #4a4a4a;
+    border-radius: 8px;
+    background: #202020;
+}
+
+.prof-ovr-category-title {
+    margin: 0 0 8px;
+    padding-bottom: 7px;
+    border-bottom: 1px solid rgba(242, 124, 17, 0.35);
+    color: rgb(242, 124, 17);
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.prof-ovr-category-settings {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+}
+
+.prof-ovr-inline-item {
+    display: grid;
+    grid-template-columns: minmax(190px, 1fr) minmax(180px, 0.9fr);
+    gap: 10px;
+    align-items: center;
+    padding: 9px;
+    border: 1px solid #3e3e3e;
+    border-radius: 6px;
+    background: #1a1a1a;
+}
+
+.prof-ovr-inline-info {
+    min-width: 0;
+}
+
+.prof-ovr-inline-name {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    color: #e9efff;
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.prof-ovr-inline-description,
+.prof-ovr-inherited-value {
+    margin-top: 3px;
+    color: #9fb1c9;
+    font-size: 11px;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+}
+
+.prof-ovr-inline-controls {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 8px;
+    align-items: center;
+}
+
+.prof-ovr-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: #e9efff;
+    font-size: 11px;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.prof-ovr-toggle input {
+    accent-color: #2f8f4e;
+}
+
+.prof-ovr-inline-input {
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+    padding: 7px 8px;
+    border: 1px solid #4a4a4a;
+    border-radius: 5px;
+    background: #171717;
+    color: #e9efff;
+    font-size: 12px;
+}
+
+.prof-ovr-inline-input:focus {
+    outline: none;
+    border-color: rgb(242, 124, 17);
+}
+
+.prof-ovr-inline-input:disabled {
+    cursor: not-allowed;
+    opacity: 0.48;
+}
+
+.prof-ovr-inline-item:not(.enabled) .prof-ovr-inline-info {
+    opacity: 0.7;
+}
+
+@media (max-width: 1180px) {
+    .prof-ovr-list {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 720px) {
+    .prof-ovr-inline-item {
+        grid-template-columns: 1fr;
+    }
+}
+<?php endif; ?>
+
 .<?= $prefix ?>ovr-item {
     background: <?= $isProfileMode ? '#1a1a1a' : '#2a2a2a' ?>;
     border: 1px solid #4a4a4a;
@@ -346,12 +469,12 @@ $schema = is_array($settingsCatalog) ? $settingsCatalog : [];
     <?php endif; ?>
     
     <div id="<?= $prefix ?>ovr-list" class="<?= $prefix ?>ovr-list"></div>
-    
-    <button type="button" id="btn-add-<?= $prefix ?>ovr" class="btn-add-<?= $prefix ?>ovr">
-        + Add <?= $isProfileMode ? 'Global Setting ' : '' ?>Override
-    </button>
-    
+
     <?php if ($isNpcMode): ?>
+    <button type="button" id="btn-add-<?= $prefix ?>ovr" class="btn-add-<?= $prefix ?>ovr">
+        + Add Override
+    </button>
+
     <div class="advanced-json-toggle" id="advanced-json-toggle">
         ▼ Advanced: Raw JSON Editor (click to expand)
     </div>
@@ -361,6 +484,7 @@ $schema = is_array($settingsCatalog) ? $settingsCatalog : [];
     <?php endif; ?>
 </div>
 
+<?php if ($isNpcMode): ?>
 <!-- Modal -->
 <div id="<?= $prefix ?>ovr-modal" class="<?= $prefix ?>ovr-modal-backdrop">
     <div class="<?= $prefix ?>ovr-modal">
@@ -389,6 +513,7 @@ $schema = is_array($settingsCatalog) ? $settingsCatalog : [];
         </div>
     </div>
 </div>
+<?php endif; ?>
 
 <script>
 (function(){
@@ -404,7 +529,7 @@ $schema = is_array($settingsCatalog) ? $settingsCatalog : [];
     const CURRENT_DATA = <?= json_encode($currentData, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
     const SCHEMA = <?= json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
     
-    let overridesState = {...CURRENT_DATA};
+    let overridesState = Object.fromEntries(Object.entries(CURRENT_DATA).filter(([key]) => !RESERVED_KEYS.includes(key)));
     let selectedSetting = null;
     let editingKey = null;
     let rawJsonEditor = null;
@@ -458,6 +583,12 @@ $schema = is_array($settingsCatalog) ? $settingsCatalog : [];
     function renderOverridesList() {
         const list = el('ovr-list');
         if (!list) return;
+
+        if (IS_PROFILE_MODE) {
+            renderProfileOverrides(list);
+            syncOverrides();
+            return;
+        }
         
         const keys = Object.keys(overridesState);
         if (keys.length === 0) {
@@ -505,6 +636,108 @@ $schema = is_array($settingsCatalog) ? $settingsCatalog : [];
         
         syncOverrides();
     }
+
+    // Profile overrides stay visible so users can enable and edit them without a secondary modal.
+    function renderProfileOverrides(list) {
+        const categories = {};
+        for (const [key, definition] of Object.entries(SCHEMA)) {
+            if (RESERVED_KEYS.includes(key)) continue;
+            const category = definition.category || 'Other';
+            if (!categories[category]) categories[category] = [];
+            categories[category].push([key, definition]);
+        }
+
+        list.innerHTML = Object.entries(categories).map(([category, settings]) => `
+            <section class="prof-ovr-category">
+                <h3 class="prof-ovr-category-title">${escapeHtml(category)}</h3>
+                <div class="prof-ovr-category-settings">
+                    ${settings.map(([key, definition]) => renderProfileOverrideItem(key, definition)).join('')}
+                </div>
+            </section>
+        `).join('');
+
+        list.querySelectorAll('.prof-ovr-inline-item').forEach((item) => {
+            const key = item.dataset.key;
+            const definition = SCHEMA[key] || {};
+            const toggle = item.querySelector('.prof-ovr-enabled');
+            const input = item.querySelector('.prof-ovr-inline-input');
+            if (!toggle || !input) return;
+
+            toggle.addEventListener('change', () => {
+                item.classList.toggle('enabled', toggle.checked);
+                input.disabled = !toggle.checked;
+                if (toggle.checked) {
+                    overridesState[key] = readProfileOverrideValue(input, definition.type);
+                } else {
+                    delete overridesState[key];
+                }
+                syncOverrides();
+            });
+
+            input.addEventListener('change', () => {
+                if (!toggle.checked) return;
+                overridesState[key] = readProfileOverrideValue(input, definition.type);
+                syncOverrides();
+            });
+            input.addEventListener('input', () => {
+                if (!toggle.checked || input.tagName === 'SELECT' || input.type === 'checkbox') return;
+                overridesState[key] = readProfileOverrideValue(input, definition.type);
+                syncOverrides();
+            });
+        });
+    }
+
+    function renderProfileOverrideItem(key, definition) {
+        const enabled = Object.prototype.hasOwnProperty.call(overridesState, key);
+        const inheritedValue = definition.global_value ?? '';
+        const value = enabled ? overridesState[key] : inheritedValue;
+        const description = String(definition.description || '').replace(/<[^>]*>/g, '');
+        return `
+            <div class="prof-ovr-inline-item${enabled ? ' enabled' : ''}" data-key="${escapeHtml(key)}">
+                <div class="prof-ovr-inline-info">
+                    <div class="prof-ovr-inline-name"><span>${getIcon(key)}</span><span>${escapeHtml(getLabel(key))}</span></div>
+                    ${description ? `<div class="prof-ovr-inline-description">${escapeHtml(description)}</div>` : ''}
+                    <div class="prof-ovr-inherited-value">Global value: ${escapeHtml(formatProfileOverrideValue(inheritedValue))}</div>
+                </div>
+                <div class="prof-ovr-inline-controls">
+                    <label class="prof-ovr-toggle"><input type="checkbox" class="prof-ovr-enabled" ${enabled ? 'checked' : ''}> Override</label>
+                    ${profileOverrideInput(key, definition, value, enabled)}
+                </div>
+            </div>
+        `;
+    }
+
+    function profileOverrideInput(key, definition, value, enabled) {
+        const type = definition.type || 'string';
+        const disabled = enabled ? '' : ' disabled';
+        if (type === 'boolean') {
+            const checked = value === true || value === 1 || String(value).toLowerCase() === 'true' || String(value) === '1';
+            return `<input type="checkbox" class="prof-ovr-inline-input" ${checked ? 'checked' : ''}${disabled}>`;
+        }
+        if (type === 'select' && Array.isArray(definition.values)) {
+            const labels = definition.value_labels || {};
+            return `<select class="prof-ovr-inline-input"${disabled}><option value="">-- Select --</option>${definition.values.map((option) => `<option value="${escapeHtml(option)}" ${String(value) === String(option) ? 'selected' : ''}>${escapeHtml(labels[option] || displayNames[option] || option)}</option>`).join('')}</select>`;
+        }
+        if (type === 'longstring') {
+            return `<textarea class="prof-ovr-inline-input" rows="3"${disabled}>${escapeHtml(value ?? '')}</textarea>`;
+        }
+        const inputType = type === 'integer' || type === 'number' ? 'number' : 'text';
+        const step = type === 'integer' ? ' step="1"' : (type === 'number' ? ' step="any"' : '');
+        return `<input type="${inputType}" class="prof-ovr-inline-input" value="${escapeHtml(value ?? '')}"${step}${disabled}>`;
+    }
+
+    function readProfileOverrideValue(input, type) {
+        if (type === 'boolean') return input.checked;
+        if (type === 'integer') return input.value === '' ? '' : parseInt(input.value, 10);
+        if (type === 'number') return input.value === '' ? '' : parseFloat(input.value);
+        return input.value;
+    }
+
+    function formatProfileOverrideValue(value) {
+        if (value === '' || value === null || typeof value === 'undefined') return 'Not set';
+        const rendered = Array.isArray(value) || typeof value === 'object' ? JSON.stringify(value) : String(value);
+        return rendered.length > 180 ? `${rendered.slice(0, 177)}...` : rendered;
+    }
     
     // Sync overrides to form
     function syncOverrides() {
@@ -540,10 +773,10 @@ $schema = is_array($settingsCatalog) ? $settingsCatalog : [];
         container.querySelectorAll('input[name^="meta_vis["]').forEach(el => el.remove());
         
         const allKeys = Array.from(new Set([
-            ...Object.keys(SCHEMA),
+            ...Object.keys(SCHEMA).filter((key) => !RESERVED_KEYS.includes(key)),
             ...Object.keys(CURRENT_DATA || {}),
             ...Object.keys(overridesState || {})
-        ]));
+        ])).filter((key) => !RESERVED_KEYS.includes(key));
         for (const key of allKeys) {
             const input = document.createElement('input');
             input.type = 'hidden';

--- a/ui/global_settings.php
+++ b/ui/global_settings.php
@@ -8,6 +8,7 @@ $enginePath = __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR;
 
 require_once($enginePath . "lib" . DIRECTORY_SEPARATOR . "runtime_bootstrap.php");
 require_once($enginePath . "lib" . DIRECTORY_SEPARATOR . "logger.php");
+require_once($enginePath . "lib" . DIRECTORY_SEPARATOR . "core" . DIRECTORY_SEPARATOR . "prisma_settings_catalog.php");
 
 chimRuntimeBootstrap($enginePath, [
     'load_general_settings' => true,
@@ -35,100 +36,9 @@ include(__DIR__ . DIRECTORY_SEPARATOR . "tmpl" . DIRECTORY_SEPARATOR . "head.htm
 $saveSuccess = isset($_GET['_saved']) && $_GET['_saved'] === '1';
 $clearReanimationResult = null;
 $promptContextSectionTitle = 'Context Selections';
-$promptContextOptionFields = [
-    [ 'name' => 'MAGIC_EVENT_BLACKLIST', 'type' => 'longstring' ],
-    [ 'name' => 'LOCATION_BLACKLIST', 'type' => 'longstring' ],
-    [ 'name' => 'ITEM_BLACKLIST', 'type' => 'longstring' ],
-    [ 'name' => 'EVENT_TYPE_FILTER', 'type' => 'longstring' ],
-];
-
-$gsSections = [
-    'Prompt & Rechat' => [
-        [ 'name' => 'PROMPT_HEAD', 'type' => 'longstring' ],
-        [ 'name' => 'EMOTEMOODS', 'type' => 'longstring' ],
-        [ 'name' => 'RECHAT_MODE', 'type' => 'select', 'values' => ['tight', 'conversational', 'group', 'random'] ],
-        [ 'name' => 'ENFORCE_STRICT_RECHAT_RESPONSE', 'type' => 'boolean' ],
-    ],
-    'Oghma' => [
-        [ 'name' => 'OGHMA_INFINIUM', 'type' => 'boolean' ],
-        [ 'name' => 'OGHMA_AMOUNT', 'type' => 'select', 'values' => ['1', '2', '3'] ],
-        [ 'name' => 'RACIAL_OGHMA', 'type' => 'boolean' ],
-        [ 'name' => 'LOCATION_OGHMA', 'type' => 'boolean' ],
-        [ 'name' => 'CORE_CONNECTOR_OGHMA_CUSTOM', 'type' => 'foreign:core_llm_connector:id:label' ],
-    ],
-    'Memory' => [
-        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@ENABLED', 'type' => 'boolean' ],
-        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@TXTAI_URL', 'type' => 'url' ],
-        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@USE_TEXT2VEC', 'type' => 'boolean' ],
-        [ 'name' => 'FEATURES@MEMORY_EMBEDDING@AUTO_CREATE_SUMMARY_INTERVAL', 'type' => 'integer' ],
-        [ 'name' => 'PLAYER_WORST_MEMORY_GAME_DAYS', 'type' => 'integer', 'min' => 0, 'max' => 365, 'default' => 7, 'help' => 'How long the player\'s worst memory of an NPC lingers before it fades, in in-game days (0 = never forget). Default 7 (one game-week). NPC-to-NPC worst memories are always permanent.' ],
-    ],
-    'Misc' => [
-        [ 'name' => 'AUTO_LOCK_PROFILE', 'type' => 'boolean' ],
-        [ 'name' => 'AUTOFILL_CUSTOM_PROFILES', 'type' => 'boolean' ],
-        [ 'name' => 'AUTOFILL_CUSTOM_PROFILES_TRIGGER', 'type' => 'integer', 'min' => 10, 'max' => 100 ],
-        [ 'name' => 'BGL_TRIGGER_HOURS', 'type' => 'number', 'min' => 1, 'max' => 720, 'step' => 0.1, 'default' => 24 ],
-        [ 'name' => 'END_CONVERSATION_COOLDOWN', 'type' => 'integer', 'min' => 0, 'max' => 300 ],
-    ],
-    'Quests' => [
-        [ 'name' => 'CHIM_AI_QUEST_PROGRESSION', 'type' => 'boolean' ],
-        [ 'name' => 'CHIM_PLAYER_ONLY_QUEST_ADVANCEMENT', 'type' => 'boolean' ],
-    ],
-    'Global Connectors' => [
-        [ 'name' => 'CORE_CONNECTOR_PLAYER', 'type' => 'foreign:core_llm_connector:id:label' ],
-        [ 'name' => 'CORE_CONNECTOR_SUMMARY', 'type' => 'foreign:core_llm_connector:id:label' ],
-        [ 'name' => 'CORE_CONNECTOR_MEDIUMTERM', 'type' => 'foreign:core_llm_connector:id:label' ],
-        [ 'name' => 'CORE_CONNECTOR_SCENECLASSIFIER', 'type' => 'foreign:core_llm_connector:id:label' ],
-        [ 'name' => 'CORE_CONNECTOR_PROFILES', 'type' => 'foreign:core_llm_connector:id:label' ],
-        [ 'name' => 'CORE_CONNECTOR_DIRECTOR', 'type' => 'foreign:core_llm_connector:id:label' ],
-        [ 'name' => 'CORE_CONNECTOR_BGL', 'type' => 'foreign:core_llm_connector:id:label' ],
-        [ 'name' => 'RELLLM_CONNECTOR', 'type' => 'foreign:core_llm_connector:id:label' ],
-    ],
-    'Context' => [
-        [ 'name' => 'DETECT_MAGIC_EVENT', 'type' => 'boolean' ],
-        [ 'name' => 'GROUND_ITEMS_DESCRIPTIONS_ONLY', 'type' => 'boolean' ],
-        [ 'name' => 'INVENTORY_ITEMS_DESCRIPTIONS_ONLY', 'type' => 'boolean' ],
-        [ 'name' => 'HIDE_AMBIENT_COMBAT', 'type' => 'boolean' ],
-        [ 'name' => 'DISABLE_REANIMATION_TRACKING', 'type' => 'boolean', 'action' => 'clear_reanimation' ],
-        [ 'name' => 'TRANSFORMATION_DETECTION', 'type' => 'boolean' ],
-        [ 'name' => 'POWER_AWARENESS_ENABLED', 'type' => 'boolean' ],
-        [ 'name' => 'CHIM_ITEM_PICKUP_EVENTLOG_MIN_VALUE', 'type' => 'integer', 'min' => 0 ],
-        [ 'name' => 'PROMPT_TIMESTAMP', 'type' => 'boolean' ],
-    ],
-    $promptContextSectionTitle => $promptContextOptionFields,
-    'Translation' => [
-        [ 'name' => 'TRANSLATION_FUNCTION', 'type' => 'select', 'values' => ['none', 'DeepL'] ],
-        [ 'name' => 'TRANSLATION@settings@translate_audio', 'type' => 'boolean' ],
-        [ 'name' => 'TRANSLATION@settings@translate_text', 'type' => 'boolean' ],
-        [ 'name' => 'TRANSLATION@settings@save_translated_text', 'type' => 'boolean' ],
-        [ 'name' => 'TRANSLATION@settings@translate_player_audio', 'type' => 'boolean' ],
-        [ 'name' => 'TRANSLATION@settings@save_translated_player_text', 'type' => 'boolean' ],
-        [ 'name' => 'TRANSLATION@DeepL@source_language', 'type' => 'string' ],
-        [ 'name' => 'TRANSLATION@DeepL@target_language', 'type' => 'string' ],
-        [ 'name' => 'TRANSLATION@DeepL@url', 'type' => 'url' ],
-        [ 'name' => 'TRANSLATION@DeepL@player_source_language', 'type' => 'string' ],
-        [ 'name' => 'TRANSLATION@DeepL@player_target_language', 'type' => 'string' ],
-    ],
-];
-
-$settingsTabs = [
-    'prompt-rechat' => '💬 Prompt & Rechat',
-    'ai-memory' => '🧠 Memory & Others',
-    'context-knowledge' => '📚 Context & Knowledge',
-    'global-connectors' => '🔌 Global Connectors',
-];
-
-$sectionTabs = [
-    'Prompt & Rechat' => 'prompt-rechat',
-    'Memory' => 'ai-memory',
-    'Misc' => 'ai-memory',
-    'Quests' => 'ai-memory',
-    'Translation' => 'ai-memory',
-    'Oghma' => 'context-knowledge',
-    'Context' => 'context-knowledge',
-    $promptContextSectionTitle => 'context-knowledge',
-    'Global Connectors' => 'global-connectors',
-];
+$gsSections = chimPrismaGlobalSettingsSections();
+$settingsTabs = chimPrismaGlobalSettingsTabs();
+$sectionTabs = chimPrismaGlobalSettingsSectionTabs();
 
 $tabControlPanels = [
     'prompt-rechat' => 'settings-panel-prompt-rechat-prompt-rechat',
@@ -136,6 +46,14 @@ $tabControlPanels = [
     'context-knowledge' => 'settings-panel-context-knowledge-oghma',
     'global-connectors' => 'settings-panel-global-connectors-global-connectors',
 ];
+
+// Paired connector toggles remain beside their connector instead of appearing twice.
+$pairedConnectorToggles = ['RELATIONSHIP_SYSTEM_ENABLED', 'SCENE_CLASSIFIER_ENABLED', 'OGHMA_CUSTOM'];
+foreach ($gsSections as $sectionName => $fields) {
+    $gsSections[$sectionName] = array_values(array_filter($fields, static function (array $field) use ($pairedConnectorToggles): bool {
+        return !in_array($field['name'] ?? '', $pairedConnectorToggles, true);
+    }));
+}
 
 function pretty_label(string $flatName): string
 {


### PR DESCRIPTION
## Summary
- add typed Prisma APIs for Global Settings and Profiles
- centralize managed Global Settings and Profile fields so the PHP and Prisma menus stay aligned
- support profile CRUD, connector assignments, overrides, defaults, and copy-to-all while preserving unknown metadata
- replace the profile override add-modal with a categorized, two-column list of every eligible Global Setting
- keep Global Settings Overrides available but start collapsed by default on the PHP Profiles page
- show each inherited global value inline and let users explicitly enable or disable its profile override
- keep reserved profile-native fields out of the generic override payload and preserve the existing NPC override editor
- document the required PHP/Prisma settings parity for future changes

## Validation
- `php -l` passed for every changed PHP file
- focused `OghmaSettingsTest`: 2 tests, 15 assertions passed
- reversible API round-trip passed for 56 global fields, 27 profile metadata fields, 66 overrides, and 8 connector assignments
- null connectors, unknown metadata preservation, default promotion, and copy-to-all passed
- affected pages and APIs returned HTTP 200; Global Settings and Profiles were visually checked in the browser
- profile override UI rendered 10 categories and 66 eligible fields, enabled and disabled an override correctly, and had no horizontal overflow at 1265px
- the generated profile page contains the inline override editor and no profile-level `Add Override` button
- the PHP override disclosure was collapsed by default, expanded normally, retained all 66 rendered override fields, and had no horizontal overflow

## Deployment
- deployed the exact changed-file contents from `a573c720f2082fe95ef777cd7bec5071b2cddbda` to `/var/www/html/HerikaServer`
- verified SHA-256 hashes match between source and the deployed PHP profile page
- related CHIM PR: https://github.com/Dwemer-Dynamics/CHIM/pull/124

## Overlap
- `ui/global_settings.php` also appears in draft PR #685, which adds settings import/export controls; this PR changes field catalog sourcing and will need compatibility review if both are merged

## Limits
- the paired in-game Settings navigation still requires manual Skyrim verification
- profile toggle serialization was verified without submitting a save, so existing local profile data was not changed during testing