### PR TITLE
Fix missing canonical mood expression mappings

### DIFF
--- a/lib/data_functions.php
+++ b/lib/data_functions.php
@@ -6653,7 +6653,7 @@ function GetExpression($mood) {
      "CombatShout"
      ];
      
-     $result="";
+     $result="MoodNeutral";
      if ($mood=="sarcastic") {
         $result= array_rand(array_flip(["DialoguePuzzled"]), 1);
          
@@ -6690,6 +6690,18 @@ function GetExpression($mood) {
          
      } else if ($mood=="smirking") {
         $result= array_rand(array_flip(["DialogueHappy"]), 1);
+     } else if (in_array($mood, ["sexy", "kindly", "lovely", "seductive", "happy"], true)) {
+        $result="DialogueHappy";
+     } else if (in_array($mood, ["desperate", "scared", "pleading"], true)) {
+        $result="DialogueFear";
+     } else if (in_array($mood, ["assertive", "angry"], true)) {
+        $result="DialogueAnger";
+     } else if ($mood=="sad") {
+        $result="DialogueSad";
+     } else if ($mood=="surprised") {
+        $result="DialogueSurprise";
+     } else if (in_array($mood, ["drunk", "shy"], true)) {
+        $result="DialoguePuzzled";
      
          
      } else if ($mood=="serious") {


### PR DESCRIPTION
## Summary

- map every supported canonical mood to an existing Skyrim expression category
- use `MoodNeutral` for unknown non-empty custom moods instead of returning a blank expression
- preserve empty-input behavior and the established mappings

## Problem

`GetExpression()` only handled 9 of the 23 moods currently returned by `getDefaultEmoteMoods()`. The other 14 canonical moods fell through with an empty result, leaving `SCRIPTLINE_EXPRESSION` blank even when the model supplied a supported mood.

## Validation

- `php -l lib/data_functions.php`
- existing `EmoteMoodsTest`: 5 tests, 5 assertions passed
- focused runtime probe: all 23 canonical moods returned their expected non-empty expression; unknown and empty fallbacks verified
- `git diff --check`

## Scope

- no database or configuration changes
- no generated or binary artifacts
- not deployed; in-game facial animation remains to be retested
- related but separate OpenAI JSON action parser fix: #686
- DialecticServer counterpart: Dwemer-Dynamics/DialecticServer#58
- StobeServer has no corresponding `GetExpression()` path, so there is no Stobe port