### PR TITLE
Use DeepSeek V4 Flash as the Standard LLM

### DIFF
--- a/conf/conf.sample.php
+++ b/conf/conf.sample.php
@@ -171,8 +171,8 @@ $RELLLM_CONNECTOR=5; // Relationship Management default (Mistral Small 3.2 24B)
 //[AI/LLM Connectors]
 //OpenRouter JSON
 $CONNECTOR["openrouterjson"]["url"]="https://openrouter.ai/api/v1/chat/completions"; //API endpoint.
-$CONNECTOR["openrouterjson"]["model"]="z-ai/glm-4.7"; //LLM model.
-$CONNECTOR["openrouterjson"]["reasoning_model"]=true; //This is a reasoning model, could output CoT.
+$CONNECTOR["openrouterjson"]["model"]="deepseek/deepseek-v4-flash"; //LLM model.
+$CONNECTOR["openrouterjson"]["reasoning_model"]=false; //This is a reasoning model, could output CoT.
 $CONNECTOR["openrouterjson"]["fallback_models"]=""; //comma separated models.
 $CONNECTOR["openrouterjson"]["PROVIDER"]=""; //use only this list of providers from OpenRouter
 $CONNECTOR["openrouterjson"]["providers_sort"]="default"; //Prioritize providers on selected attribute.

--- a/conf/conf.sample.php
+++ b/conf/conf.sample.php
@@ -172,7 +172,7 @@ $RELLLM_CONNECTOR=5; // Relationship Management default (Mistral Small 3.2 24B)
 //OpenRouter JSON
 $CONNECTOR["openrouterjson"]["url"]="https://openrouter.ai/api/v1/chat/completions"; //API endpoint.
 $CONNECTOR["openrouterjson"]["model"]="deepseek/deepseek-v4-flash"; //LLM model.
-$CONNECTOR["openrouterjson"]["reasoning_model"]=false; //This is a reasoning model, could output CoT.
+$CONNECTOR["openrouterjson"]["reasoning_model"]=true; //This is a reasoning model, could output CoT.
 $CONNECTOR["openrouterjson"]["fallback_models"]=""; //comma separated models.
 $CONNECTOR["openrouterjson"]["PROVIDER"]=""; //use only this list of providers from OpenRouter
 $CONNECTOR["openrouterjson"]["providers_sort"]="default"; //Prioritize providers on selected attribute.

--- a/lib/core/database_schema/core_llm_connector.sql
+++ b/lib/core/database_schema/core_llm_connector.sql
@@ -86,7 +86,7 @@ INSERT INTO public.core_llm_connector (
     id, label, metadata, url, model, provider, driver, reasoning_model,
     max_tokens, enforce_json, prefill_json, api_badge_id, json_schema, temperature, service
 ) VALUES
-    (1, 'GLM 4.7', '{}', 'https://openrouter.ai/api/v1/chat/completions', 'z-ai/glm-4.7', 'openrouter', 'openrouterjson', 1, 750, 1, 0, 1, 1, 1, 'openrouter'),
+    (1, 'DeepSeek V4 Flash', '{}', 'https://openrouter.ai/api/v1/chat/completions', 'deepseek/deepseek-v4-flash', 'openrouter', 'openrouterjson', NULL, 750, 1, 0, 1, 1, 0.6, 'openrouter'),
     (2, 'Gemini 2.5 Flash Lite', '{}', 'https://openrouter.ai/api/v1/chat/completions', 'google/gemini-2.5-flash-lite', 'openrouter', 'openrouterjson', NULL, 750, 1, 0, 1, 1, 1, 'openrouter'),
     (3, 'GLM 5.2',               '{}', 'https://openrouter.ai/api/v1/chat/completions', 'z-ai/glm-5.2', 'openrouter', 'openrouterjson', 1, 750, 1, 0, 1, 1, 1, 'openrouter'),
     (4, 'DeepSeek V4 Pro',          '{}', 'https://openrouter.ai/api/v1/chat/completions', 'deepseek/deepseek-v4-pro', 'openrouter', 'openrouterjson', NULL, 750, 1, 0, 1, 1, 0.6, 'openrouter'),

--- a/lib/core/database_schema/core_llm_connector.sql
+++ b/lib/core/database_schema/core_llm_connector.sql
@@ -86,7 +86,7 @@ INSERT INTO public.core_llm_connector (
     id, label, metadata, url, model, provider, driver, reasoning_model,
     max_tokens, enforce_json, prefill_json, api_badge_id, json_schema, temperature, service
 ) VALUES
-    (1, 'DeepSeek V4 Flash', '{}', 'https://openrouter.ai/api/v1/chat/completions', 'deepseek/deepseek-v4-flash', 'openrouter', 'openrouterjson', NULL, 750, 1, 0, 1, 1, 0.6, 'openrouter'),
+    (1, 'DeepSeek V4 Flash', '{}', 'https://openrouter.ai/api/v1/chat/completions', 'deepseek/deepseek-v4-flash', 'openrouter', 'openrouterjson', 1, 750, 1, 0, 1, 1, 0.6, 'openrouter'),
     (2, 'Gemini 2.5 Flash Lite', '{}', 'https://openrouter.ai/api/v1/chat/completions', 'google/gemini-2.5-flash-lite', 'openrouter', 'openrouterjson', NULL, 750, 1, 0, 1, 1, 1, 'openrouter'),
     (3, 'GLM 5.2',               '{}', 'https://openrouter.ai/api/v1/chat/completions', 'z-ai/glm-5.2', 'openrouter', 'openrouterjson', 1, 750, 1, 0, 1, 1, 1, 'openrouter'),
     (4, 'DeepSeek V4 Pro',          '{}', 'https://openrouter.ai/api/v1/chat/completions', 'deepseek/deepseek-v4-pro', 'openrouter', 'openrouterjson', NULL, 750, 1, 0, 1, 1, 0.6, 'openrouter'),

--- a/lib/core/llm_connector.class.php
+++ b/lib/core/llm_connector.class.php
@@ -298,7 +298,7 @@ class LLMConnector
             $apiKey = $this->getApiKeyForBadge($currentConnectorData["api_badge_id"] ?? null);
             // error_log("[CORE SYSTEM] Using new profile system CONNECTOR openaijson {$currentConnectorData["id"]} {$currentConnectorData["driver"]}/{$currentConnectorData["model"]}");
             $GLOBALS["CONNECTOR"]["openrouterjson"]["url"] = $currentConnectorData["url"] ?? 'https://openrouter.ai/api/v1/chat/completions';
-            $GLOBALS["CONNECTOR"]["openrouterjson"]["model"] = $currentConnectorData["model"] ?? 'z-ai/glm-4.7';
+            $GLOBALS["CONNECTOR"]["openrouterjson"]["model"] = $currentConnectorData["model"] ?? 'deepseek/deepseek-v4-flash';
             $GLOBALS["CONNECTOR"]["openrouterjson"]["PROVIDER"] = $currentConnectorData["provider"] ?? '';
             $GLOBALS["CONNECTOR"]["openrouterjson"]["reasoning_model"] = $currentConnectorData["reasoning_model"] ?? false;
             $GLOBALS["CONNECTOR"]["openrouterjson"]["max_tokens"] = $currentConnectorData["max_tokens"] ?? '1024';

--- a/ui/quickstart.php
+++ b/ui/quickstart.php
@@ -901,8 +901,8 @@ echo '<section class="qs-section">
                 <div id="qs_llm_connectors_cards_default" style="' . $llmCardsDefaultStyle . '">
                     <div style="background:#1f1f1f; border:1px solid #3b3b3b; border-radius:8px; padding:12px;">
                         <div style="font-size:14px; color:#cfd9ea;">&#x1F579;&#xFE0F; <b>Standard</b></div>
-                        <div style="margin-top:6px; color:#9fb1c9;">OpenRouter: GLM 4.7 (z-ai/glm-4.7)</div>
-                        <div style="margin-top:4px; color:#bbb; font-size:12px;">$0.38/M input | $1.74/M output</div>
+                        <div style="margin-top:6px; color:#9fb1c9;">OpenRouter: DeepSeek V4 Flash (deepseek/deepseek-v4-flash)</div>
+                        <div style="margin-top:4px; color:#bbb; font-size:12px;">$0.14/M input | $0.28/M output</div>
                     </div>
                     <div style="background:#1f1f1f; border:1px solid #3b3b3b; border-radius:8px; padding:12px;">
                         <div style="font-size:14px; color:#cfd9ea;">&#x1F3C3;&#x200D;&#x2642;&#xFE0F; <b>Fast</b></div>


### PR DESCRIPTION
## Summary

- replace GLM 4.7 with DeepSeek V4 Flash for the seeded Standard LLM connector
- mark V4 Flash as reasoning-capable so the existing driver explicitly sends `reasoning.enabled=false` instead of allowing DeepSeek's default high-effort thinking mode
- keep the 750-token, temperature 0.6 JSON-schema configuration; Fast, Powerful, and Experimental remain unchanged

## Compatibility

No migration forces an existing user-selected connector to change.

## Validation

- PHP lint passed for `conf/conf.sample.php`, `lib/core/llm_connector.class.php`, and `ui/quickstart.php`
- disposable PostgreSQL load confirmed connector ID 1 resolves to DeepSeek V4 Flash with `reasoning_model=1`, 750 max tokens, JSON/schema enabled, and temperature 0.6
- live CHIM connector probe sent `reasoning: { exclude: true, enabled: false }`, returned valid action JSON in 5.349 seconds, and OpenRouter reported `reasoning_tokens: 0`; the prior omitted-reasoning probe took 9.112 seconds
- `git diff --check` passed
- CHIM unstable push guard: PR REQUIRED for core runtime paths

## Deployment

The branch was not deployed. The live probe used a temporary connector matching these defaults in the existing local CHIM runtime; the connector and disposable database state were removed afterward. In-game behavior remains untested.

## Related PRs

- https://github.com/Dwemer-Dynamics/StobeServer/pull/84
- https://github.com/Dwemer-Dynamics/DialecticServer/pull/65