### PR TITLE
Add per-NPC event history and injection

### DIFF
--- a/lib/eventlog_helper.php
+++ b/lib/eventlog_helper.php
@@ -56,6 +56,24 @@ if (!function_exists('chimBuildVisibleEventLogWhereClause')) {
     }
 }
 
+if (!function_exists('chimBuildNpcEventLogPeopleWhereClause')) {
+    // Match one NPC token without allowing partial-name matches or far-away audience markers.
+    function chimBuildNpcEventLogPeopleWhereClause($db, $npcName, $peopleColumn = 'people')
+    {
+        $peopleColumn = trim((string)$peopleColumn);
+        if (!preg_match('/^(?:[A-Za-z_][A-Za-z0-9_]*\.)?[A-Za-z_][A-Za-z0-9_]*$/', $peopleColumn)) {
+            $peopleColumn = 'people';
+        }
+
+        $escapedNpcName = $db->escape(trim((string)$npcName));
+        return "EXISTS (
+            SELECT 1
+            FROM unnest(string_to_array(trim(BOTH '|' FROM COALESCE({$peopleColumn}, '')), '|')) AS chim_person(person_name)
+            WHERE lower(regexp_replace(btrim(chim_person.person_name), ' \\((busy|hostile|in combat|restrained)\\)$', '', 'i')) = lower('{$escapedNpcName}')
+        )";
+    }
+}
+
 if (!function_exists('chimGetVisibleEventLogTypes')) {
     function chimGetVisibleEventLogTypes($db, $additionalExcludedTypes = [])
     {

--- a/ui/api/chim_npc_manager.php
+++ b/ui/api/chim_npc_manager.php
@@ -29,6 +29,8 @@ require_once LIB_PATH . DIRECTORY_SEPARATOR . 'logger.php';
 require_once LIB_PATH . DIRECTORY_SEPARATOR . "{$GLOBALS['DBDRIVER']}.class.php";
 require_once LIB_PATH . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'npc_master.class.php';
 require_once LIB_PATH . DIRECTORY_SEPARATOR . 'relationship_manager.php';
+require_once LIB_PATH . DIRECTORY_SEPARATOR . 'utils_game_timestamp.php';
+require_once LIB_PATH . DIRECTORY_SEPARATOR . 'eventlog_helper.php';
 
 $db = new sql();
 $npcMaster = new NpcMaster();
@@ -272,6 +274,144 @@ function chimNpcManagerFindNpc(array $input): array
     }
 
     throw new InvalidArgumentException('NPC not found');
+}
+
+function chimNpcManagerEventRecipients($people): array
+{
+    $recipients = [];
+    foreach (explode('|', trim((string)$people, '|')) as $recipient) {
+        $recipient = trim((string)$recipient);
+        if ($recipient !== '' && !in_array($recipient, $recipients, true)) {
+            $recipients[] = $recipient;
+        }
+    }
+    return $recipients;
+}
+
+function chimNpcManagerHistory(array $input): array
+{
+    $npc = chimNpcManagerFindNpc($input);
+    $npcName = trim((string)($npc['npc_name'] ?? ''));
+    $limit = max(1, min(100, (int)($input['limit'] ?? 50)));
+    $peopleWhere = chimBuildNpcEventLogPeopleWhereClause($GLOBALS['db'], $npcName, 'a.people');
+    $visibleWhere = chimBuildVisibleEventLogWhereClause($GLOBALS['db']);
+    $rows = $GLOBALS['db']->fetchAll(
+        "SELECT a.rowid, a.type, a.data, a.people, a.gamets, a.localts, a.ts, a.sess
+         FROM eventlog a
+         WHERE {$visibleWhere} AND {$peopleWhere}
+         ORDER BY a.gamets DESC, a.ts DESC, a.localts DESC, a.rowid DESC
+         LIMIT {$limit}"
+    );
+
+    $events = array_map(static function ($row) {
+        $gamets = (int)($row['gamets'] ?? 0);
+        return [
+            'rowid' => (int)($row['rowid'] ?? 0),
+            'type' => (string)($row['type'] ?? ''),
+            'data' => (string)($row['data'] ?? ''),
+            'recipients' => chimNpcManagerEventRecipients($row['people'] ?? ''),
+            'gamets' => $gamets,
+            'tamrielic_time' => $gamets > 0 ? convert_gamets2skyrim_long_date2($gamets) : '',
+            'local_time' => !empty($row['localts']) ? gmdate('Y-m-d H:i:s', (int)$row['localts']) . ' UTC' : '',
+            'manual_injection' => strtolower((string)($row['type'] ?? '')) === 'inputtext'
+                && (string)($row['sess'] ?? '') === 'npc_editor',
+        ];
+    }, (array)$rows);
+
+    return [
+        'npc' => ['id' => (int)$npc['id'], 'name' => $npcName],
+        'events' => $events,
+    ];
+}
+
+function chimNpcManagerResolveEventRecipients(array $input, array $npc): array
+{
+    $ids = [(int)$npc['id']];
+    $requestedIds = is_array($input['recipient_ids'] ?? null) ? $input['recipient_ids'] : [];
+    foreach ($requestedIds as $requestedId) {
+        $requestedId = (int)$requestedId;
+        if ($requestedId > 0 && !in_array($requestedId, $ids, true)) {
+            $ids[] = $requestedId;
+        }
+    }
+    if (count($ids) > 12) {
+        throw new InvalidArgumentException('An event can include at most 12 NPCs');
+    }
+
+    $recipients = [];
+    foreach ($ids as $id) {
+        $row = $id === (int)$npc['id'] ? $npc : chimNpcManagerFindNpc(['id' => $id]);
+        $name = trim((string)($row['npc_name'] ?? ''));
+        if ($name === '' || strpos($name, '|') !== false) {
+            throw new InvalidArgumentException('One of the selected NPC names cannot be used for event routing');
+        }
+        $recipients[] = ['id' => (int)$row['id'], 'name' => $name];
+    }
+    return $recipients;
+}
+
+function chimNpcManagerInjectEvent(array $input): array
+{
+    $npc = chimNpcManagerFindNpc($input);
+    $eventText = trim((string)($input['event'] ?? ''));
+    if (strlen($eventText) >= 2 && $eventText[0] === '(' && substr($eventText, -1) === ')') {
+        $eventText = trim(substr($eventText, 1, -1));
+    }
+    if ($eventText === '') {
+        throw new InvalidArgumentException('Event text is required');
+    }
+    $eventLength = function_exists('mb_strlen') ? mb_strlen($eventText, 'UTF-8') : strlen($eventText);
+    if ($eventLength > 4000) {
+        throw new InvalidArgumentException('Event text must be 4000 characters or fewer');
+    }
+
+    $recipients = chimNpcManagerResolveEventRecipients($input, $npc);
+    $people = '|' . implode('|', array_column($recipients, 'name')) . '|';
+    $rowId = $GLOBALS['db']->insertReturningId('eventlog', [
+        'ts' => max(0, (int)DataLastKnownTS()) + 1,
+        'gamets' => max(0, (int)DataLastKnownGameTS()),
+        'type' => 'inputtext',
+        'data' => '(' . $eventText . ')',
+        'sess' => 'npc_editor',
+        'localts' => time(),
+        'people' => $people,
+        'location' => '',
+        'party' => '',
+    ], 'rowid');
+    if ($rowId <= 0) {
+        throw new RuntimeException('Event could not be injected');
+    }
+
+    return [
+        'message' => 'Event injected for ' . implode(', ', array_column($recipients, 'name')) . '.',
+        'rowid' => $rowId,
+        'recipients' => $recipients,
+    ];
+}
+
+function chimNpcManagerDeleteEvent(array $input): array
+{
+    $npc = chimNpcManagerFindNpc($input);
+    $rowId = (int)($input['rowid'] ?? 0);
+    if ($rowId <= 0) {
+        throw new InvalidArgumentException('Invalid event row');
+    }
+
+    $npcName = trim((string)($npc['npc_name'] ?? ''));
+    $peopleWhere = chimBuildNpcEventLogPeopleWhereClause($GLOBALS['db'], $npcName, 'a.people');
+    $visibleWhere = chimBuildVisibleEventLogWhereClause($GLOBALS['db']);
+    $event = $GLOBALS['db']->fetchOne(
+        "SELECT a.rowid FROM eventlog a WHERE a.rowid = {$rowId} AND {$visibleWhere} AND {$peopleWhere} LIMIT 1"
+    );
+    if (!$event) {
+        throw new InvalidArgumentException('Event is not available in this NPC history');
+    }
+
+    $result = chimDeleteEventLogRow($GLOBALS['db'], $rowId);
+    if (empty($result['ok'])) {
+        throw new RuntimeException((string)($result['message'] ?? 'Event could not be deleted'));
+    }
+    return ['message' => 'Event deleted.', 'rowid' => $rowId];
 }
 
 // Persist only the temporary return point without overwriting live NPC metadata updates.
@@ -655,6 +795,12 @@ try {
             throw new InvalidArgumentException('Invalid JSON request');
         }
         $operation = strtolower(trim((string)($input['operation'] ?? 'save')));
+        if ($operation === 'inject_event') {
+            chimNpcManagerRespond(['success' => true, 'data' => chimNpcManagerInjectEvent($input)]);
+        }
+        if ($operation === 'delete_event') {
+            chimNpcManagerRespond(['success' => true, 'data' => chimNpcManagerDeleteEvent($input)]);
+        }
         if ($operation === 'action') {
             chimNpcManagerRespond(['success' => true, 'data' => chimNpcManagerAction($input)]);
         }
@@ -671,6 +817,9 @@ try {
     if ($operation === 'detail') {
         $row = chimNpcManagerFindNpc($_GET);
         chimNpcManagerRespond(['success' => true, 'data' => chimNpcManagerDetail($row, $profiles)]);
+    }
+    if ($operation === 'history') {
+        chimNpcManagerRespond(['success' => true, 'data' => chimNpcManagerHistory($_GET)]);
     }
     throw new InvalidArgumentException('Unsupported NPC manager operation');
 } catch (InvalidArgumentException $error) {

--- a/ui/api/chim_npc_manager.php
+++ b/ui/api/chim_npc_manager.php
@@ -295,6 +295,28 @@ function chimNpcManagerHistory(array $input): array
     $limit = max(1, min(100, (int)($input['limit'] ?? 100)));
     $selectedEventType = trim((string)($input['event_type'] ?? ''));
     $hiddenEventTypes = chimGetPersistedEventLogHiddenTypes($GLOBALS['db']);
+    // Keep NPC History aligned with the PHP Adventure Log's default narrative event list.
+    $allowedEventTypes = [
+        'im_alive',
+        'chat',
+        'infoaction',
+        'rpg_word',
+        'rpg_lvlup',
+        'rechat',
+        'quest',
+        'itemfound',
+        'inputtext',
+        'goodnight',
+        'goodmorning',
+        'ginputtext',
+        'death',
+        'combatendmighty',
+        'combatend',
+    ];
+    $escapedAllowedEventTypes = array_map(static function ($eventType) {
+        return "'" . $GLOBALS['db']->escape($eventType) . "'";
+    }, $allowedEventTypes);
+    $allowedTypesWhere = 'a.type IN (' . implode(',', $escapedAllowedEventTypes) . ')';
     $peopleWhere = chimBuildNpcEventLogPeopleWhereClause($GLOBALS['db'], $npcName, 'a.people');
     $visibleWhere = chimBuildVisibleEventLogWhereClause(
         $GLOBALS['db'],
@@ -304,7 +326,7 @@ function chimNpcManagerHistory(array $input): array
     $rows = $GLOBALS['db']->fetchAll(
         "SELECT a.rowid, a.type, a.data, a.people, a.gamets, a.localts, a.ts, a.sess
          FROM eventlog a
-         WHERE {$visibleWhere} AND {$peopleWhere}
+         WHERE {$allowedTypesWhere} AND {$visibleWhere} AND {$peopleWhere}
          ORDER BY a.gamets DESC, a.ts DESC, a.localts DESC, a.rowid DESC
          LIMIT {$limit}"
     );
@@ -312,7 +334,7 @@ function chimNpcManagerHistory(array $input): array
     $eventTypes = $GLOBALS['db']->fetchAll(
         "SELECT a.type, COUNT(*) AS total
          FROM eventlog a
-         WHERE {$visibleTypesWhere} AND {$peopleWhere}
+         WHERE {$allowedTypesWhere} AND {$visibleTypesWhere} AND {$peopleWhere}
          GROUP BY a.type
          ORDER BY a.type ASC"
     );

--- a/ui/api/chim_npc_manager.php
+++ b/ui/api/chim_npc_manager.php
@@ -292,15 +292,29 @@ function chimNpcManagerHistory(array $input): array
 {
     $npc = chimNpcManagerFindNpc($input);
     $npcName = trim((string)($npc['npc_name'] ?? ''));
-    $limit = max(1, min(100, (int)($input['limit'] ?? 50)));
+    $limit = max(1, min(100, (int)($input['limit'] ?? 100)));
+    $selectedEventType = trim((string)($input['event_type'] ?? ''));
+    $hiddenEventTypes = chimGetPersistedEventLogHiddenTypes($GLOBALS['db']);
     $peopleWhere = chimBuildNpcEventLogPeopleWhereClause($GLOBALS['db'], $npcName, 'a.people');
-    $visibleWhere = chimBuildVisibleEventLogWhereClause($GLOBALS['db']);
+    $visibleWhere = chimBuildVisibleEventLogWhereClause(
+        $GLOBALS['db'],
+        $selectedEventType,
+        $hiddenEventTypes
+    );
     $rows = $GLOBALS['db']->fetchAll(
         "SELECT a.rowid, a.type, a.data, a.people, a.gamets, a.localts, a.ts, a.sess
          FROM eventlog a
          WHERE {$visibleWhere} AND {$peopleWhere}
          ORDER BY a.gamets DESC, a.ts DESC, a.localts DESC, a.rowid DESC
          LIMIT {$limit}"
+    );
+    $visibleTypesWhere = chimBuildVisibleEventLogWhereClause($GLOBALS['db'], '', $hiddenEventTypes);
+    $eventTypes = $GLOBALS['db']->fetchAll(
+        "SELECT a.type, COUNT(*) AS total
+         FROM eventlog a
+         WHERE {$visibleTypesWhere} AND {$peopleWhere}
+         GROUP BY a.type
+         ORDER BY a.type ASC"
     );
 
     $events = array_map(static function ($row) {
@@ -312,7 +326,7 @@ function chimNpcManagerHistory(array $input): array
             'recipients' => chimNpcManagerEventRecipients($row['people'] ?? ''),
             'gamets' => $gamets,
             'tamrielic_time' => $gamets > 0 ? convert_gamets2skyrim_long_date2($gamets) : '',
-            'local_time' => !empty($row['localts']) ? gmdate('Y-m-d H:i:s', (int)$row['localts']) . ' UTC' : '',
+            'local_time' => !empty($row['localts']) ? gmdate('d-m-Y H:i:s', (int)$row['localts']) : '',
             'manual_injection' => strtolower((string)($row['type'] ?? '')) === 'inputtext'
                 && (string)($row['sess'] ?? '') === 'npc_editor',
         ];
@@ -321,6 +335,16 @@ function chimNpcManagerHistory(array $input): array
     return [
         'npc' => ['id' => (int)$npc['id'], 'name' => $npcName],
         'events' => $events,
+        'filters' => [
+            'selected_event_type' => $selectedEventType,
+            'hidden_event_types' => $hiddenEventTypes,
+            'event_types' => array_map(static function ($row) {
+                return [
+                    'type' => (string)($row['type'] ?? ''),
+                    'total' => (int)($row['total'] ?? 0),
+                ];
+            }, (array)$eventTypes),
+        ],
     ];
 }
 

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -2118,10 +2118,10 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
     <button type="button" class="npc-editor-tab is-active" role="tab" aria-selected="true" data-npc-editor-tab="general">🧭 General</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="bios">📖 Roleplay</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="relationships">🤝 Relationships</button>
-    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="background-life">🌍 Background Life</button>
-    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="history">📜 History</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="info">🛠️ Info</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="actions">⚡ Actions</button>
+    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="background-life">🌍 Background Life</button>
+    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="history">📜 History</button>
 </div>
 <style>
 .npc-editor-tabs {
@@ -2276,7 +2276,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
             tablist.dataset.initialized = '1';
 
             const panels = {};
-            ['general','bios','relationships','background-life','history','info','actions'].forEach(function(section){
+            ['general','bios','relationships','info','actions','background-life','history'].forEach(function(section){
                 const panel = document.createElement('div');
                 panel.className = 'npc-editor-panel form-grid';
                 if (section === 'history') panel.classList.add('npc-editor-panel-history');

--- a/ui/core/npc_master.php
+++ b/ui/core/npc_master.php
@@ -42,6 +42,7 @@ include(__DIR__.DIRECTORY_SEPARATOR."../tmpl/head.html");
 ?>
 
 <link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/main.css">
+<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/npc_event_history.css">
 <style>
 /* Core styling alignment */
 @font-face {
@@ -1918,6 +1919,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
 
 <?php if (isset($_GET['partial']) && $_GET['partial']=='1') { ob_end_clean(); ?>
 <link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/main.css">
+<link rel="stylesheet" href="<?php echo $webRoot; ?>/ui/css/npc_event_history.css">
 <style>html,body{background:#2a2a2a;margin-bottom:50px;margin-right:5px;} main{background:#2a2a2a; padding:12px;} .form-container{background:#2a2a2a; border:1px solid #4a4a4a; border-radius:8px;}
 .modal-inline-actions{display:flex; gap:6px; align-items:center; justify-content:flex-end; margin-bottom:8px;}
 .modal-inline-actions .btn-toggle{background:transparent; border:none; padding:6px; color:#e9efff; font-size:22px; line-height:1; text-decoration:none; cursor:pointer;}
@@ -1929,6 +1931,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
 <?php } else { ?>
 <form method="post" onsubmit='return consolidation()' style='<?= $editItem!=null?"":"display:none"?>'>
 <?php } ?>
+    <script src="<?php echo $webRoot; ?>/ui/js/npc_event_history.js"></script>
     <style>
     .form-grid { display:grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap:12px 16px; }
     @media (max-width: 900px){ .form-grid { grid-template-columns: 1fr; } }
@@ -2116,13 +2119,14 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="bios">📖 Roleplay</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="relationships">🤝 Relationships</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="background-life">🌍 Background Life</button>
+    <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="history">📜 History</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="info">🛠️ Info</button>
     <button type="button" class="npc-editor-tab" role="tab" aria-selected="false" data-npc-editor-tab="actions">⚡ Actions</button>
 </div>
 <style>
 .npc-editor-tabs {
     display:grid;
-    grid-template-columns:repeat(6, minmax(0, 1fr));
+    grid-template-columns:repeat(7, minmax(0, 1fr));
     gap:8px;
     margin-bottom:14px;
     padding:8px;
@@ -2258,6 +2262,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
         bios: new Set(['core','npc_static_bio','appearance','personality','occupation','skills','speechstyle','goals']),
         relationships: new Set(['relationships','relationships_jsonb','middle_term_latest']),
         'background-life': new Set(['background_life_goals']),
+        history: new Set(),
         info: new Set(['emote_moods','metadata','extended_data']),
         actions: new Set()
     };
@@ -2271,9 +2276,10 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
             tablist.dataset.initialized = '1';
 
             const panels = {};
-            ['general','bios','relationships','background-life','info','actions'].forEach(function(section){
+            ['general','bios','relationships','background-life','history','info','actions'].forEach(function(section){
                 const panel = document.createElement('div');
                 panel.className = 'npc-editor-panel form-grid';
+                if (section === 'history') panel.classList.add('npc-editor-panel-history');
                 panel.dataset.npcEditorPanel = section;
                 panel.id = 'npc-editor-panel-' + section + '-' + index;
                 panel.setAttribute('role', 'tabpanel');
@@ -2341,6 +2347,13 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
             const savedReturnLocation = <?= json_encode($editorReturnLocation, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
             const initialTeleportAction = savedReturnLocation ? 'return' : 'teleport';
             const initialReturnName = savedReturnLocation && savedReturnLocation.name ? String(savedReturnLocation.name) : '';
+            const historyController = window.chimNpcEventHistory
+                ? window.chimNpcEventHistory.mount(panels.history, {
+                    npcId: targetId,
+                    npcName: targetName,
+                    apiUrl: '../api/chim_npc_manager.php'
+                })
+                : null;
             panels.actions.innerHTML = `
                 <p class="npc-editor-action-note">The game must be running and unpaused for Visit, Teleport, and Return NPC.</p>
                 <div class="npc-editor-action-list">
@@ -2643,6 +2656,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
                     button.tabIndex = active ? 0 : -1;
                 });
                 Object.entries(panels).forEach(function(entry){ entry[1].hidden = entry[0] !== section; });
+                if (section === 'history' && historyController) historyController.load();
                 try { window.localStorage.setItem(storageKey, section); } catch (_e) {}
             }
 
@@ -4255,7 +4269,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
   Loading an older save will roll back unlocked profiles to that point in time. NPCs created <em>after</em> the save's timestamp may disappear entirely.
   <br>
   <span style="color:rgb(242,124,17);">Lock a profile (🔒) to protect it from pullback.</span>
-  You can view and restore previous versions of any NPC via the <strong>View History</strong> button in the edit modal.
+  You can view and restore previous profile versions via the <strong>Profile Versions</strong> button in the edit modal.
 </div>
 <div class="npc-grid">
     <?php foreach ($data as $row): ?>
@@ -4377,7 +4391,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
         <button id="npc_modal_import_to" class="btn-cancel" title="Import biography from another NPC's export file">Import Bio</button>
         <button id="npc_modal_reset" class="btn-cancel" title="Reimport bio template fields">Reset NPC</button>
         <button id="npc_modal_diary" class="btn-cancel">View Diary</button>
-        <button id="npc_modal_history" class="btn-cancel">View History</button>
+        <button id="npc_modal_history" class="btn-cancel">Profile Versions</button>
         <button id="npc_modal_regen" class="btn-cancel" title="Will use AI to regenerate this profile. Intended for custom NPCs without biography descriptions.">AI Generate Profile</button>
         <button id="npc_modal_close" class="btn-cancel">Close</button>
       </div>
@@ -4450,11 +4464,11 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
   
 </div>
 
-<!-- NPC History viewer overlay -->
+<!-- NPC profile versions viewer overlay -->
 <div id="history_viewer" class="modal-backdrop" style="z-index:10002;">
   <div class="modal-container" style="max-width:1100px; width:95%;">
     <div class="modal-header">
-      <h2 class="modal-title">NPC History</h2>
+      <h2 class="modal-title">NPC Profile Versions</h2>
       <div class="modal-actions">
         <button id="history_close" class="btn-cancel">Close</button>
         <button id="history_generation" class="btn-cancel" title="Note: Will do a LLM request.">Evolution report (AI request)</button>
@@ -5106,7 +5120,7 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_from_bio'])) {
   })();
 
   
-  // View History button wiring
+  // Profile Versions button wiring
   (function(){
     const btn = document.getElementById('npc_modal_history');
     const overlay = document.getElementById('history_viewer');

--- a/ui/css/npc_event_history.css
+++ b/ui/css/npc_event_history.css
@@ -20,19 +20,32 @@
 .npc-event-history-status { color:#aaa; font-size:.82rem; }
 .npc-event-history-status.is-error,
 .npc-event-history-empty.is-error { color:#ef8f96; }
-.npc-event-history-list { display:grid; gap:8px; max-height:440px; overflow:auto; }
-.npc-event-history-card { padding:10px; border:1px solid #3f3f3f; border-radius:7px; background:#1d1d1d; }
-.npc-event-history-card-header { display:flex; align-items:flex-start; justify-content:space-between; gap:10px; }
-.npc-event-history-card-header strong,
-.npc-event-history-card-header span { display:block; }
-.npc-event-history-card-header strong { color:#f2bd7f; font-size:.84rem; }
-.npc-event-history-card-header span { margin-top:2px; color:#888; font-size:.72rem; }
+.npc-event-history-filterbar { display:flex; align-items:flex-end; flex-wrap:wrap; gap:8px 14px; margin-bottom:10px; }
+.npc-event-history-filterbar label { display:grid; gap:4px; color:#f2bd7f; font-size:.78rem; font-weight:700; }
+.npc-event-history-filterbar select { min-width:220px; padding:7px 9px; border:1px solid #555; border-radius:5px; background:#1d1d1d; color:#eee; }
+.npc-event-history-filter-note { color:#929dab; font-size:.74rem; overflow-wrap:anywhere; }
+.npc-event-history-list { max-height:440px; overflow:auto; }
+.npc-event-history-table-wrap { overflow-x:auto; border:1px solid #3f3f3f; border-radius:6px; background:#1d1d1d; }
+.npc-event-history-table { width:100%; min-width:900px; border-collapse:collapse; color:#e5e5e5; font-size:.78rem; }
+.npc-event-history-table th { position:sticky; top:0; z-index:1; padding:9px 10px; border-bottom:1px solid #555; background:#292929; color:rgb(242,124,17); text-align:left; white-space:nowrap; }
+.npc-event-history-table td { padding:9px 10px; border-bottom:1px solid #363636; vertical-align:top; line-height:1.35; }
+.npc-event-history-table tbody tr:last-child td { border-bottom:0; }
+.npc-event-history-table tbody tr:hover td { background:rgba(242,124,17,.08); }
+.npc-event-history-table th:nth-child(2),
+.npc-event-history-table td:nth-child(2) { min-width:320px; }
+.npc-event-history-table th:nth-child(3),
+.npc-event-history-table td:nth-child(3) { min-width:220px; }
+.npc-event-history-type { color:#f2bd7f; font-weight:700; white-space:nowrap; }
 .npc-event-history-delete { border:1px solid #74424a; border-radius:5px; background:#442a2e; color:#f5c3c7; cursor:pointer; padding:5px 8px; }
 .npc-event-history-delete:hover { border-color:#bd5d68; }
-.npc-event-history-data { margin:9px 0 0; color:#e5e5e5; white-space:pre-wrap; overflow-wrap:anywhere; }
-.npc-event-history-audience { margin:7px 0 0; color:#929dab; font-size:.74rem; }
+.npc-event-history-data { white-space:pre-wrap; overflow-wrap:anywhere; }
+.npc-event-history-audience { color:#929dab; }
 .npc-event-history-empty { margin:0; padding:12px; color:#888; text-align:center; }
 @media (max-width:700px) {
     .npc-event-history-heading,
     .npc-event-history-actions { align-items:stretch; flex-direction:column; }
+    .npc-event-history-filterbar { align-items:stretch; flex-direction:column; }
+    .npc-event-history-filterbar select { width:100%; min-width:0; }
+    .npc-event-history-table th,
+    .npc-event-history-table td { padding:7px 8px; }
 }

--- a/ui/css/npc_event_history.css
+++ b/ui/css/npc_event_history.css
@@ -1,0 +1,38 @@
+.npc-editor-panel-history { grid-template-columns:minmax(0, 1fr) !important; }
+.npc-event-history-shell { display:grid; gap:12px; width:100%; }
+.npc-event-history-section { padding:14px; border:1px solid #444; border-radius:8px; background:#252525; }
+.npc-event-history-heading { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; margin-bottom:10px; }
+.npc-event-history-heading h3 { margin:0 0 3px; color:#f2bd7f; font-size:1rem; }
+.npc-event-history-heading p { margin:0; color:#aaa; font-size:.82rem; }
+.npc-event-history-label { display:block; margin:10px 0 5px; color:#f2bd7f; font-size:.82rem; font-weight:700; }
+.npc-event-recipient-row { display:flex; flex-wrap:wrap; gap:6px; min-height:30px; }
+.npc-event-recipient-chip { display:inline-flex; align-items:center; gap:6px; padding:5px 9px; border:1px solid #6b4a2f; border-radius:999px; background:#39291f; color:#f4dfca; font-size:.8rem; }
+.npc-event-recipient-chip button { padding:0; border:0; background:transparent; color:#f4dfca; cursor:pointer; font-size:1rem; line-height:1; }
+.npc-event-recipient-search,
+.npc-event-history-text { width:100%; border:1px solid #4a4a4a; border-radius:6px; background:#1d1d1d; color:#eee; }
+.npc-event-recipient-search { padding:8px 10px; }
+.npc-event-history-text { min-height:110px; padding:10px; resize:vertical; }
+.npc-event-search-results { display:grid; gap:4px; margin-top:5px; padding:6px; border:1px solid #444; border-radius:6px; background:#1d1d1d; }
+.npc-event-search-results[hidden] { display:none; }
+.npc-event-search-result { padding:7px 9px; border:1px solid transparent; border-radius:5px; background:#2b2b2b; color:#eee; cursor:pointer; text-align:left; }
+.npc-event-search-result:hover { border-color:rgb(242,124,17); }
+.npc-event-history-actions { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-top:9px; }
+.npc-event-history-status { color:#aaa; font-size:.82rem; }
+.npc-event-history-status.is-error,
+.npc-event-history-empty.is-error { color:#ef8f96; }
+.npc-event-history-list { display:grid; gap:8px; max-height:440px; overflow:auto; }
+.npc-event-history-card { padding:10px; border:1px solid #3f3f3f; border-radius:7px; background:#1d1d1d; }
+.npc-event-history-card-header { display:flex; align-items:flex-start; justify-content:space-between; gap:10px; }
+.npc-event-history-card-header strong,
+.npc-event-history-card-header span { display:block; }
+.npc-event-history-card-header strong { color:#f2bd7f; font-size:.84rem; }
+.npc-event-history-card-header span { margin-top:2px; color:#888; font-size:.72rem; }
+.npc-event-history-delete { border:1px solid #74424a; border-radius:5px; background:#442a2e; color:#f5c3c7; cursor:pointer; padding:5px 8px; }
+.npc-event-history-delete:hover { border-color:#bd5d68; }
+.npc-event-history-data { margin:9px 0 0; color:#e5e5e5; white-space:pre-wrap; overflow-wrap:anywhere; }
+.npc-event-history-audience { margin:7px 0 0; color:#929dab; font-size:.74rem; }
+.npc-event-history-empty { margin:0; padding:12px; color:#888; text-align:center; }
+@media (max-width:700px) {
+    .npc-event-history-heading,
+    .npc-event-history-actions { align-items:stretch; flex-direction:column; }
+}

--- a/ui/js/npc_event_history.js
+++ b/ui/js/npc_event_history.js
@@ -25,6 +25,7 @@
         const recipients = new Map([[npcId, npcName]]);
         let searchTimer = null;
         let searchGeneration = 0;
+        let selectedEventType = '';
 
         root.innerHTML = `
             <div class="npc-event-history-shell span-2">
@@ -48,6 +49,12 @@
                         <div><h3>Recent Events</h3><p>The latest events routed to this NPC. Deleting a shared event removes it for every listed recipient.</p></div>
                         <button type="button" class="btn-cancel" data-history-refresh>Refresh</button>
                     </div>
+                    <div class="npc-event-history-filterbar">
+                        <label>Event type
+                            <select data-history-event-type><option value="">All visible events</option></select>
+                        </label>
+                        <span class="npc-event-history-filter-note" data-history-filter-note>Using Event Log visibility filters.</span>
+                    </div>
                     <div class="npc-event-history-list" data-history-list><p class="npc-event-history-empty">Open this tab to load recent events.</p></div>
                 </section>
             </div>`;
@@ -60,6 +67,8 @@
         const list = root.querySelector('[data-history-list]');
         const injectButton = root.querySelector('[data-history-inject]');
         const refreshButton = root.querySelector('[data-history-refresh]');
+        const eventTypeSelect = root.querySelector('[data-history-event-type]');
+        const filterNote = root.querySelector('[data-history-filter-note]');
 
         function setStatus(message, isError) {
             status.textContent = message || '';
@@ -122,18 +131,49 @@
             }
         }
 
+        function renderFilters(filters) {
+            const types = Array.isArray(filters.event_types) ? filters.event_types : [];
+            const hiddenTypes = Array.isArray(filters.hidden_event_types) ? filters.hidden_event_types : [];
+            const selected = String(filters.selected_event_type || selectedEventType);
+            eventTypeSelect.replaceChildren(new Option('All visible events', ''));
+            types.forEach(function (entry) {
+                const type = String(entry.type || '');
+                if (!type) return;
+                eventTypeSelect.appendChild(new Option(type + ' (' + Number(entry.total || 0) + ')', type));
+            });
+            eventTypeSelect.value = selected;
+            selectedEventType = eventTypeSelect.value;
+            filterNote.textContent = hiddenTypes.length
+                ? 'Hidden by Event Log: ' + hiddenTypes.join(', ')
+                : 'Using Event Log visibility filters.';
+        }
+
         function renderEvents(events) {
             list.replaceChildren();
             if (!events.length) {
                 list.appendChild(element('p', 'npc-event-history-empty', 'No events are recorded for this NPC yet.'));
                 return;
             }
+            const tableWrap = element('div', 'npc-event-history-table-wrap');
+            const table = element('table', 'npc-event-history-table');
+            const thead = document.createElement('thead');
+            const headerRow = document.createElement('tr');
+            ['Event', 'Events', 'People Present', 'Tamrielic Time', 'Time (UTC)', ''].forEach(function (label) {
+                headerRow.appendChild(element('th', '', label));
+            });
+            thead.appendChild(headerRow);
+            const tbody = document.createElement('tbody');
             events.forEach(function (event) {
-                const card = element('article', 'npc-event-history-card');
-                const header = element('div', 'npc-event-history-card-header');
-                const title = element('div');
-                title.appendChild(element('strong', '', event.manual_injection ? 'Injected Event' : (event.type || 'Event')));
-                title.appendChild(element('span', '', event.tamrielic_time || event.local_time || 'Unknown time'));
+                const row = document.createElement('tr');
+                row.appendChild(element('td', 'npc-event-history-type', event.type || 'Event'));
+                row.appendChild(element('td', 'npc-event-history-data', event.data || ''));
+                row.appendChild(element(
+                    'td',
+                    'npc-event-history-audience',
+                    Array.isArray(event.recipients) ? event.recipients.join(', ') : ''
+                ));
+                row.appendChild(element('td', '', event.tamrielic_time || ''));
+                row.appendChild(element('td', '', event.local_time || ''));
                 const deleteButton = element('button', 'npc-event-history-delete', 'Delete');
                 deleteButton.type = 'button';
                 deleteButton.addEventListener('click', async function () {
@@ -154,14 +194,14 @@
                         deleteButton.disabled = false;
                     }
                 });
-                header.append(title, deleteButton);
-                card.appendChild(header);
-                card.appendChild(element('p', 'npc-event-history-data', event.data || ''));
-                if (Array.isArray(event.recipients) && event.recipients.length) {
-                    card.appendChild(element('p', 'npc-event-history-audience', 'NPCs: ' + event.recipients.join(', ')));
-                }
-                list.appendChild(card);
+                const actions = document.createElement('td');
+                actions.appendChild(deleteButton);
+                row.appendChild(actions);
+                tbody.appendChild(row);
             });
+            table.append(thead, tbody);
+            tableWrap.appendChild(table);
+            list.appendChild(tableWrap);
         }
 
         async function load() {
@@ -169,8 +209,10 @@
             refreshButton.disabled = true;
             list.replaceChildren(element('p', 'npc-event-history-empty', 'Loading recent events...'));
             try {
-                const query = new URLSearchParams({operation: 'history', id: String(npcId), limit: '50'});
+                const query = new URLSearchParams({operation: 'history', id: String(npcId), limit: '100'});
+                if (selectedEventType) query.set('event_type', selectedEventType);
                 const data = await requestJson(apiUrl + '?' + query.toString(), {cache: 'no-store'});
+                renderFilters(data.filters || {});
                 renderEvents(Array.isArray(data.events) ? data.events : []);
             } catch (error) {
                 list.replaceChildren(element('p', 'npc-event-history-empty is-error', 'History failed to load: ' + (error.message || error)));
@@ -184,6 +226,10 @@
             searchTimer = setTimeout(searchNpcRecipients, 250);
         });
         refreshButton.addEventListener('click', load);
+        eventTypeSelect.addEventListener('change', function () {
+            selectedEventType = eventTypeSelect.value;
+            load();
+        });
         injectButton.addEventListener('click', async function () {
             const text = eventText.value.trim();
             if (!text) {

--- a/ui/js/npc_event_history.js
+++ b/ui/js/npc_event_history.js
@@ -38,7 +38,7 @@
                     <input type="search" class="npc-event-recipient-search" data-history-recipient-search placeholder="Search NPC profiles">
                     <div class="npc-event-search-results" data-history-search-results hidden></div>
                     <label class="npc-event-history-label" for="npc-event-history-text-${npcId}">Event</label>
-                    <textarea id="npc-event-history-text-${npcId}" class="npc-event-history-text" data-history-event-text maxlength="4000" placeholder="Character A wrote to Character B that the Player will come and ask for the item."></textarea>
+                    <textarea id="npc-event-history-text-${npcId}" class="npc-event-history-text" data-history-event-text maxlength="4000" placeholder="A gave B a sweetroll."></textarea>
                     <div class="npc-event-history-actions">
                         <span class="npc-event-history-status" data-history-status role="status" aria-live="polite"></span>
                         <button type="button" class="btn-cancel" data-history-inject>Inject Event</button>

--- a/ui/js/npc_event_history.js
+++ b/ui/js/npc_event_history.js
@@ -1,0 +1,222 @@
+(function (global) {
+    'use strict';
+
+    async function requestJson(url, options) {
+        const response = await fetch(url, options);
+        let payload = null;
+        try { payload = await response.json(); } catch (_error) {}
+        if (!response.ok || !payload || !payload.success) {
+            throw new Error((payload && payload.error) || ('HTTP ' + response.status));
+        }
+        return payload.data;
+    }
+
+    function element(tag, className, text) {
+        const node = document.createElement(tag);
+        if (className) node.className = className;
+        if (text !== undefined) node.textContent = text;
+        return node;
+    }
+
+    function mount(root, options) {
+        const npcId = Number(options.npcId || 0);
+        const npcName = String(options.npcName || '').trim();
+        const apiUrl = String(options.apiUrl || '../api/chim_npc_manager.php');
+        const recipients = new Map([[npcId, npcName]]);
+        let searchTimer = null;
+        let searchGeneration = 0;
+
+        root.innerHTML = `
+            <div class="npc-event-history-shell span-2">
+                <section class="npc-event-history-section">
+                    <div class="npc-event-history-heading">
+                        <div><h3>Inject Event</h3><p>Add roleplay context directly to this NPC, even while they are outside the current scene.</p></div>
+                    </div>
+                    <div class="npc-event-recipient-row" data-history-recipients></div>
+                    <label class="npc-event-history-label">Also include another NPC</label>
+                    <input type="search" class="npc-event-recipient-search" data-history-recipient-search placeholder="Search NPC profiles">
+                    <div class="npc-event-search-results" data-history-search-results hidden></div>
+                    <label class="npc-event-history-label" for="npc-event-history-text-${npcId}">Event</label>
+                    <textarea id="npc-event-history-text-${npcId}" class="npc-event-history-text" data-history-event-text maxlength="4000" placeholder="Character A wrote to Character B that the Player will come and ask for the item."></textarea>
+                    <div class="npc-event-history-actions">
+                        <span class="npc-event-history-status" data-history-status role="status" aria-live="polite"></span>
+                        <button type="button" class="btn-cancel" data-history-inject>Inject Event</button>
+                    </div>
+                </section>
+                <section class="npc-event-history-section">
+                    <div class="npc-event-history-heading">
+                        <div><h3>Recent Events</h3><p>The latest events routed to this NPC. Deleting a shared event removes it for every listed recipient.</p></div>
+                        <button type="button" class="btn-cancel" data-history-refresh>Refresh</button>
+                    </div>
+                    <div class="npc-event-history-list" data-history-list><p class="npc-event-history-empty">Open this tab to load recent events.</p></div>
+                </section>
+            </div>`;
+
+        const recipientBox = root.querySelector('[data-history-recipients]');
+        const recipientSearch = root.querySelector('[data-history-recipient-search]');
+        const searchResults = root.querySelector('[data-history-search-results]');
+        const eventText = root.querySelector('[data-history-event-text]');
+        const status = root.querySelector('[data-history-status]');
+        const list = root.querySelector('[data-history-list]');
+        const injectButton = root.querySelector('[data-history-inject]');
+        const refreshButton = root.querySelector('[data-history-refresh]');
+
+        function setStatus(message, isError) {
+            status.textContent = message || '';
+            status.classList.toggle('is-error', Boolean(isError));
+        }
+
+        function renderRecipients() {
+            recipientBox.replaceChildren();
+            recipients.forEach(function (name, id) {
+                const chip = element('span', 'npc-event-recipient-chip');
+                chip.appendChild(element('span', '', name));
+                if (Number(id) !== npcId) {
+                    const remove = element('button', '', 'x');
+                    remove.type = 'button';
+                    remove.setAttribute('aria-label', 'Remove ' + name);
+                    remove.addEventListener('click', function () {
+                        recipients.delete(id);
+                        renderRecipients();
+                    });
+                    chip.appendChild(remove);
+                }
+                recipientBox.appendChild(chip);
+            });
+        }
+
+        function renderSearchResults(npcs) {
+            searchResults.replaceChildren();
+            const available = npcs.filter(function (npc) { return !recipients.has(Number(npc.id)); });
+            if (!available.length) {
+                searchResults.hidden = true;
+                return;
+            }
+            available.forEach(function (npc) {
+                const button = element('button', 'npc-event-search-result', npc.name || 'Unknown NPC');
+                button.type = 'button';
+                button.addEventListener('click', function () {
+                    recipients.set(Number(npc.id), String(npc.name || 'Unknown NPC'));
+                    recipientSearch.value = '';
+                    searchResults.hidden = true;
+                    renderRecipients();
+                });
+                searchResults.appendChild(button);
+            });
+            searchResults.hidden = false;
+        }
+
+        async function searchNpcRecipients() {
+            const search = recipientSearch.value.trim();
+            if (search.length < 2) {
+                searchResults.hidden = true;
+                return;
+            }
+            const generation = ++searchGeneration;
+            const query = new URLSearchParams({operation: 'list', search: search, page: '1', limit: '10'});
+            try {
+                const data = await requestJson(apiUrl + '?' + query.toString(), {cache: 'no-store'});
+                if (generation === searchGeneration) renderSearchResults(Array.isArray(data.npcs) ? data.npcs : []);
+            } catch (_error) {
+                if (generation === searchGeneration) searchResults.hidden = true;
+            }
+        }
+
+        function renderEvents(events) {
+            list.replaceChildren();
+            if (!events.length) {
+                list.appendChild(element('p', 'npc-event-history-empty', 'No events are recorded for this NPC yet.'));
+                return;
+            }
+            events.forEach(function (event) {
+                const card = element('article', 'npc-event-history-card');
+                const header = element('div', 'npc-event-history-card-header');
+                const title = element('div');
+                title.appendChild(element('strong', '', event.manual_injection ? 'Injected Event' : (event.type || 'Event')));
+                title.appendChild(element('span', '', event.tamrielic_time || event.local_time || 'Unknown time'));
+                const deleteButton = element('button', 'npc-event-history-delete', 'Delete');
+                deleteButton.type = 'button';
+                deleteButton.addEventListener('click', async function () {
+                    const shared = Array.isArray(event.recipients) && event.recipients.length > 1;
+                    const warning = shared ? ' This removes it from every listed NPC history.' : '';
+                    if (!global.confirm('Delete this event?' + warning)) return;
+                    deleteButton.disabled = true;
+                    try {
+                        await requestJson(apiUrl, {
+                            method: 'POST',
+                            headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({operation: 'delete_event', id: npcId, rowid: Number(event.rowid)})
+                        });
+                        setStatus('Event deleted.', false);
+                        await load();
+                    } catch (error) {
+                        setStatus('Delete failed: ' + (error.message || error), true);
+                        deleteButton.disabled = false;
+                    }
+                });
+                header.append(title, deleteButton);
+                card.appendChild(header);
+                card.appendChild(element('p', 'npc-event-history-data', event.data || ''));
+                if (Array.isArray(event.recipients) && event.recipients.length) {
+                    card.appendChild(element('p', 'npc-event-history-audience', 'NPCs: ' + event.recipients.join(', ')));
+                }
+                list.appendChild(card);
+            });
+        }
+
+        async function load() {
+            if (npcId <= 0) return;
+            refreshButton.disabled = true;
+            list.replaceChildren(element('p', 'npc-event-history-empty', 'Loading recent events...'));
+            try {
+                const query = new URLSearchParams({operation: 'history', id: String(npcId), limit: '50'});
+                const data = await requestJson(apiUrl + '?' + query.toString(), {cache: 'no-store'});
+                renderEvents(Array.isArray(data.events) ? data.events : []);
+            } catch (error) {
+                list.replaceChildren(element('p', 'npc-event-history-empty is-error', 'History failed to load: ' + (error.message || error)));
+            } finally {
+                refreshButton.disabled = false;
+            }
+        }
+
+        recipientSearch.addEventListener('input', function () {
+            clearTimeout(searchTimer);
+            searchTimer = setTimeout(searchNpcRecipients, 250);
+        });
+        refreshButton.addEventListener('click', load);
+        injectButton.addEventListener('click', async function () {
+            const text = eventText.value.trim();
+            if (!text) {
+                setStatus('Enter an event before injecting it.', true);
+                eventText.focus();
+                return;
+            }
+            injectButton.disabled = true;
+            setStatus('Injecting event...', false);
+            try {
+                const data = await requestJson(apiUrl, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        operation: 'inject_event',
+                        id: npcId,
+                        event: text,
+                        recipient_ids: Array.from(recipients.keys())
+                    })
+                });
+                eventText.value = '';
+                setStatus(data.message || 'Event injected.', false);
+                await load();
+            } catch (error) {
+                setStatus('Injection failed: ' + (error.message || error), true);
+            } finally {
+                injectButton.disabled = false;
+            }
+        });
+
+        renderRecipients();
+        return {load: load};
+    }
+
+    global.chimNpcEventHistory = {mount: mount};
+})(window);

--- a/unittests/tests/HistoricContextTest.php
+++ b/unittests/tests/HistoricContextTest.php
@@ -126,6 +126,33 @@ final class HistoricContextTest extends DatabaseTestCase
         $this->assertContains("Prisoner: Keep your voice down.", $contents);
     }
 
+    public function testBuildHistoricContextKeepsInjectedEventForOffSceneRecipient(): void
+    {
+        $injectedEvent = "(Camilla wrote to Farengar that the Prisoner will ask for the sealed letter.)";
+        $this->insertEvent("inputtext", $injectedEvent, "|Camilla|Lydia|", 90, 90, 90);
+
+        for ($index = 0; $index < 8; $index++) {
+            $this->insertEvent(
+                "inputtext",
+                "(Unrelated quest event {$index}.)",
+                "|Belethor|",
+                100 + $index,
+                100 + $index,
+                100 + $index
+            );
+        }
+
+        $lydiaContents = array_map(static function (array $row): string {
+            return (string)($row["content"] ?? "");
+        }, buildHistoricContext("Lydia", -5));
+        $ysoldaContents = array_map(static function (array $row): string {
+            return (string)($row["content"] ?? "");
+        }, buildHistoricContext("Ysolda", -5));
+
+        $this->assertContains($injectedEvent, $lydiaContents);
+        $this->assertNotContains($injectedEvent, $ysoldaContents);
+    }
+
     public function testBuildHistoricContextIncludesNarratorRowsForSharedAudience(): void
     {
         $this->insertEvent(


### PR DESCRIPTION
## What

- adds exact-NPC recent event history to the PHP NPC editor
- limits History to the PHP Adventure Log's default narrative event allow list, then applies saved Event Log hidden types
- adds an NPC-scoped event-type filter and Event Log-style recent-events table capped at the latest 100 rows
- places Background Life second-last and History last in the PHP NPC editor
- lets users inject ordinary `inputtext` events for an NPC who is outside the current scene
- supports optional additional NPC recipients and guarded event deletion
- keeps the existing profile rollback viewer under the clearer `Profile Versions` label

## Why

NPCs need to remember cross-scene handoffs, such as one NPC giving another a sweetroll, even when they are not currently together.

## Maintainer Discussion

- [ ] I discussed this PR with `RANGROO` or `tyler.maister` in Discord.

## Related PRs

Companion PrismaUI PR: https://github.com/Dwemer-Dynamics/CHIM/pull/126

## Notes

- No schema migration or new event type. Injected rows use the existing `inputtext` event/context path.
- Existing save-load eventlog cleanup rolls these rows back when an older save predates them.
- History reads the Event Log hide-list but does not mutate it; the local type selector only narrows the edited NPC.
- Internal/noisy rows such as `infoloc` are excluded from both History rows and its type selector.
- `ui/core/npc_master.php` also overlaps draft PR #594, but this change is scoped to event history/injection rather than persistent NPC tasks.
- Focused PHPUnit execution is currently blocked before assertions on current `unstable`: `debug/db_updates.php` calls `sql::escapeLiteral()`, which is absent from the active test database class.

## Validation

- `php -l ui/api/chim_npc_manager.php`
- `node --check ui/js/npc_event_history.js`
- `git diff --check`
- copied allow list programmatically matched `ui/adventurelog.php` exactly
- full local release deploy using the feature worktrees, followed by focused UI/API sync for this update
- deployed server endpoint hash matched the feature worktree
- live history API: 100 Dorthe events, only allowed event types, no `infoloc` in rows or filter options
- live type filters: `chat` returned only `chat`; requesting `infoloc` returned zero rows
- deployed two-recipient `inputtext` inject/read/delete round trip using `Dorthe gave Alvor a sweetroll.`, with the temporary row removed from both histories
- browser PHP editor: 100 rows, allowed type options only, and final tab order `Background Life` -> `History`