### PR TITLE
Compact vanilla NPC action tools

### DIFF
--- a/connector/openai.php
+++ b/connector/openai.php
@@ -549,6 +549,13 @@ class openai
                 $parameter = $parameterArr;
 
                 $functionCodeName = getFunctionCodeName($this->_functionName);
+                $executionResolution = resolveFunctionExecutionAction($functionCodeName, $parameter);
+                if (empty($executionResolution["valid"])) {
+                    Logger::warn("openai: Invalid grouped action parameters: " . implode(", ", $executionResolution["missing_required"]));
+                    return null;
+                }
+                $functionCodeName = $executionResolution["code_name"];
+                $parameter = $executionResolution["parameter_value"];
                 $parameter = buildFunctionExecutionParameter($functionCodeName, $parameter);
                 $commandStr = "Herika|command|$functionCodeName@$parameter\r\n";
 
@@ -610,6 +617,13 @@ class openai
                 $parameter = $parameterArr;
 
                 $functionCodeName = getFunctionCodeName($this->_functionName);
+                $executionResolution = resolveFunctionExecutionAction($functionCodeName, $parameter);
+                if (empty($executionResolution["valid"])) {
+                    Logger::warn("openai: Invalid grouped action parameters: " . implode(", ", $executionResolution["missing_required"]));
+                    return null;
+                }
+                $functionCodeName = $executionResolution["code_name"];
+                $parameter = $executionResolution["parameter_value"];
                 $parameter = buildFunctionExecutionParameter($functionCodeName, $parameter);
                 $commandStr = "Herika|command|$functionCodeName@$parameter\r\n";
 

--- a/connector/openrouter.php
+++ b/connector/openrouter.php
@@ -506,6 +506,13 @@ class openrouter
             $parameterArr = json_decode($this->_parameterBuff, true);
                 $parameter = $parameterArr;
             $functionCodeName = getFunctionCodeName($this->_functionName);
+            $executionResolution = resolveFunctionExecutionAction($functionCodeName, $parameter);
+            if (empty($executionResolution["valid"])) {
+                Logger::warn("openrouter: Invalid grouped action parameters: " . implode(", ", $executionResolution["missing_required"]));
+                return $this->_commandBuffer;
+            }
+            $functionCodeName = $executionResolution["code_name"];
+            $parameter = $executionResolution["parameter_value"];
             $parameter = buildFunctionExecutionParameter($functionCodeName, $parameter);
             $commandStr = "Herika|command|$functionCodeName@$parameter\r\n";
 
@@ -563,6 +570,13 @@ class openrouter
             $parameterArr = json_decode($this->_parameterBuff, true);
                 $parameter = $parameterArr;
             $functionCodeName = getFunctionCodeName($this->_functionName);
+            $executionResolution = resolveFunctionExecutionAction($functionCodeName, $parameter);
+            if (empty($executionResolution["valid"])) {
+                Logger::warn("openrouter: Invalid grouped action parameters: " . implode(", ", $executionResolution["missing_required"]));
+                return $this->_commandBuffer;
+            }
+            $functionCodeName = $executionResolution["code_name"];
+            $parameter = $executionResolution["parameter_value"];
             $parameter = buildFunctionExecutionParameter($functionCodeName, $parameter);
             $commandStr = "Herika|command|$functionCodeName@$parameter\r\n";
 

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -2425,7 +2425,7 @@ function functionExecutionParameterValueIsEmpty($parameterValue)
     return trim(strval($parameterValue)) === "";
 }
 
-function buildFunctionParameterValueFromResponse($functionDef, $parsedResponse)
+function buildFunctionParameterValueFromResponse($functionDef, $parsedResponse, $forceObject = false)
 {
     $properties = $functionDef["parameters"]["properties"] ?? [];
     $requiredParameters = [];
@@ -2443,7 +2443,7 @@ function buildFunctionParameterValueFromResponse($functionDef, $parsedResponse)
         }
     }
 
-    if (count($properties) > 1) {
+    if ($forceObject || count($properties) > 1) {
         $parameters = [];
         foreach ($properties as $parameterName => $parameterSchema) {
             if (array_key_exists($parameterName, $parsedResponse)) {
@@ -2481,7 +2481,12 @@ function buildFunctionExecutionContextFromResponse($parsedResponse)
     $missingRequired = [];
 
     if (is_array($functionDef)) {
-        $parameterData = buildFunctionParameterValueFromResponse($functionDef, is_array($parsedResponse) ? $parsedResponse : []);
+        $forceObjectParameters = isset($GLOBALS['HERIKA_GROUPED_ACTION_SPECS'][$functionCodeName]);
+        $parameterData = buildFunctionParameterValueFromResponse(
+            $functionDef,
+            is_array($parsedResponse) ? $parsedResponse : [],
+            $forceObjectParameters
+        );
         $parameterValue = $parameterData["parameter_value"];
         $missingRequired = $parameterData["missing_required"];
     }

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -2008,6 +2008,14 @@ function getFunctionNameAliases()
 function getFunctionCodeName($key)
 {
     $key = strval($key);
+
+    if (isset($GLOBALS["HERIKA_GROUPED_ACTION_NAME_TO_CODE"]) && is_array($GLOBALS["HERIKA_GROUPED_ACTION_NAME_TO_CODE"])) {
+        $groupedCode = $GLOBALS["HERIKA_GROUPED_ACTION_NAME_TO_CODE"][$key] ?? false;
+        if ($groupedCode !== false) {
+            return $groupedCode;
+        }
+    }
+
     static $resolvedCodeNames = [];
 
     if (array_key_exists($key, $resolvedCodeNames)) {
@@ -2478,6 +2486,15 @@ function buildFunctionExecutionContextFromResponse($parsedResponse)
         $missingRequired = $parameterData["missing_required"];
     }
 
+    $submittedParameterValue = $parameterValue;
+    $executionResolution = resolveFunctionExecutionAction($functionCodeName, $parameterValue);
+    $functionCodeName = $executionResolution["code_name"];
+    $parameterValue = $executionResolution["parameter_value"];
+    $missingRequired = array_values(array_unique(array_merge(
+        $missingRequired,
+        $executionResolution["missing_required"]
+    )));
+
     if (strcasecmp($functionCodeName, 'TakeHeldItem') === 0) {
         $resolvedHeldItem = HeldItems::resolveHeldIdentifier(strval($parameterValue));
         if ($resolvedHeldItem === null) {
@@ -2500,7 +2517,34 @@ function buildFunctionExecutionContextFromResponse($parsedResponse)
         "parameter_string" => buildFunctionExecutionParameter($functionCodeName, $parameterValue),
         "missing_required" => $missingRequired,
         "has_required_parameters" => functionDefinitionHasRequiredParameters($functionDef),
-        "parameter_is_empty" => functionExecutionParameterValueIsEmpty($parameterValue),
+        "parameter_is_empty" => functionExecutionParameterValueIsEmpty($submittedParameterValue),
+        "parameter_resolution_valid" => $executionResolution["valid"],
+    ];
+}
+
+// Resolves compact runtime tools before connector-specific command serialization.
+function resolveFunctionExecutionAction($functionCodeName, $parameterValue)
+{
+    $functionCodeName = trim(strval($functionCodeName));
+    $resolution = function_exists('herikaActionGroupsResolveExecution')
+        ? herikaActionGroupsResolveExecution($functionCodeName, $parameterValue)
+        : null;
+    if (!is_array($resolution)) {
+        return [
+            "code_name" => $functionCodeName,
+            "parameter_value" => $parameterValue,
+            "missing_required" => [],
+            "valid" => true,
+        ];
+    }
+
+    return [
+        "code_name" => trim(strval($resolution["code_name"] ?? '')),
+        "parameter_value" => $resolution["parameter_value"] ?? '',
+        "missing_required" => is_array($resolution["missing_required"] ?? null)
+            ? $resolution["missing_required"]
+            : [],
+        "valid" => !empty($resolution["valid"]),
     ];
 }
 
@@ -2515,6 +2559,12 @@ function queueFunctionExecutionCommand(&$commandBuffer, &$alreadySent, $executio
         if ($actionName !== "Talk") {
             Logger::warn("{$connectorName}: Function not found for {$actionName}");
         }
+        return false;
+    }
+
+    if (array_key_exists("parameter_resolution_valid", $executionContext) && empty($executionContext["parameter_resolution_valid"])) {
+        $missingRequired = $executionContext["missing_required"] ?? [];
+        Logger::warn("{$connectorName}: Invalid grouped action parameters: " . implode(", ", $missingRequired));
         return false;
     }
 
@@ -2812,6 +2862,10 @@ file_put_contents(__DIR__ . "/../log/bug_func.txt", print_r($GLOBALS["ENABLED_FU
 chimTraceFunctionsIncludePhase(__LINE__, 'bug_func_write_done', $startTime);
 
 $GLOBALS["FUNCTIONS"] = array_values($GLOBALS["FUNCTIONS"]); //Get rid of array keys
+
+if (function_exists('herikaActionGroupsApplyToRuntime')) {
+    herikaActionGroupsApplyToRuntime();
+}
 
 chimTraceFunctionsIncludePhase(__LINE__, 'functions_reindexed', $startTime);
 

--- a/functions/json_response.php
+++ b/functions/json_response.php
@@ -188,6 +188,36 @@
         }
     }
 
+    if (!function_exists('chimGetActionResponseFieldDescriptions')) {
+        // Keeps the shared JSON envelope aligned with the currently active grouped action modes.
+        function chimGetActionResponseFieldDescriptions(): array
+        {
+            $modeChoices = [];
+            $modeValues = [''];
+            foreach (($GLOBALS['HERIKA_GROUPED_ACTION_SPECS'] ?? []) as $spec) {
+                $actionName = trim(strval($spec['action_name'] ?? ''));
+                $variants = is_array($spec['variants'] ?? null) ? array_keys($spec['variants']) : [];
+                if ($actionName !== '' && count($variants) > 0) {
+                    $modeChoices[] = $actionName . '=' . implode('|', $variants);
+                    $modeValues = array_merge($modeValues, $variants);
+                }
+            }
+
+            $playerName = strval($GLOBALS['PLAYER_NAME'] ?? 'the player');
+            $modeDescription = count($modeChoices) > 0
+                ? 'For a grouped action, select exactly one active mode: ' . implode('; ', $modeChoices) . '. Leave blank for Talk or an individual action.'
+                : 'Leave blank unless the selected action description explicitly lists a mode.';
+
+            return [
+                'mode' => $modeDescription,
+                'mode_enum' => array_values(array_unique($modeValues)),
+                'target' => "Actor, recipient, or destination required by the selected action. Prefer exact Name [RefID: XXXXXXXX] from people_present for actors. For Travel_To use the destination; Consume uses the exact BaseID:ItemName inventory identifier; TeleportNPC uses the actor to teleport; SpawnItem and SpawnGold use the recipient; SpawnNPC uses the SNQE template key; KillTarget uses the victim; CreateNewNPC and DirectorCommand use their requested brief. Use '{$playerName}', PLAYER, or me for player-targeted actions. For grouped actions, put the variant in mode, never target. Leave blank when no target is needed.",
+                'item' => 'Actual item, spell, location, or crime detail required by the selected action. Use exact shown identifiers for inventory, held, or nearby items. Handle_Crime add_bounty uses the crime type here. TeleportNPC uses the destination and SpawnItem uses the item name. For grouped actions, put the variant in mode, never item. Leave blank when no item or detail is needed.',
+                'amount' => 'Positive integer quantity when required. It is required for SpawnItem, SpawnNPC, SpawnGold, Give in gold mode, and Handle_Crime add_bounty when item is Custom; optional for Give in item mode. Omit it when the selected action does not use an amount.',
+            ];
+        }
+    }
+
     chimRefreshJsonResponseState(true);
 
     // specify the available actions which will be made available in the context
@@ -295,6 +325,7 @@
         $moodDescription = empty($moods)
             ? "choose exactly one mood while speaking, never combine moods"
             : "choose exactly one mood while speaking from this list, never combine moods: ".implode("|", $moods);
+        $actionFieldDescriptions = chimGetActionResponseFieldDescriptions();
     
         // Auto-detect language from TTS config if LLM_LANG not set
         if (!isset($GLOBALS["LLM_LANG"]) && isset($GLOBALS["LANG_LLM_XTTS"]) && $GLOBALS["LANG_LLM_XTTS"]) {
@@ -354,9 +385,10 @@
                     "message"=>$messageDescription,
                     "mood"=>$moodDescription,
                     "action"=>implode("|",$GLOBALS["FUNC_LIST"]),
-                    "target"=>"action target actor (prefer exact Name [RefID: XXXXXXXX] from people_present, otherwise use actor name). For TeleportNPC, this is the actor to teleport. For SpawnItem and SpawnGold, this is the actor who should receive the spawned item or gold. For SpawnNPC, this is the SNQE NPC template key to spawn near {$GLOBALS["PLAYER_NAME"]}. For KillTarget, this is the actor to kill. For CreateNewNPC, this is a short creation brief for the new nearby NPC. For DirectorCommand, this is a short freeform director brief describing the scene instruction or event to stage. Use '{$GLOBALS["PLAYER_NAME"]}', PLAYER, or me for player-targeted narrator actions. Leave blank when the chosen action does not need a target.",
-                    "item"=>"item identifier (REQUIRED for GiveItemTo: use exact BaseID:ItemName from inventory; for Take_Held_Item: use exact RefID:ItemName from shown in <held_items>, for PickupItem: use exact RefID:ItemName from nearby_items; for CastSpell: use exact spell name from spells) OR amount of gold (REQUIRED when action is GiveGoldTo - number as string, e.g. '50') OR destination location name (REQUIRED when action is TeleportNPC) OR item name from the descriptions database (REQUIRED when action is SpawnItem). Leave blank when the chosen action does not need an item, including SpawnGold and SpawnNPC and CreateNewNPC and DirectorCommand.",
-                    "amount"=>"quantity to give or spawn only when the chosen action supports it. REQUIRED when action is SpawnItem or SpawnNPC or SpawnGold. Optional when action is GiveItemTo. Leave blank for other actions such as KillTarget or TeleportNPC or CreateNewNPC or DirectorCommand. Use a positive integer when needed.",
+                    "mode"=>$actionFieldDescriptions["mode"],
+                    "target"=>$actionFieldDescriptions["target"],
+                    "item"=>$actionFieldDescriptions["item"],
+                    "amount"=>$actionFieldDescriptions["amount"],
                     "lang"=>isset($GLOBALS["LLM_LANG"])?$GLOBALS["LLM_LANG"]:"en|es|fr|de|it|pt|ru|zh-cn|ja|ko|ar|pl|tr|cs|nl|hu|hi",
                 ];
             } else {
@@ -366,9 +398,10 @@
                     "message"=>$messageDescription,
                     "mood"=>$moodDescription,
                     "action"=>implode("|",$GLOBALS["FUNC_LIST"]),
-                    "target"=>"action target actor (prefer exact Name [RefID: XXXXXXXX] from people_present, otherwise use actor name). For TeleportNPC, this is the actor to teleport. For SpawnItem and SpawnGold, this is the actor who should receive the spawned item or gold. For SpawnNPC, this is the SNQE NPC template key to spawn near {$GLOBALS["PLAYER_NAME"]}. For KillTarget, this is the actor to kill. For CreateNewNPC, this is a short creation brief for the new nearby NPC. For DirectorCommand, this is a short freeform director brief describing the scene instruction or event to stage. Use '{$GLOBALS["PLAYER_NAME"]}', PLAYER, or me for player-targeted narrator actions. Leave blank when the chosen action does not need a target.",
-                    "item"=>"item identifier (REQUIRED for GiveItemTo: use exact BaseID:ItemName from inventory; for Take_Held_Item: use exact RefID:ItemName from shown in <held_items>,for PickupItem: use exact RefID:ItemName from nearby_items; for CastSpell: use exact spell name from spells) OR amount of gold (REQUIRED when action is GiveGoldTo - number as string, e.g. '50') OR destination location name (REQUIRED when action is TeleportNPC) OR item name from the descriptions database (REQUIRED when action is SpawnItem). Leave blank when the chosen action does not need an item, including SpawnGold and SpawnNPC and CreateNewNPC and DirectorCommand.",
-                    "amount"=>"quantity to give or spawn only when the chosen action supports it. REQUIRED when action is SpawnItem or SpawnNPC or SpawnGold. Optional when action is GiveItemTo. Leave blank for other actions such as KillTarget or TeleportNPC or CreateNewNPC or DirectorCommand. Use a positive integer when needed."
+                    "mode"=>$actionFieldDescriptions["mode"],
+                    "target"=>$actionFieldDescriptions["target"],
+                    "item"=>$actionFieldDescriptions["item"],
+                    "amount"=>$actionFieldDescriptions["amount"]
                 ];
             }
         } else {
@@ -378,9 +411,10 @@
                     "listener"=>$listenerDesc,
                     "mood"=>$moodDescription,
                     "action"=>implode("|",$GLOBALS["FUNC_LIST"]),
-                    "target"=>"action target actor (prefer exact Name [RefID: XXXXXXXX] from people_present, otherwise use actor name). For TeleportNPC, this is the actor to teleport. For SpawnItem and SpawnGold, this is the actor who should receive the spawned item or gold. For SpawnNPC, this is the SNQE NPC template key to spawn near {$GLOBALS["PLAYER_NAME"]}. For KillTarget, this is the actor to kill. For CreateNewNPC, this is a short creation brief for the new nearby NPC. For DirectorCommand, this is a short freeform director brief describing the scene instruction or event to stage. Use '{$GLOBALS["PLAYER_NAME"]}', PLAYER, or me for player-targeted narrator actions. Leave blank when the chosen action does not need a target.",
-                    "item"=>"item identifier (REQUIRED for GiveItemTo: use exact BaseID:ItemName from inventory; for Take_Held_Item: use exact RefID:ItemName from shown in <held_items>,for PickupItem: use exact RefID:ItemName from nearby_items; for CastSpell: use exact spell name from spells) OR amount of gold (REQUIRED when action is GiveGoldTo - number as string, e.g. '50') OR destination location name (REQUIRED when action is TeleportNPC) OR item name from the descriptions database (REQUIRED when action is SpawnItem). Leave blank when the chosen action does not need an item, including SpawnGold and SpawnNPC and CreateNewNPC and DirectorCommand.",
-                    "amount"=>"quantity to give or spawn only when the chosen action supports it. REQUIRED when action is SpawnItem or SpawnNPC or SpawnGold. Optional when action is GiveItemTo. Leave blank for other actions such as KillTarget or TeleportNPC or CreateNewNPC or DirectorCommand. Use a positive integer when needed.",
+                    "mode"=>$actionFieldDescriptions["mode"],
+                    "target"=>$actionFieldDescriptions["target"],
+                    "item"=>$actionFieldDescriptions["item"],
+                    "amount"=>$actionFieldDescriptions["amount"],
                     "lang"=>isset($GLOBALS["LLM_LANG"])?$GLOBALS["LLM_LANG"]:"en|es|fr|de|it|pt|ru|zh-cn|ja|ko|ar|pl|tr|cs|nl|hu|hi",
                     "message"=>$messageDescription
                 ];
@@ -390,9 +424,10 @@
                     "listener"=>$listenerDesc,
                     "mood"=>$moodDescription,
                     "action"=>implode("|",$GLOBALS["FUNC_LIST"]),
-                    "target"=>"action target actor (prefer exact Name [RefID: XXXXXXXX] from people_present, otherwise use actor name). For TeleportNPC, this is the actor to teleport. For SpawnItem and SpawnGold, this is the actor who should receive the spawned item or gold. For SpawnNPC, this is the SNQE NPC template key to spawn near {$GLOBALS["PLAYER_NAME"]}. For KillTarget, this is the actor to kill. For CreateNewNPC, this is a short creation brief for the new nearby NPC. Use '{$GLOBALS["PLAYER_NAME"]}', PLAYER, or me for player-targeted narrator actions. Leave blank when the chosen action does not need a target.",
-                    "item"=>"item identifier (REQUIRED for GiveItemTo: use exact BaseID:ItemName from inventory; for Take_Held_Item: use exact RefID:ItemName from shown in <held_items>, for PickupItem: use exact RefID:ItemName from nearby_items; for CastSpell: use exact spell name from spells) OR destination location name (REQUIRED when action is TeleportNPC) OR item name from the descriptions database (REQUIRED when action is SpawnItem). Leave blank when the chosen action does not need an item, including SpawnGold and SpawnNPC and CreateNewNPC.",
-                    "amount"=>"quantity to give or spawn only when the chosen action supports it. REQUIRED when action is SpawnItem or SpawnNPC or SpawnGold. Optional when action is GiveItemTo. Leave blank for other actions such as KillTarget or TeleportNPC or CreateNewNPC. Use a positive integer when needed.",
+                    "mode"=>$actionFieldDescriptions["mode"],
+                    "target"=>$actionFieldDescriptions["target"],
+                    "item"=>$actionFieldDescriptions["item"],
+                    "amount"=>$actionFieldDescriptions["amount"],
                     "message"=>$messageDescription
                 ];
             }
@@ -432,6 +467,7 @@
         $moods=normalizeEmoteMoods($GLOBALS["EMOTEMOODS"] ?? "");
         shuffle($moods);
         $moodDescription = "choose exactly one mood while speaking, never combine moods";
+        $actionFieldDescriptions = chimGetActionResponseFieldDescriptions();
         $listenerDescription = chimIsVisionRequest()
             ? "leave blank unless {$promptCharacterName} directly addresses someone while explaining the Soulgaze vision"
             : "specify who {$promptCharacterName} is talking to, comma separated, max two listeners, in addressing order";
@@ -493,17 +529,23 @@
                                 "description" => "a valid action (refer to available actions list)",
                                 "enum" => $GLOBALS["FUNC_LIST"]
                             ),
+                        "mode" => array(
+                            "type" => "string",
+                            "description" => $actionFieldDescriptions["mode"],
+                            "enum" => $actionFieldDescriptions["mode_enum"]
+                        ),
                         "target" => array(
                             "type" => "string",
-                "description" => "action target actor (prefer exact Name [RefID: XXXXXXXX] from people_present, otherwise use actor name)| destination when action is Travel_To|exact BaseID:ItemName inventory identifier when action is Consume| actor to teleport when action is TeleportNPC| actor to receive spawned gold when action is SpawnGold| actor to receive the spawned item when action is SpawnItem| SNQE NPC template key when action is SpawnNPC| actor to kill when action is KillTarget| short creation brief when action is CreateNewNPC| short freeform director brief when action is DirectorCommand. Use '{$GLOBALS["PLAYER_NAME"]}', PLAYER, or me for player-targeted narrator actions. Leave blank when the chosen action does not need a target. Also used for specifying destination when using Travel_To"
+                            "description" => $actionFieldDescriptions["target"]
                         ),
                         "item" => array(
                             "type" => "string",
-                "description" => "item identifier (REQUIRED for GiveItemTo: use exact BaseID:ItemName from inventory;for Take_Held_Item: use exact RefID:ItemName from shown in <held_items>, for PickupItem: use exact RefID:ItemName from nearby_items or the representative RefID:ItemName shown in grouped ITEM DESCRIPTIONS; for CastSpell: use exact spell name from spells) OR amount of gold (REQUIRED when action is GiveGoldTo - number as string, e.g. '50') OR destination location name (REQUIRED when action is TeleportNPC) OR item name from the descriptions database (REQUIRED when action is SpawnItem). For Consume, leave item blank unless target is empty and you need item as the same exact BaseID:ItemName inventory identifier fallback. Leave item blank for SpawnGold and SpawnNPC and CreateNewNPC and DirectorCommand."
+                            "description" => $actionFieldDescriptions["item"]
                         ),
                         "amount" => array(
                             "type" => "integer",
-                "description" => "quantity to give or spawn when the chosen action supports it. REQUIRED when action is SpawnItem or SpawnNPC or SpawnGold. Optional when action is GiveItemTo. Leave blank for CreateNewNPC and DirectorCommand. Use a positive integer."
+                            "minimum" => 1,
+                            "description" => $actionFieldDescriptions["amount"]
                         )
                     ),
                     "required" => [
@@ -512,6 +554,7 @@
                         "message",
                         "mood",
                         "action",
+                        "mode",
                         "target",
                         "item"
                     ],
@@ -652,6 +695,13 @@
             $actions_str = "string";
         }
 
+        $modeValues = chimGetActionResponseFieldDescriptions()['mode_enum'];
+        $modes_quoted = [];
+        foreach ($modeValues as $mode) {
+            $modes_quoted[] = '"\"'.$mode.'\""';
+        }
+        $modes_str = "(".implode(' | ', $modes_quoted).")";
+
         // build the string for zonos tts tones
         $zonos_tones_str = zonosIsActive()
             ? '"," ws root-response-tone-happiness "," ws root-response-tone-sadness "," ws root-response-tone-disgust "," ws root-response-tone-fear ","'.
@@ -660,13 +710,16 @@
 
         // using a quoted heredoc to avoid having to escape everything
         $GLOBALS["grammar"] = <<<'EOD'
-        root ::= "{" ws root-character "," ws root-listener "," ws root-message "," ws root-mood "," ws root-action "," ws root-target {$ZONOS}"}" ws
+        root ::= "{" ws root-character "," ws root-listener "," ws root-message "," ws root-mood "," ws root-action "," ws root-mode "," ws root-target "," ws root-item ("," ws root-amount)? {$ZONOS}"}" ws
         root-character ::= "\"character\"" ":" ws string
         root-listener ::= "\"listener\"" ":" ws string
         root-message ::= "\"message\"" ":" ws string
         root-mood ::= "\"mood\"" ":" ws {$MOODS}
         root-action ::= "\"action\"" ":" ws {$ACTIONS}
+        root-mode ::= "\"mode\"" ":" ws {$MODES}
         root-target ::= "\"target\"" ":" ws string
+        root-item ::= "\"item\"" ":" ws string
+        root-amount ::= "\"amount\"" ":" ws positive-integer
         root-response-tone-happiness ::= "\"response-tone-happiness\"" ":" ws number
         root-response-tone-sadness ::= "\"response-tone-sadness\"" ":" ws number
         root-response-tone-disgust ::= "\"response-tone-disgust\"" ":" ws number
@@ -683,6 +736,7 @@
         )* "\"" ws
 
         number ::= ("-"? ([0-9] | [1-9] [0-9]*)) ("." [0-9]+)? ([eE] [-+]? [0-9]+)? ws
+        positive-integer ::= [1-9] [0-9]* ws
 
         # Optional space: by convention, applied in this grammar after literal chars when allowed
         ws ::= ([ \t\n] ws)?
@@ -692,6 +746,7 @@
         $GLOBALS["grammar"]=str_replace('{$ZONOS}', $zonos_tones_str, $GLOBALS["grammar"]);
         $GLOBALS["grammar"]=str_replace('{$MOODS}', $moods_str, $GLOBALS["grammar"]);
         $GLOBALS["grammar"]=str_replace('{$ACTIONS}', $actions_str, $GLOBALS["grammar"]);
+        $GLOBALS["grammar"]=str_replace('{$MODES}', $modes_str, $GLOBALS["grammar"]);
     }
 
     Function zonosIsActive() {

--- a/lib/core/action_catalog.php
+++ b/lib/core/action_catalog.php
@@ -2,6 +2,7 @@
 
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'game_plugins.php');
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'npc_master.class.php');
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'action_groups.php');
 
 function herikaGetRetiredActionCodes()
 {

--- a/lib/core/action_groups.php
+++ b/lib/core/action_groups.php
@@ -11,19 +11,19 @@ function herikaActionGroupsGetSpecs()
     $specs = [
         'GroupedHandleCrime' => [
             'action_name' => 'Handle_Crime',
-            'description' => 'Choose one guard response to the player\'s crime. Put add_bounty, arrest, forgive, or pay_bounty in target. For add_bounty, put the crime type in item and a Custom gold value in amount.',
-            'selector' => 'target',
+            'description' => 'Choose one guard response to the player\'s crime with mode. For add_bounty, put the crime type in item and a Custom gold value in amount.',
+            'selector' => 'mode',
             'variants' => [
                 'add_bounty' => 'AddBounty',
                 'arrest' => 'ArrestPlayer',
                 'forgive' => 'ForgiveCrime',
-                'pay_bounty' => 'PayBounty',
+                'collect_bounty_payment' => 'PayBounty',
             ],
             'parameters' => [
                 'type' => 'object',
-                'required' => ['target'],
+                'required' => ['mode'],
                 'properties' => [
-                    'target' => [
+                    'mode' => [
                         'type' => 'string',
                         'description' => 'Guard response to perform.',
                     ],
@@ -38,149 +38,149 @@ function herikaActionGroupsGetSpecs()
                         'description' => 'Required only for a Custom bounty; the gold amount to add.',
                     ],
                 ],
+                'additionalProperties' => false,
             ],
         ],
         'GroupedStartCombat' => [
             'action_name' => 'Start_Combat',
-            'description' => 'Start combat with the actor in target. Put lethal or nonlethal in item; nonlethal uses protected brawl behavior.',
-            'selector' => 'item',
+            'description' => 'Start combat with the actor in target. Select lethal or brawl with mode; brawl uses protected non-lethal behavior.',
+            'selector' => 'mode',
             'variants' => [
                 'lethal' => 'Attack',
-                'nonlethal' => 'Brawl',
+                'brawl' => 'Brawl',
             ],
             'parameters' => [
                 'type' => 'object',
-                'required' => ['target', 'item'],
+                'required' => ['mode', 'target'],
                 'properties' => [
+                    'mode' => [
+                        'type' => 'string',
+                        'description' => 'Whether combat is lethal or a protected brawl.',
+                    ],
                     'target' => [
                         'type' => 'string',
                         'description' => 'Target NPC, actor, or being.',
                     ],
-                    'item' => [
-                        'type' => 'string',
-                        'description' => 'Whether combat is lethal or non-lethal.',
-                    ],
                 ],
+                'additionalProperties' => false,
             ],
         ],
         'GroupedFollow' => [
             'action_name' => 'Follow',
-            'description' => 'Put actor, player, or approach_player in item. For actor mode, put the nearby actor to follow in target; otherwise leave target blank.',
-            'selector' => 'item',
+            'description' => 'Select follow_actor, follow_player, or approach_player with mode. For follow_actor, put the nearby actor in target.',
+            'selector' => 'mode',
             'variants' => [
-                'actor' => 'Follow',
-                'player' => 'FollowPlayer',
+                'follow_actor' => 'Follow',
+                'follow_player' => 'FollowPlayer',
                 'approach_player' => 'ComeCloser',
             ],
             'parameters' => [
                 'type' => 'object',
-                'required' => ['item'],
+                'required' => ['mode'],
                 'properties' => [
-                    'target' => [
-                        'type' => 'string',
-                        'description' => 'Required only for actor mode; the nearby actor to follow.',
-                    ],
-                    'item' => [
+                    'mode' => [
                         'type' => 'string',
                         'description' => 'Following behavior to use.',
                     ],
+                    'target' => [
+                        'type' => 'string',
+                        'description' => 'Required only for follow_actor; the nearby actor to follow.',
+                    ],
                 ],
+                'additionalProperties' => false,
             ],
         ],
         'GroupedSetPace' => [
             'action_name' => 'Set_Pace',
-            'description' => 'Adjust the NPC\'s movement pace. Put faster or slower in target and leave item blank.',
-            'selector' => 'target',
+            'description' => 'Adjust the NPC\'s movement pace by selecting faster or slower with mode.',
+            'selector' => 'mode',
             'variants' => [
                 'faster' => 'IncreaseWalkSpeed',
                 'slower' => 'DecreaseWalkSpeed',
             ],
             'parameters' => [
                 'type' => 'object',
-                'required' => ['target'],
+                'required' => ['mode'],
                 'properties' => [
-                    'target' => [
+                    'mode' => [
                         'type' => 'string',
                         'description' => 'Whether to move faster or slower.',
                     ],
-                    'item' => [
-                        'type' => 'string',
-                        'description' => 'Keep it blank.',
-                    ],
                 ],
+                'additionalProperties' => false,
             ],
         ],
         'GroupedGive' => [
             'action_name' => 'Give',
-            'description' => 'Give an exact inventory item or Gold to another actor or the player.',
+            'description' => 'Give an inventory item or gold to the actor in target. Select item or gold with mode; use item only for an inventory item and amount for the quantity.',
+            'selector' => 'mode',
             'variants' => [
                 'item' => 'GiveItemTo',
                 'gold' => 'GiveGoldTo',
             ],
             'parameters' => [
                 'type' => 'object',
-                'required' => ['target', 'item'],
+                'required' => ['mode', 'target'],
                 'properties' => [
+                    'mode' => [
+                        'type' => 'string',
+                        'description' => 'Whether to give an inventory item or gold.',
+                    ],
                     'target' => [
                         'type' => 'string',
-                        'description' => 'Actor who will receive the item.',
+                        'description' => 'Actor who will receive the item or gold.',
                     ],
                     'item' => [
                         'type' => 'string',
-                        'description' => 'Use Gold for currency, otherwise use the exact item name from inventory.',
+                        'description' => 'Required for item mode; use the exact item identifier from inventory. Leave blank for gold.',
                     ],
                     'amount' => [
                         'type' => 'integer',
                         'minimum' => 1,
-                        'description' => 'Number of items or gold pieces to give. Defaults to 1.',
+                        'description' => 'Required for gold. Optional for an item and defaults to 1.',
                     ],
                 ],
+                'additionalProperties' => false,
             ],
         ],
         'GroupedExchange' => [
             'action_name' => 'Exchange',
-            'description' => 'Open normal trading or let the player give a gift to the NPC. Put trade or accept_gift in target and leave item blank.',
-            'selector' => 'target',
+            'description' => 'Open normal trading or let the player give a gift to the NPC. Select trade or receive_gift with mode.',
+            'selector' => 'mode',
             'variants' => [
                 'trade' => 'OpenInventory',
-                'accept_gift' => 'OpenInventory2',
+                'receive_gift' => 'OpenInventory2',
             ],
             'parameters' => [
                 'type' => 'object',
-                'required' => ['target'],
+                'required' => ['mode'],
                 'properties' => [
-                    'target' => [
+                    'mode' => [
                         'type' => 'string',
-                        'description' => 'Use trade for normal exchange or accept_gift when the player is giving items.',
-                    ],
-                    'item' => [
-                        'type' => 'string',
-                        'description' => 'Keep it blank.',
+                        'description' => 'Use trade for normal exchange or receive_gift when the player is giving items.',
                     ],
                 ],
+                'additionalProperties' => false,
             ],
         ],
         'GroupedGesture' => [
             'action_name' => 'Perform_Gesture',
-            'description' => 'Perform a visual drinking or toast gesture. Put drink or toast in target and leave item blank. This does not consume an inventory item.',
-            'selector' => 'target',
+            'description' => 'Perform a visual drinking or toast gesture by selecting drink_gesture or toast with mode. This does not consume an inventory item.',
+            'selector' => 'mode',
             'variants' => [
-                'drink' => 'Drink',
+                'drink_gesture' => 'Drink',
                 'toast' => 'Toast',
             ],
             'parameters' => [
                 'type' => 'object',
-                'required' => ['target'],
+                'required' => ['mode'],
                 'properties' => [
-                    'target' => [
+                    'mode' => [
                         'type' => 'string',
                         'description' => 'Visual gesture to perform.',
                     ],
-                    'item' => [
-                        'type' => 'string',
-                        'description' => 'Keep it blank.',
-                    ],
                 ],
+                'additionalProperties' => false,
             ],
         ],
     ];
@@ -365,19 +365,33 @@ function herikaActionGroupsResolveExecution($groupCode, $parameter)
     $legacyParameter = '';
 
     if ($groupCode === 'GroupedHandleCrime') {
-        $outcome = herikaActionGroupsNormalizeChoice($payload['outcome'] ?? ($payload['target'] ?? ''));
+        $outcome = herikaActionGroupsNormalizeChoice($payload['mode'] ?? ($payload['outcome'] ?? ($payload['target'] ?? '')));
+        if ($outcome === 'pay_bounty') {
+            $outcome = 'collect_bounty_payment';
+        }
         $selectedCode = strval($variants[$outcome] ?? '');
         if ($outcome === '') {
-            $missing[] = 'outcome';
+            $missing[] = 'mode';
         } elseif ($selectedCode === '') {
-            $missing[] = 'available outcome';
+            $missing[] = 'available mode';
         } elseif ($outcome === 'add_bounty') {
             $crimeType = trim(strval($payload['crime_type'] ?? ($payload['item'] ?? '')));
             if ($crimeType === '') {
-                $missing[] = 'crime_type';
+                $missing[] = 'item';
             } else {
-                $legacyParameter = $crimeType;
-                if (strcasecmp($crimeType, 'Custom') === 0) {
+                $allowedCrimeTypes = $spec['parameters']['properties']['item']['enum'] ?? [];
+                $canonicalCrimeType = '';
+                foreach ($allowedCrimeTypes as $allowedCrimeType) {
+                    if (strcasecmp($crimeType, strval($allowedCrimeType)) === 0) {
+                        $canonicalCrimeType = strval($allowedCrimeType);
+                        break;
+                    }
+                }
+                if ($canonicalCrimeType === '') {
+                    $missing[] = 'valid item';
+                }
+                $legacyParameter = $canonicalCrimeType;
+                if ($canonicalCrimeType === 'Custom') {
                     $amount = intval($payload['amount'] ?? 0);
                     if ($amount <= 0) {
                         $missing[] = 'amount';
@@ -389,8 +403,8 @@ function herikaActionGroupsResolveExecution($groupCode, $parameter)
         }
     } elseif ($groupCode === 'GroupedStartCombat') {
         $mode = herikaActionGroupsNormalizeChoice($payload['mode'] ?? ($payload['item'] ?? ''));
-        if ($mode === 'non_lethal') {
-            $mode = 'nonlethal';
+        if (in_array($mode, ['nonlethal', 'non_lethal'], true)) {
+            $mode = 'brawl';
         }
         $selectedCode = strval($variants[$mode] ?? '');
         $legacyParameter = trim(strval($payload['target'] ?? ''));
@@ -403,51 +417,73 @@ function herikaActionGroupsResolveExecution($groupCode, $parameter)
     } elseif ($groupCode === 'GroupedFollow') {
         $mode = herikaActionGroupsNormalizeChoice($payload['mode'] ?? ($payload['item'] ?? ''));
         $target = trim(strval($payload['target'] ?? ''));
-        if ($mode === '') {
-            $mode = $target !== '' ? 'actor' : 'player';
+        if ($mode === 'actor') {
+            $mode = 'follow_actor';
+        } elseif ($mode === 'player') {
+            $mode = 'follow_player';
+        } elseif ($mode === '' && $target !== '') {
+            $mode = 'follow_actor';
         }
         $selectedCode = strval($variants[$mode] ?? '');
         if ($selectedCode === '') {
             $missing[] = 'mode';
-        } elseif ($mode === 'actor') {
+        } elseif ($mode === 'follow_actor') {
             $legacyParameter = $target;
             if ($target === '') {
                 $missing[] = 'target';
             }
         }
     } elseif ($groupCode === 'GroupedSetPace') {
-        $pace = herikaActionGroupsNormalizeChoice($payload['pace'] ?? ($payload['target'] ?? ''));
+        $pace = herikaActionGroupsNormalizeChoice($payload['mode'] ?? ($payload['pace'] ?? ($payload['target'] ?? '')));
         $selectedCode = strval($variants[$pace] ?? '');
         if ($selectedCode === '') {
-            $missing[] = 'pace';
+            $missing[] = 'mode';
         }
     } elseif ($groupCode === 'GroupedGive') {
+        $mode = herikaActionGroupsNormalizeChoice($payload['mode'] ?? '');
         $target = trim(strval($payload['target'] ?? ''));
         $item = trim(strval($payload['item'] ?? ''));
-        $amount = max(1, intval($payload['amount'] ?? 1));
-        $isGold = in_array(strtolower($item), ['gold', 'coins', 'septims'], true);
-        $selectedCode = strval($variants[$isGold ? 'gold' : 'item'] ?? '');
+        $legacyGoldSentinel = in_array(strtolower($item), ['gold', 'coins', 'septims'], true);
+        if ($mode === '') {
+            $mode = $legacyGoldSentinel ? 'gold' : ($item !== '' ? 'item' : '');
+        }
+        $selectedCode = strval($variants[$mode] ?? '');
         if ($target === '') {
             $missing[] = 'target';
         }
-        if ($item === '') {
-            $missing[] = 'item';
-        }
         if ($selectedCode === '') {
-            $missing[] = $isGold ? 'Gold transfer' : 'item transfer';
-        } elseif ($isGold) {
-            $legacyParameter = ['target' => $target, 'item' => strval($amount)];
-        } else {
+            $missing[] = 'mode';
+        } elseif ($mode === 'gold') {
+            $amount = intval($payload['amount'] ?? 0);
+            if ($amount <= 0) {
+                $missing[] = 'amount';
+            } else {
+                $legacyParameter = ['target' => $target, 'item' => strval($amount)];
+            }
+        } elseif ($mode === 'item') {
+            if ($item === '') {
+                $missing[] = 'item';
+            }
+            $amount = array_key_exists('amount', $payload) ? intval($payload['amount']) : 1;
+            if ($amount <= 0) {
+                $missing[] = 'amount';
+            }
             $legacyParameter = ['target' => $target, 'item' => $item, 'amount' => $amount];
         }
     } elseif ($groupCode === 'GroupedExchange') {
         $mode = herikaActionGroupsNormalizeChoice($payload['mode'] ?? ($payload['target'] ?? ''));
+        if ($mode === 'accept_gift') {
+            $mode = 'receive_gift';
+        }
         $selectedCode = strval($variants[$mode] ?? '');
         if ($selectedCode === '') {
             $missing[] = 'mode';
         }
     } elseif ($groupCode === 'GroupedGesture') {
-        $gesture = herikaActionGroupsNormalizeChoice($payload['gesture'] ?? ($payload['target'] ?? ''));
+        $gesture = herikaActionGroupsNormalizeChoice($payload['mode'] ?? ($payload['gesture'] ?? ($payload['target'] ?? '')));
+        if ($gesture === 'drink') {
+            $gesture = 'drink_gesture';
+        }
         $selectedCode = strval($variants[$gesture] ?? '');
         if ($selectedCode === '') {
             $missing[] = 'gesture';

--- a/lib/core/action_groups.php
+++ b/lib/core/action_groups.php
@@ -1,0 +1,464 @@
+<?php
+
+// Defines the compact model-facing tools while preserving legacy action codes for execution.
+function herikaActionGroupsGetSpecs()
+{
+    static $specs = null;
+    if (is_array($specs)) {
+        return $specs;
+    }
+
+    $specs = [
+        'GroupedHandleCrime' => [
+            'action_name' => 'Handle_Crime',
+            'description' => 'Choose one guard response to the player\'s crime. Put add_bounty, arrest, forgive, or pay_bounty in target. For add_bounty, put the crime type in item and a Custom gold value in amount.',
+            'selector' => 'target',
+            'variants' => [
+                'add_bounty' => 'AddBounty',
+                'arrest' => 'ArrestPlayer',
+                'forgive' => 'ForgiveCrime',
+                'pay_bounty' => 'PayBounty',
+            ],
+            'parameters' => [
+                'type' => 'object',
+                'required' => ['target'],
+                'properties' => [
+                    'target' => [
+                        'type' => 'string',
+                        'description' => 'Guard response to perform.',
+                    ],
+                    'item' => [
+                        'type' => 'string',
+                        'enum' => ['Assault', 'Murder', 'Theft', 'Pickpocketing', 'Trespassing', 'Jailbreak', 'Custom'],
+                        'description' => 'Required for add_bounty. Select the witnessed or reported crime.',
+                    ],
+                    'amount' => [
+                        'type' => 'integer',
+                        'minimum' => 1,
+                        'description' => 'Required only for a Custom bounty; the gold amount to add.',
+                    ],
+                ],
+            ],
+        ],
+        'GroupedStartCombat' => [
+            'action_name' => 'Start_Combat',
+            'description' => 'Start combat with the actor in target. Put lethal or nonlethal in item; nonlethal uses protected brawl behavior.',
+            'selector' => 'item',
+            'variants' => [
+                'lethal' => 'Attack',
+                'nonlethal' => 'Brawl',
+            ],
+            'parameters' => [
+                'type' => 'object',
+                'required' => ['target', 'item'],
+                'properties' => [
+                    'target' => [
+                        'type' => 'string',
+                        'description' => 'Target NPC, actor, or being.',
+                    ],
+                    'item' => [
+                        'type' => 'string',
+                        'description' => 'Whether combat is lethal or non-lethal.',
+                    ],
+                ],
+            ],
+        ],
+        'GroupedFollow' => [
+            'action_name' => 'Follow',
+            'description' => 'Put actor, player, or approach_player in item. For actor mode, put the nearby actor to follow in target; otherwise leave target blank.',
+            'selector' => 'item',
+            'variants' => [
+                'actor' => 'Follow',
+                'player' => 'FollowPlayer',
+                'approach_player' => 'ComeCloser',
+            ],
+            'parameters' => [
+                'type' => 'object',
+                'required' => ['item'],
+                'properties' => [
+                    'target' => [
+                        'type' => 'string',
+                        'description' => 'Required only for actor mode; the nearby actor to follow.',
+                    ],
+                    'item' => [
+                        'type' => 'string',
+                        'description' => 'Following behavior to use.',
+                    ],
+                ],
+            ],
+        ],
+        'GroupedSetPace' => [
+            'action_name' => 'Set_Pace',
+            'description' => 'Adjust the NPC\'s movement pace. Put faster or slower in target and leave item blank.',
+            'selector' => 'target',
+            'variants' => [
+                'faster' => 'IncreaseWalkSpeed',
+                'slower' => 'DecreaseWalkSpeed',
+            ],
+            'parameters' => [
+                'type' => 'object',
+                'required' => ['target'],
+                'properties' => [
+                    'target' => [
+                        'type' => 'string',
+                        'description' => 'Whether to move faster or slower.',
+                    ],
+                    'item' => [
+                        'type' => 'string',
+                        'description' => 'Keep it blank.',
+                    ],
+                ],
+            ],
+        ],
+        'GroupedGive' => [
+            'action_name' => 'Give',
+            'description' => 'Give an exact inventory item or Gold to another actor or the player.',
+            'variants' => [
+                'item' => 'GiveItemTo',
+                'gold' => 'GiveGoldTo',
+            ],
+            'parameters' => [
+                'type' => 'object',
+                'required' => ['target', 'item'],
+                'properties' => [
+                    'target' => [
+                        'type' => 'string',
+                        'description' => 'Actor who will receive the item.',
+                    ],
+                    'item' => [
+                        'type' => 'string',
+                        'description' => 'Use Gold for currency, otherwise use the exact item name from inventory.',
+                    ],
+                    'amount' => [
+                        'type' => 'integer',
+                        'minimum' => 1,
+                        'description' => 'Number of items or gold pieces to give. Defaults to 1.',
+                    ],
+                ],
+            ],
+        ],
+        'GroupedExchange' => [
+            'action_name' => 'Exchange',
+            'description' => 'Open normal trading or let the player give a gift to the NPC. Put trade or accept_gift in target and leave item blank.',
+            'selector' => 'target',
+            'variants' => [
+                'trade' => 'OpenInventory',
+                'accept_gift' => 'OpenInventory2',
+            ],
+            'parameters' => [
+                'type' => 'object',
+                'required' => ['target'],
+                'properties' => [
+                    'target' => [
+                        'type' => 'string',
+                        'description' => 'Use trade for normal exchange or accept_gift when the player is giving items.',
+                    ],
+                    'item' => [
+                        'type' => 'string',
+                        'description' => 'Keep it blank.',
+                    ],
+                ],
+            ],
+        ],
+        'GroupedGesture' => [
+            'action_name' => 'Perform_Gesture',
+            'description' => 'Perform a visual drinking or toast gesture. Put drink or toast in target and leave item blank. This does not consume an inventory item.',
+            'selector' => 'target',
+            'variants' => [
+                'drink' => 'Drink',
+                'toast' => 'Toast',
+            ],
+            'parameters' => [
+                'type' => 'object',
+                'required' => ['target'],
+                'properties' => [
+                    'target' => [
+                        'type' => 'string',
+                        'description' => 'Visual gesture to perform.',
+                    ],
+                    'item' => [
+                        'type' => 'string',
+                        'description' => 'Keep it blank.',
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    return $specs;
+}
+
+function herikaActionGroupsGetCustomizedCodeSet()
+{
+    if (isset($GLOBALS['HERIKA_ACTION_GROUP_CUSTOM_CODE_SET']) && is_array($GLOBALS['HERIKA_ACTION_GROUP_CUSTOM_CODE_SET'])) {
+        return $GLOBALS['HERIKA_ACTION_GROUP_CUSTOM_CODE_SET'];
+    }
+
+    $customCodeSet = [];
+    if (function_exists('herikaActionCatalogDbReady') && herikaActionCatalogDbReady()) {
+        $rows = $GLOBALS['db']->fetchAll("
+            SELECT c.code_name
+            FROM public.core_action_custom c
+            INNER JOIN public.core_action b ON LOWER(b.code_name) = LOWER(c.code_name)
+            WHERE c.action_name IS DISTINCT FROM b.action_name
+               OR c.description IS DISTINCT FROM b.description
+               OR c.parameters_json IS DISTINCT FROM b.parameters_json
+               OR c.game_function IS DISTINCT FROM b.game_function
+               OR COALESCE(c.metadata->>'dispatch', '') IS DISTINCT FROM COALESCE(b.metadata->>'dispatch', '')
+               OR c.script_proxy_program IS DISTINCT FROM b.script_proxy_program
+        ");
+        foreach ($rows as $row) {
+            $codeName = trim(strval($row['code_name'] ?? ''));
+            if ($codeName !== '') {
+                $customCodeSet[$codeName] = true;
+            }
+        }
+    }
+
+    $GLOBALS['HERIKA_ACTION_GROUP_CUSTOM_CODE_SET'] = $customCodeSet;
+    return $customCodeSet;
+}
+
+function herikaActionGroupsBuildFunctionEntry($spec, $activeVariants)
+{
+    $parameters = $spec['parameters'];
+    $selector = trim(strval($spec['selector'] ?? ''));
+    if ($selector !== '' && isset($parameters['properties'][$selector])) {
+        $parameters['properties'][$selector]['enum'] = array_keys($activeVariants);
+    }
+
+    return [
+        'name' => $spec['action_name'],
+        'description' => $spec['description'],
+        'parameters' => $parameters,
+    ];
+}
+
+// Replaces only simultaneously eligible, uncustomized vanilla actions with compact runtime definitions.
+function herikaActionGroupsApplyToRuntime()
+{
+    if (!isset($GLOBALS['FUNCTIONS'], $GLOBALS['ENABLED_FUNCTIONS']) || !is_array($GLOBALS['FUNCTIONS']) || !is_array($GLOBALS['ENABLED_FUNCTIONS'])) {
+        return 0;
+    }
+
+    $enabledSet = array_fill_keys(array_map('strval', $GLOBALS['ENABLED_FUNCTIONS']), true);
+    $customCodeSet = herikaActionGroupsGetCustomizedCodeSet();
+    $runtimeEntries = [];
+    $runtimeCodeSet = [];
+    foreach ($GLOBALS['FUNCTIONS'] as $index => $functionEntry) {
+        $codeName = is_array($functionEntry) && !empty($functionEntry['name']) && function_exists('getFunctionCodeName')
+            ? getFunctionCodeName($functionEntry['name'])
+            : false;
+        $runtimeEntries[$index] = [
+            'code_name' => is_string($codeName) ? $codeName : '',
+            'entry' => $functionEntry,
+        ];
+        if (is_string($codeName) && $codeName !== '') {
+            $runtimeCodeSet[$codeName] = true;
+        }
+    }
+
+    $codesToReplace = [];
+    $groupEntries = [];
+    $groupNameToCode = [];
+    $activeSpecs = [];
+    foreach (herikaActionGroupsGetSpecs() as $groupCode => $spec) {
+        $activeVariants = [];
+        foreach ($spec['variants'] as $variantName => $legacyCode) {
+            if (isset($enabledSet[$legacyCode], $runtimeCodeSet[$legacyCode]) && !isset($customCodeSet[$legacyCode])) {
+                $activeVariants[$variantName] = $legacyCode;
+            }
+        }
+
+        $activeMemberCodes = array_values(array_unique(array_values($activeVariants)));
+        if (count($activeMemberCodes) < 2) {
+            continue;
+        }
+
+        $nameCollision = false;
+        foreach ($runtimeEntries as $runtimeEntry) {
+            if (in_array($runtimeEntry['code_name'], $activeMemberCodes, true)) {
+                continue;
+            }
+            if (strcasecmp(trim(strval($runtimeEntry['entry']['name'] ?? '')), $spec['action_name']) === 0) {
+                $nameCollision = true;
+                break;
+            }
+        }
+        if ($nameCollision) {
+            continue;
+        }
+
+        foreach ($activeMemberCodes as $legacyCode) {
+            $codesToReplace[$legacyCode] = true;
+        }
+        $groupEntry = herikaActionGroupsBuildFunctionEntry($spec, $activeVariants);
+        $groupEntries[$groupCode] = $groupEntry;
+        $activeSpecs[$groupCode] = array_merge($spec, ['variants' => $activeVariants]);
+        $groupNameToCode[$spec['action_name']] = $groupCode;
+        if (function_exists('herikaNormalizeActionCatalogDisplayActionName')) {
+            $groupNameToCode[herikaNormalizeActionCatalogDisplayActionName($spec['action_name'])] = $groupCode;
+        }
+    }
+
+    if (count($groupEntries) === 0) {
+        return 0;
+    }
+
+    $filteredFunctions = [];
+    foreach ($runtimeEntries as $runtimeEntry) {
+        if (!isset($codesToReplace[$runtimeEntry['code_name']])) {
+            $filteredFunctions[] = $runtimeEntry['entry'];
+        }
+    }
+    foreach ($groupEntries as $groupEntry) {
+        $filteredFunctions[] = $groupEntry;
+    }
+    $GLOBALS['FUNCTIONS'] = $filteredFunctions;
+
+    $GLOBALS['ENABLED_FUNCTIONS'] = array_values(array_filter(
+        $GLOBALS['ENABLED_FUNCTIONS'],
+        static fn($codeName) => !isset($codesToReplace[strval($codeName)])
+    ));
+    foreach ($groupEntries as $groupCode => $groupEntry) {
+        $GLOBALS['ENABLED_FUNCTIONS'][] = $groupCode;
+        $GLOBALS['BASE_FUNCTIONS'][$groupCode] = $groupEntry;
+        $GLOBALS['F_NAMES'][$groupCode] = $groupEntry['name'];
+        $GLOBALS['F_TRANSLATIONS'][$groupCode] = $groupEntry['description'];
+        $GLOBALS['F_RETURNMESSAGES'][$groupCode] = '';
+    }
+    $GLOBALS['ENABLED_FUNCTIONS'] = array_values(array_unique($GLOBALS['ENABLED_FUNCTIONS']));
+    $GLOBALS['HERIKA_GROUPED_ACTION_NAME_TO_CODE'] = $groupNameToCode;
+    $GLOBALS['HERIKA_GROUPED_ACTION_SPECS'] = $activeSpecs;
+
+    return count($groupEntries);
+}
+
+function herikaActionGroupsNormalizeChoice($value)
+{
+    $value = strtolower(trim(strval($value)));
+    return str_replace(['-', ' '], '_', $value);
+}
+
+function herikaActionGroupsDecodeParameters($parameter)
+{
+    if (is_array($parameter)) {
+        return $parameter;
+    }
+
+    $decoded = json_decode(strval($parameter), true);
+    return is_array($decoded) ? $decoded : [];
+}
+
+// Converts a compact model-facing action back into one eligible legacy action and payload.
+function herikaActionGroupsResolveExecution($groupCode, $parameter)
+{
+    $spec = $GLOBALS['HERIKA_GROUPED_ACTION_SPECS'][$groupCode] ?? null;
+    if (!is_array($spec)) {
+        return null;
+    }
+
+    $payload = herikaActionGroupsDecodeParameters($parameter);
+    $variants = $spec['variants'];
+    $missing = [];
+    $selectedCode = '';
+    $legacyParameter = '';
+
+    if ($groupCode === 'GroupedHandleCrime') {
+        $outcome = herikaActionGroupsNormalizeChoice($payload['outcome'] ?? ($payload['target'] ?? ''));
+        $selectedCode = strval($variants[$outcome] ?? '');
+        if ($outcome === '') {
+            $missing[] = 'outcome';
+        } elseif ($selectedCode === '') {
+            $missing[] = 'available outcome';
+        } elseif ($outcome === 'add_bounty') {
+            $crimeType = trim(strval($payload['crime_type'] ?? ($payload['item'] ?? '')));
+            if ($crimeType === '') {
+                $missing[] = 'crime_type';
+            } else {
+                $legacyParameter = $crimeType;
+                if (strcasecmp($crimeType, 'Custom') === 0) {
+                    $amount = intval($payload['amount'] ?? 0);
+                    if ($amount <= 0) {
+                        $missing[] = 'amount';
+                    } else {
+                        $legacyParameter .= '@' . $amount;
+                    }
+                }
+            }
+        }
+    } elseif ($groupCode === 'GroupedStartCombat') {
+        $mode = herikaActionGroupsNormalizeChoice($payload['mode'] ?? ($payload['item'] ?? ''));
+        if ($mode === 'non_lethal') {
+            $mode = 'nonlethal';
+        }
+        $selectedCode = strval($variants[$mode] ?? '');
+        $legacyParameter = trim(strval($payload['target'] ?? ''));
+        if ($mode === '' || $selectedCode === '') {
+            $missing[] = 'mode';
+        }
+        if ($legacyParameter === '') {
+            $missing[] = 'target';
+        }
+    } elseif ($groupCode === 'GroupedFollow') {
+        $mode = herikaActionGroupsNormalizeChoice($payload['mode'] ?? ($payload['item'] ?? ''));
+        $target = trim(strval($payload['target'] ?? ''));
+        if ($mode === '') {
+            $mode = $target !== '' ? 'actor' : 'player';
+        }
+        $selectedCode = strval($variants[$mode] ?? '');
+        if ($selectedCode === '') {
+            $missing[] = 'mode';
+        } elseif ($mode === 'actor') {
+            $legacyParameter = $target;
+            if ($target === '') {
+                $missing[] = 'target';
+            }
+        }
+    } elseif ($groupCode === 'GroupedSetPace') {
+        $pace = herikaActionGroupsNormalizeChoice($payload['pace'] ?? ($payload['target'] ?? ''));
+        $selectedCode = strval($variants[$pace] ?? '');
+        if ($selectedCode === '') {
+            $missing[] = 'pace';
+        }
+    } elseif ($groupCode === 'GroupedGive') {
+        $target = trim(strval($payload['target'] ?? ''));
+        $item = trim(strval($payload['item'] ?? ''));
+        $amount = max(1, intval($payload['amount'] ?? 1));
+        $isGold = in_array(strtolower($item), ['gold', 'coins', 'septims'], true);
+        $selectedCode = strval($variants[$isGold ? 'gold' : 'item'] ?? '');
+        if ($target === '') {
+            $missing[] = 'target';
+        }
+        if ($item === '') {
+            $missing[] = 'item';
+        }
+        if ($selectedCode === '') {
+            $missing[] = $isGold ? 'Gold transfer' : 'item transfer';
+        } elseif ($isGold) {
+            $legacyParameter = ['target' => $target, 'item' => strval($amount)];
+        } else {
+            $legacyParameter = ['target' => $target, 'item' => $item, 'amount' => $amount];
+        }
+    } elseif ($groupCode === 'GroupedExchange') {
+        $mode = herikaActionGroupsNormalizeChoice($payload['mode'] ?? ($payload['target'] ?? ''));
+        $selectedCode = strval($variants[$mode] ?? '');
+        if ($selectedCode === '') {
+            $missing[] = 'mode';
+        }
+    } elseif ($groupCode === 'GroupedGesture') {
+        $gesture = herikaActionGroupsNormalizeChoice($payload['gesture'] ?? ($payload['target'] ?? ''));
+        $selectedCode = strval($variants[$gesture] ?? '');
+        if ($selectedCode === '') {
+            $missing[] = 'gesture';
+        }
+    }
+
+    $missing = array_values(array_unique($missing));
+    return [
+        'code_name' => $selectedCode,
+        'parameter_value' => $legacyParameter,
+        'missing_required' => $missing,
+        'valid' => $selectedCode !== '' && count($missing) === 0,
+    ];
+}

--- a/unittests/tests/ActionCatalogTest.php
+++ b/unittests/tests/ActionCatalogTest.php
@@ -877,9 +877,14 @@ final class ActionCatalogTest extends TestCase
             $this->assertNotContains('GiveGoldTo', $GLOBALS['ENABLED_FUNCTIONS']);
             $this->assertContains('GroupedGive', $GLOBALS['ENABLED_FUNCTIONS']);
             $this->assertSame(
-                ['actor', 'player', 'approach_player'],
-                $GLOBALS['BASE_FUNCTIONS']['GroupedFollow']['parameters']['properties']['item']['enum']
+                ['follow_actor', 'follow_player', 'approach_player'],
+                $GLOBALS['BASE_FUNCTIONS']['GroupedFollow']['parameters']['properties']['mode']['enum']
             );
+            $this->assertSame(
+                ['mode'],
+                array_keys($GLOBALS['BASE_FUNCTIONS']['GroupedSetPace']['parameters']['properties'])
+            );
+            $this->assertFalse($GLOBALS['BASE_FUNCTIONS']['GroupedSetPace']['parameters']['additionalProperties']);
         } finally {
             foreach ($previousGlobals as $globalName => $previous) {
                 if ($previous['exists']) {
@@ -922,14 +927,14 @@ final class ActionCatalogTest extends TestCase
         try {
             $combat = herikaActionGroupsResolveExecution('GroupedStartCombat', [
                 'target' => 'Bandit',
-                'item' => 'non-lethal',
+                'mode' => 'brawl',
             ]);
             $this->assertTrue($combat['valid']);
             $this->assertSame('Brawl', $combat['code_name']);
             $this->assertSame('Bandit', $combat['parameter_value']);
 
             $crime = herikaActionGroupsResolveExecution('GroupedHandleCrime', [
-                'target' => 'add_bounty',
+                'mode' => 'add_bounty',
                 'item' => 'Custom',
                 'amount' => 250,
             ]);
@@ -938,24 +943,24 @@ final class ActionCatalogTest extends TestCase
             $this->assertSame('Custom@250', $crime['parameter_value']);
 
             $gold = herikaActionGroupsResolveExecution('GroupedGive', [
+                'mode' => 'gold',
                 'target' => 'Player',
-                'item' => 'Gold',
                 'amount' => 25,
             ]);
             $this->assertTrue($gold['valid']);
             $this->assertSame('GiveGoldTo', $gold['code_name']);
             $this->assertSame(['target' => 'Player', 'item' => '25'], $gold['parameter_value']);
 
-            $gift = herikaActionGroupsResolveExecution('GroupedExchange', ['target' => 'accept_gift']);
+            $gift = herikaActionGroupsResolveExecution('GroupedExchange', ['mode' => 'receive_gift']);
             $this->assertTrue($gift['valid']);
             $this->assertSame('OpenInventory2', $gift['code_name']);
 
-            $pace = herikaActionGroupsResolveExecution('GroupedSetPace', ['target' => 'slower']);
+            $pace = herikaActionGroupsResolveExecution('GroupedSetPace', ['mode' => 'slower']);
             $this->assertTrue($pace['valid']);
             $this->assertSame('DecreaseWalkSpeed', $pace['code_name']);
             $this->assertSame('', $pace['parameter_value']);
 
-            $gesture = herikaActionGroupsResolveExecution('GroupedGesture', ['target' => 'toast']);
+            $gesture = herikaActionGroupsResolveExecution('GroupedGesture', ['mode' => 'toast']);
             $this->assertTrue($gesture['valid']);
             $this->assertSame('Toast', $gesture['code_name']);
 
@@ -964,9 +969,35 @@ final class ActionCatalogTest extends TestCase
             $this->assertSame('Follow', $legacyFollow['code_name']);
             $this->assertSame('Lydia', $legacyFollow['parameter_value']);
 
-            $invalidFollow = herikaActionGroupsResolveExecution('GroupedFollow', ['mode' => 'actor']);
+            $invalidFollow = herikaActionGroupsResolveExecution('GroupedFollow', ['mode' => 'follow_actor']);
             $this->assertFalse($invalidFollow['valid']);
             $this->assertContains('target', $invalidFollow['missing_required']);
+
+            $missingGoldAmount = herikaActionGroupsResolveExecution('GroupedGive', [
+                'mode' => 'gold',
+                'target' => 'Player',
+            ]);
+            $this->assertFalse($missingGoldAmount['valid']);
+            $this->assertContains('amount', $missingGoldAmount['missing_required']);
+
+            $inventoryGold = herikaActionGroupsResolveExecution('GroupedGive', [
+                'mode' => 'item',
+                'target' => 'Player',
+                'item' => 'Gold',
+            ]);
+            $this->assertTrue($inventoryGold['valid']);
+            $this->assertSame('GiveItemTo', $inventoryGold['code_name']);
+
+            $invalidCrime = herikaActionGroupsResolveExecution('GroupedHandleCrime', [
+                'mode' => 'add_bounty',
+                'item' => 'Loitering',
+            ]);
+            $this->assertFalse($invalidCrime['valid']);
+            $this->assertContains('valid item', $invalidCrime['missing_required']);
+
+            $missingFollowMode = herikaActionGroupsResolveExecution('GroupedFollow', []);
+            $this->assertFalse($missingFollowMode['valid']);
+            $this->assertContains('mode', $missingFollowMode['missing_required']);
         } finally {
             unset($GLOBALS['HERIKA_GROUPED_ACTION_SPECS']);
         }

--- a/unittests/tests/ActionCatalogTest.php
+++ b/unittests/tests/ActionCatalogTest.php
@@ -820,4 +820,155 @@ final class ActionCatalogTest extends TestCase
             }
         }
     }
+
+    public function testVanillaActionGroupsCompactEligibleRuntimeFunctions(): void
+    {
+        $trackedGlobals = [
+            'FUNCTIONS', 'ENABLED_FUNCTIONS', 'BASE_FUNCTIONS', 'F_NAMES', 'F_TRANSLATIONS',
+            'F_RETURNMESSAGES', 'TEST_FUNCTION_CODE_MAP', 'HERIKA_ACTION_GROUP_CUSTOM_CODE_SET',
+            'HERIKA_GROUPED_ACTION_NAME_TO_CODE', 'HERIKA_GROUPED_ACTION_SPECS',
+        ];
+        $previousGlobals = [];
+        foreach ($trackedGlobals as $globalName) {
+            $previousGlobals[$globalName] = [
+                'exists' => array_key_exists($globalName, $GLOBALS),
+                'value' => $GLOBALS[$globalName] ?? null,
+            ];
+        }
+
+        $legacyCodes = [
+            'AddBounty', 'ArrestPlayer', 'ForgiveCrime', 'PayBounty',
+            'Attack', 'Brawl',
+            'Follow', 'FollowPlayer', 'ComeCloser',
+            'IncreaseWalkSpeed', 'DecreaseWalkSpeed',
+            'GiveItemTo', 'GiveGoldTo',
+            'OpenInventory', 'OpenInventory2',
+            'Drink', 'Toast',
+        ];
+        $GLOBALS['FUNCTIONS'] = [];
+        $GLOBALS['TEST_FUNCTION_CODE_MAP'] = [];
+        foreach (array_merge($legacyCodes, ['KeepAction']) as $codeName) {
+            $GLOBALS['FUNCTIONS'][] = [
+                'name' => $codeName,
+                'description' => $codeName,
+                'parameters' => ['type' => 'object', 'properties' => [], 'required' => []],
+            ];
+            $GLOBALS['TEST_FUNCTION_CODE_MAP'][$codeName] = $codeName;
+        }
+        $GLOBALS['ENABLED_FUNCTIONS'] = array_merge($legacyCodes, ['KeepAction']);
+        $GLOBALS['BASE_FUNCTIONS'] = [];
+        $GLOBALS['F_NAMES'] = [];
+        $GLOBALS['F_TRANSLATIONS'] = [];
+        $GLOBALS['F_RETURNMESSAGES'] = [];
+        $GLOBALS['HERIKA_ACTION_GROUP_CUSTOM_CODE_SET'] = [];
+
+        try {
+            $this->assertSame(7, herikaActionGroupsApplyToRuntime());
+            $this->assertCount(8, $GLOBALS['FUNCTIONS']);
+            $this->assertContains('KeepAction', array_column($GLOBALS['FUNCTIONS'], 'name'));
+            $this->assertContains('Handle_Crime', array_column($GLOBALS['FUNCTIONS'], 'name'));
+            $this->assertContains('Start_Combat', array_column($GLOBALS['FUNCTIONS'], 'name'));
+            $this->assertContains('Follow', array_column($GLOBALS['FUNCTIONS'], 'name'));
+            $this->assertContains('Set_Pace', array_column($GLOBALS['FUNCTIONS'], 'name'));
+            $this->assertContains('Give', array_column($GLOBALS['FUNCTIONS'], 'name'));
+            $this->assertContains('Exchange', array_column($GLOBALS['FUNCTIONS'], 'name'));
+            $this->assertContains('Perform_Gesture', array_column($GLOBALS['FUNCTIONS'], 'name'));
+            $this->assertNotContains('Attack', array_column($GLOBALS['FUNCTIONS'], 'name'));
+            $this->assertNotContains('GiveGoldTo', $GLOBALS['ENABLED_FUNCTIONS']);
+            $this->assertContains('GroupedGive', $GLOBALS['ENABLED_FUNCTIONS']);
+            $this->assertSame(
+                ['actor', 'player', 'approach_player'],
+                $GLOBALS['BASE_FUNCTIONS']['GroupedFollow']['parameters']['properties']['item']['enum']
+            );
+        } finally {
+            foreach ($previousGlobals as $globalName => $previous) {
+                if ($previous['exists']) {
+                    $GLOBALS[$globalName] = $previous['value'];
+                } else {
+                    unset($GLOBALS[$globalName]);
+                }
+            }
+        }
+    }
+
+    public function testCustomizedVanillaActionsRemainIndividual(): void
+    {
+        $GLOBALS['FUNCTIONS'] = [
+            ['name' => 'Drink', 'description' => '', 'parameters' => []],
+            ['name' => 'Toast', 'description' => '', 'parameters' => []],
+        ];
+        $GLOBALS['ENABLED_FUNCTIONS'] = ['Drink', 'Toast'];
+        $GLOBALS['TEST_FUNCTION_CODE_MAP'] = ['Drink' => 'Drink', 'Toast' => 'Toast'];
+        $GLOBALS['HERIKA_ACTION_GROUP_CUSTOM_CODE_SET'] = ['Toast' => true];
+
+        try {
+            $this->assertSame(0, herikaActionGroupsApplyToRuntime());
+            $this->assertSame(['Drink', 'Toast'], array_column($GLOBALS['FUNCTIONS'], 'name'));
+            $this->assertSame(['Drink', 'Toast'], $GLOBALS['ENABLED_FUNCTIONS']);
+        } finally {
+            unset(
+                $GLOBALS['FUNCTIONS'],
+                $GLOBALS['ENABLED_FUNCTIONS'],
+                $GLOBALS['TEST_FUNCTION_CODE_MAP'],
+                $GLOBALS['HERIKA_ACTION_GROUP_CUSTOM_CODE_SET']
+            );
+        }
+    }
+
+    public function testVanillaActionGroupsResolveLegacyCodesAndPayloads(): void
+    {
+        $GLOBALS['HERIKA_GROUPED_ACTION_SPECS'] = herikaActionGroupsGetSpecs();
+
+        try {
+            $combat = herikaActionGroupsResolveExecution('GroupedStartCombat', [
+                'target' => 'Bandit',
+                'item' => 'non-lethal',
+            ]);
+            $this->assertTrue($combat['valid']);
+            $this->assertSame('Brawl', $combat['code_name']);
+            $this->assertSame('Bandit', $combat['parameter_value']);
+
+            $crime = herikaActionGroupsResolveExecution('GroupedHandleCrime', [
+                'target' => 'add_bounty',
+                'item' => 'Custom',
+                'amount' => 250,
+            ]);
+            $this->assertTrue($crime['valid']);
+            $this->assertSame('AddBounty', $crime['code_name']);
+            $this->assertSame('Custom@250', $crime['parameter_value']);
+
+            $gold = herikaActionGroupsResolveExecution('GroupedGive', [
+                'target' => 'Player',
+                'item' => 'Gold',
+                'amount' => 25,
+            ]);
+            $this->assertTrue($gold['valid']);
+            $this->assertSame('GiveGoldTo', $gold['code_name']);
+            $this->assertSame(['target' => 'Player', 'item' => '25'], $gold['parameter_value']);
+
+            $gift = herikaActionGroupsResolveExecution('GroupedExchange', ['target' => 'accept_gift']);
+            $this->assertTrue($gift['valid']);
+            $this->assertSame('OpenInventory2', $gift['code_name']);
+
+            $pace = herikaActionGroupsResolveExecution('GroupedSetPace', ['target' => 'slower']);
+            $this->assertTrue($pace['valid']);
+            $this->assertSame('DecreaseWalkSpeed', $pace['code_name']);
+            $this->assertSame('', $pace['parameter_value']);
+
+            $gesture = herikaActionGroupsResolveExecution('GroupedGesture', ['target' => 'toast']);
+            $this->assertTrue($gesture['valid']);
+            $this->assertSame('Toast', $gesture['code_name']);
+
+            $legacyFollow = herikaActionGroupsResolveExecution('GroupedFollow', ['target' => 'Lydia']);
+            $this->assertTrue($legacyFollow['valid']);
+            $this->assertSame('Follow', $legacyFollow['code_name']);
+            $this->assertSame('Lydia', $legacyFollow['parameter_value']);
+
+            $invalidFollow = herikaActionGroupsResolveExecution('GroupedFollow', ['mode' => 'actor']);
+            $this->assertFalse($invalidFollow['valid']);
+            $this->assertContains('target', $invalidFollow['missing_required']);
+        } finally {
+            unset($GLOBALS['HERIKA_GROUPED_ACTION_SPECS']);
+        }
+    }
 }

--- a/unittests/tests/CoreRequestStabilityTest.php
+++ b/unittests/tests/CoreRequestStabilityTest.php
@@ -139,6 +139,68 @@ final class CoreRequestStabilityTest extends TestCase
         $this->assertFalse(zonosIsActive());
     }
 
+    public function testGroupedActionsUseModeAcrossJsonTemplatesAndGrammar(): void
+    {
+        $trackedGlobals = [
+            'HERIKA_GROUPED_ACTION_SPECS', 'FUNC_LIST', 'EMOTEMOODS', 'LANG_LLM_XTTS',
+            'TTSFUNCTION', 'INLINE_NARRATION_MODE', 'INLINE_NARRATION_ENABLED',
+            'use_emotions_expression', 'FEATURES', 'responseTemplate',
+            'structuredOutputTemplate', 'grammar',
+        ];
+        $previousGlobals = [];
+        foreach ($trackedGlobals as $globalName) {
+            $previousGlobals[$globalName] = [
+                'exists' => array_key_exists($globalName, $GLOBALS),
+                'value' => $GLOBALS[$globalName] ?? null,
+            ];
+        }
+
+        $GLOBALS['HERIKA_GROUPED_ACTION_SPECS'] = [
+            'GroupedStartCombat' => [
+                'action_name' => 'Start_Combat',
+                'variants' => ['lethal' => 'Attack', 'brawl' => 'Brawl'],
+            ],
+        ];
+        $GLOBALS['FUNC_LIST'] = ['Start_Combat', 'Talk'];
+        $GLOBALS['EMOTEMOODS'] = 'neutral';
+        $GLOBALS['LANG_LLM_XTTS'] = false;
+        $GLOBALS['TTSFUNCTION'] = '';
+        $GLOBALS['INLINE_NARRATION_MODE'] = 'disabled';
+        $GLOBALS['INLINE_NARRATION_ENABLED'] = false;
+        $GLOBALS['use_emotions_expression'] = false;
+        $GLOBALS['FEATURES']['MISC']['JSON_DIALOGUE_FORMAT_REORDER'] = false;
+
+        try {
+            setResponseTemplate();
+            setStructuredOutputTemplate();
+            setGBNFGrammar();
+
+            $this->assertArrayHasKey('mode', $GLOBALS['responseTemplate']);
+            $this->assertStringContainsString('Start_Combat=lethal|brawl', $GLOBALS['responseTemplate']['mode']);
+            $this->assertStringContainsString('never target', $GLOBALS['responseTemplate']['target']);
+            $this->assertStringContainsString('never item', $GLOBALS['responseTemplate']['item']);
+
+            $schema = $GLOBALS['structuredOutputTemplate']['json_schema']['schema'];
+            $this->assertArrayHasKey('mode', $schema['properties']);
+            $this->assertContains('mode', $schema['required']);
+            $this->assertSame(['', 'lethal', 'brawl'], $schema['properties']['mode']['enum']);
+            $this->assertSame(1, $schema['properties']['amount']['minimum']);
+
+            $this->assertStringContainsString('root-mode', $GLOBALS['grammar']);
+            $this->assertStringContainsString('("\"\"" | "\"lethal\"" | "\"brawl\"")', $GLOBALS['grammar']);
+            $this->assertStringContainsString('root-item', $GLOBALS['grammar']);
+            $this->assertStringContainsString('root-amount', $GLOBALS['grammar']);
+        } finally {
+            foreach ($previousGlobals as $globalName => $previous) {
+                if ($previous['exists']) {
+                    $GLOBALS[$globalName] = $previous['value'];
+                } else {
+                    unset($GLOBALS[$globalName]);
+                }
+            }
+        }
+    }
+
     public function testDynamicProfileBatchIsQueuedAndConsumedOnce(): void
     {
         $db = new DynamicProfileQueueTestDb();


### PR DESCRIPTION
## Summary
- Compact 17 simultaneously eligible, uncustomized vanilla actions into 7 model-facing tools, reducing the maximum first-pass NPC action surface from 41 tools to 31.
- Use one consistent action envelope across prompt JSON, structured output, local-model grammar, and grouped tool definitions: `action`, `mode`, `target`, `item`, and `amount`.
- Route each grouped selection back to its existing legacy action code and payload so current confirmation, cooldown, follow-up, script-proxy, and CHIM command behavior stays in place.
- Preserve customized action definitions and expose only variants eligible for the current actor and turn.

## Grouped action modes
- `Handle_Crime`: `add_bounty`, `arrest`, `forgive`, `collect_bounty_payment`
- `Start_Combat`: `lethal`, `brawl`
- `Follow`: `follow_actor`, `follow_player`, `approach_player`
- `Set_Pace`: `faster`, `slower`
- `Give`: `item`, `gold`
- `Exchange`: `trade`, `receive_gift`
- `Perform_Gesture`: `drink_gesture`, `toast`

`target` now consistently carries an actor, recipient, or destination; `item` carries an actual item or action detail; and `amount` carries a positive quantity. JSON connectors receive a generated `mode` enum containing only active grouped variants plus blank for Talk and individual actions.

## Validation
- PHP lint on all 8 changed PHP files
- `ActionCatalogTest.php`: 13 tests, 187 assertions
- `CoreRequestStabilityTest.php`: 8 tests, 25 assertions
- `ActionActorTargetRefTest.php`: 2 tests, 4 assertions
- `ProfileConnectorTestsRegressionTest.php`: 1 test, 1 assertion
- Total: 24 tests, 217 assertions
- `git diff --check`
- CHIM unstable guard: `PR_REQUIRED` as expected for core runtime changes; it also reports overlap with #594 in `functions/functions.php`, `functions/json_response.php`, and `lib/core/action_catalog.php`

## Compatibility
- Existing legacy action codes and command payloads are unchanged.
- The grouped resolver accepts the first draft's old selector aliases while new model-facing schemas use `mode`.
- No database migration or seed rewrite is required.

## Scope and limits
- No release/version change, DLL, deploy, or direct `unstable` push.
- StobeServer has no equivalent core action catalog. DialecticServer has a separate Fallout-specific catalog, so neither sibling is changed here.
- Source, schema generation, and focused execution routing are validated; live connector calls and in-game behavior have not been tested.