### PR TITLE
Add transactional database migration system

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,45 @@
+# Database migrations
+
+HerikaServer schema changes are ordered, immutable migrations. Normal requests only verify the migration ledger; they never run DDL.
+
+## Operator commands
+
+Back up the database before applying migrations.
+
+```bash
+php scripts/database.php status
+php scripts/database.php migrate
+php scripts/database.php verify
+php scripts/database.php doctor
+```
+
+Existing databases without `chim_meta.schema_migrations` must use the compatibility bridge once:
+
+```bash
+php scripts/database.php legacy-bridge
+```
+
+The bridge runs the frozen legacy updater and the narrowly audited `legacy-baseline-repair.sql`, validates the generated `202608110000` baseline contract, records that baseline, applies every pending migration in its own transaction, and validates the current schema contract. It is not called by normal web or game traffic.
+
+## Adding a schema change
+
+1. Add `database/migrations/YYYYMMDDNNNN_short_name.sql`. Versions are globally ordered and filenames are lowercase.
+2. Use raw SQL by default. Do not add `BEGIN`, `COMMIT`, or `ROLLBACK`; the runner owns the transaction.
+3. Use a PHP migration only when a data transformation genuinely needs application logic. The file must return a callable that accepts the PostgreSQL connection.
+4. Apply the migration to a disposable database, then regenerate `database/schema-contract.json`:
+
+```bash
+HERIKA_DATABASE_DSN='host=localhost dbname=testdb user=dwemer password=dwemer' \
+  php scripts/generate-schema-contract.php current database/schema-contract.json
+```
+
+5. Test both a fresh database and a copy of an existing database. Run `migrate` twice, then run `verify`.
+
+Never edit an applied migration. The runner checks the stored name and SHA-256 checksum and rejects drift, missing files, and gaps.
+
+## Contracts and legacy code
+
+- `database/baseline/202608110000_contract.json` is the generated structural contract for the one-time legacy transition. It is immutable.
+- `database/schema-contract.json` is the generated contract for the latest code and migration. It detects missing tables, columns, constraints, indexes, views, and required extensions.
+- `debug/db_updates.php` is frozen as a temporary compatibility bridge. New changes must not be added there.
+- `data/database_default.sql` remains the legacy seed during the transition. The installer immediately runs the bridge after importing it.

--- a/database/baseline/202608110000_contract.json
+++ b/database/baseline/202608110000_contract.json
@@ -1,0 +1,4136 @@
+{
+    "baseline_version": 202608110000,
+    "extensions": [
+        "pg_trgm",
+        "vector"
+    ],
+    "tables": {
+        "public.actions_issued": {
+            "columns": {
+                "action": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "fullcall": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "actorname": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "original": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                }
+            }
+        },
+        "public.animations": {
+            "columns": {
+                "mood": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "animations": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                }
+            }
+        },
+        "public.animations_custom": {
+            "columns": {
+                "mood": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "animations": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                }
+            }
+        },
+        "public.audit_memory": {
+            "columns": {
+                "input": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "keywords": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rank_any": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "rank_all": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "memory": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "time": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.audit_request": {
+            "columns": {
+                "request": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "result": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "connector": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "usage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                }
+            }
+        },
+        "public.bgl_history": {
+            "columns": {
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "category": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.bio_templates": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "oghma_knowledge_tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "core": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_static_bio": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "refid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.bio_templates_custom": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "oghma_knowledge_tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "core": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_static_bio": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "refid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.books": {
+            "columns": {
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "title": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "content": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.conf_opts": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "value": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_action": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "code_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "action_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "return_message": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "available_to_npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "available_to_followers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "available_to_narrator": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "is_activated": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "parameters_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "game_function": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "import_version": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "script_proxy_program": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_action_custom": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "code_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "action_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "return_message": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "available_to_npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "available_to_followers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "available_to_narrator": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "is_activated": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "parameters_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "game_function": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "import_version": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "script_proxy_program": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_api_badge": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "api_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                }
+            }
+        },
+        "public.core_itt_connector": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "driver": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "api_badge_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_llm_connector": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "model": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "provider": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "driver": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "reasoning_model": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "max_tokens": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "enforce_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "prefill_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "api_badge_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "json_schema": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "temperature": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "presence_penalty": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "frequency_penalty": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "repetition_penalty": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "top_p": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "top_k": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "min_p": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "top_a": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "service": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_narrator": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "value": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_npc_master": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "npc_favorite": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "lock_profile": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "prompt_head": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_static_bio": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "oghma_knowledge_tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "emote_moods": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "refid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "profile_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "dynamic_profile": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "extended_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "md5": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets_last_updated": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "core": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "base": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_npc_master_history": {
+            "columns": {
+                "history_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "npc_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_favorite": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "lock_profile": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "prompt_head": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_static_bio": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "oghma_knowledge_tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "emote_moods": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "refid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "profile_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "dynamic_profile": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "extended_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "md5": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets_last_updated": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "created": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "core": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "base": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_player": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "value": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_profiles": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "default_npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "default_narrator": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tts_connector_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "itt_connector_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_primary_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_secondary_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_tertiary_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_quaternary_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_formatter_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_fallback_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "diary_connector_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "slot": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "prompt": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_stt_connector": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "driver": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "api_badge_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_tts_connector": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "driver": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "api_badge_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "voice_field": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_tts_fallback": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.currentmission": {
+            "columns": {
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.database_versioning": {
+            "columns": {
+                "tablename": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "version": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.descriptions": {
+            "columns": {
+                "plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "baseid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.descriptions_custom": {
+            "columns": {
+                "plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "baseid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.diarylog": {
+            "columns": {
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "topic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "content": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "people": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "location": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.dynamic_bio": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "prompt": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                }
+            }
+        },
+        "public.eventlog": {
+            "columns": {
+                "type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "people": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "location": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "party": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "utterance_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "delivery_state": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.faction_vanilla": {
+            "columns": {
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "formid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.factions": {
+            "columns": {
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "formid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "vendor_cont": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "stock": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "gold": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "player_rank": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                }
+            }
+        },
+        "public.game_plugins": {
+            "columns": {
+                "plugin_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "is_light": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "compile_index": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "small_file_compile_index": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "partial_index": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "formid_prefix": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.general_settings": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "value": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.import_rules": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "match_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "match_race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "match_gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "match_base": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "match_faction": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "match_mods": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "_text",
+                    "nullable": true
+                },
+                "action": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "profile": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "priority": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "enabled": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                }
+            }
+        },
+        "public.json_personalities": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                }
+            }
+        },
+        "public.locations": {
+            "columns": {
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "formid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "region": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "hold": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "factions": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "is_interior": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "vanilla_location": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                },
+                "coords": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "point",
+                    "nullable": true
+                },
+                "refs": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "cleared": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "world": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "chim_added": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                }
+            }
+        },
+        "public.log": {
+            "columns": {
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "prompt": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "response": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.market_cache": {
+            "columns": {
+                "baseid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "enchantment": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "price": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                }
+            }
+        },
+        "public.master_packages": {
+            "columns": {
+                "mod": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "formid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "start": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "change": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "end": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.memory": {
+            "columns": {
+                "speaker": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "message": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "session": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "uid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "listener": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "momentum": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "event": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                }
+            }
+        },
+        "public.memory_summary": {
+            "columns": {
+                "gamets_truncated": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "n": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "packed_message": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "summary": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "classifier": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "uid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "embedding": {
+                    "udt_schema": "public",
+                    "udt_name": "vector",
+                    "nullable": true
+                },
+                "companions": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "embedding768": {
+                    "udt_schema": "public",
+                    "udt_name": "vector",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "scope": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "native_vec": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "tsvector",
+                    "nullable": true
+                }
+            }
+        },
+        "public.moods_issued": {
+            "columns": {
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "speaker": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "mood": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "listener": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "emotion": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "emotion_intensity": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.named_cell": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "cell_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "location_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "interior": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "dest_door_cell_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "dest_door_exterior": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "door_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "vanilla_cell": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                },
+                "statics_list": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "worldspace": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "closed": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "door_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "door_x": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "door_y": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                }
+            }
+        },
+        "public.npc_profile_backup": {
+            "columns": {
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.npc_templates": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "npc_pers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "npc_misc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "melotts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "xtts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "xvasynth_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_dynamic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_background": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.npc_templates_custom": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "npc_pers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "npc_misc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "melotts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "xtts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "xvasynth_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_dynamic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_background": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.npc_templates_trl": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "npc_pers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "npc_misc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "lang": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "orig_desc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "name_trl": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                }
+            }
+        },
+        "public.npc_templates_v2": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "npc_pers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "npc_misc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "melotts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "xtts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "xvasynth_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                }
+            }
+        },
+        "public.oghma": {
+            "columns": {
+                "topic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "topic_desc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "native_vector": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "tsvector",
+                    "nullable": true
+                },
+                "knowledge_class": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "topic_desc_basic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "knowledge_class_basic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "category": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "aliases": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "vector384": {
+                    "udt_schema": "public",
+                    "udt_name": "vector",
+                    "nullable": true
+                }
+            }
+        },
+        "public.oghma_dynamic": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "id_quest": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "topic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "topic_desc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "knowledge_class": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "topic_desc_basic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "knowledge_class_basic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "category": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.physical_npc_diaries": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "title": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "last_diary_localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.prompts": {
+            "columns": {
+                "prompt_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "default_prompt": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "custom_prompt": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.quest_asset_group_members": {
+            "columns": {
+                "dataset_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "group_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "stable_ref": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "weight": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "constraints_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "source_pack": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_asset_groups": {
+            "columns": {
+                "dataset_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "group_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "selection_policy_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "source_pack": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_asset_imports": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "pack_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "manifest_version": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "manifest_hash": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "source_file": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "asset_count": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "group_count": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "member_count": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "imported_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_asset_packs": {
+            "columns": {
+                "pack_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "game": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "manifest_version": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "required_plugins_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "source": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "manifest_hash": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "imported_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_assets": {
+            "columns": {
+                "source_pack": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "stable_ref": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "signature": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "editor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "display_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "source_plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "winning_plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "metadata_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "safety_status": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_item_types": {
+            "columns": {
+                "type_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "formids_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_npc_own_templates": {
+            "columns": {
+                "template_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "formids_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_npc_templates": {
+            "columns": {
+                "template_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "formids_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_outfits": {
+            "columns": {
+                "class_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "formids_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                }
+            }
+        },
+        "public.questlog": {
+            "columns": {
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "id_quest": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "editor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "giver_actor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "reward": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "target_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "is_unique": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                },
+                "mod": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "briefing": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "briefing2": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "status": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quests": {
+            "columns": {
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "id_quest": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "editor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "giver_actor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "reward": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "target_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "is_unique": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                },
+                "mod": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "briefing": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "briefing2": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "status": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.relationship_eval_queue": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "npc_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "eval_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "retry_count": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                }
+            }
+        },
+        "public.relationship_init_queue": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "npc_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "init_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "retry_count": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "last_error": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.responselog": {
+            "columns": {
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "sent": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "actor": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "text": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "action": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tag": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.rolemaster": {
+            "columns": {
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ttl": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.rumors": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "hold": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "content": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rumor_length_days": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                }
+            }
+        },
+        "public.skyrim_quest_action_outbox": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "quest_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "beat_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "action_type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "action_gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "payload_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "status": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "result_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "applied_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                }
+            }
+        },
+        "public.skyrim_quest_beat_state": {
+            "columns": {
+                "quest_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "beat_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "fired": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "fired_order": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "fired_gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "evidence_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                }
+            }
+        },
+        "public.skyrim_quest_definitions": {
+            "columns": {
+                "quest_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "quest_editor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "title": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "source_plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "source_form_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "source_path": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "skeleton": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                }
+            }
+        },
+        "public.skyrim_quest_events": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "quest_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "event_type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "event_source": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "location_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "payload_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                }
+            }
+        },
+        "public.skyrim_quest_instances": {
+            "columns": {
+                "quest_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "quest_editor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "run_state": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "current_stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "last_gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "state_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                }
+            }
+        },
+        "public.sneq_quests": {
+            "columns": {
+                "quest_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "code": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "quest_run_state": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "quest_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "title": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.sneq_quests_saved": {
+            "columns": {
+                "quest_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "code": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "quest_run_state": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "quest_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "title": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "state": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "history_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                }
+            }
+        },
+        "public.speech": {
+            "columns": {
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "speaker": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "speech": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "location": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "listener": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "topic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "companions": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "audios": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "utterance_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "mood": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "emotion": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "emotion_intensity": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.translations": {
+            "columns": {
+                "source_word": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "translated_word": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "expansion": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "sense": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                }
+            }
+        },
+        "public.visual_context": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "subject_type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "subject_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "subject_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "baseid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "refid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "cell_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "location_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "image_path": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "image_sha256": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "perspective": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "provider": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "model": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "locked": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "user_edited": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "captured_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                }
+            }
+        }
+    },
+    "views": {
+        "public.combined_animations": "SELECT c.mood,\n    c.animations,\n    c.npc\n   FROM animations_custom c\nUNION ALL\n SELECT t.mood,\n    t.animations,\n    t.npc\n   FROM (animations t\n     LEFT JOIN animations_custom c ON (((t.mood)::text = (c.mood)::text)))\n  WHERE (c.mood IS NULL);",
+        "public.combined_bio_templates": "SELECT c.npc_name,\n    c.oghma_knowledge_tags,\n    c.core,\n    c.npc_static_bio,\n    c.appearance,\n    c.personality,\n    c.relationships,\n    c.occupation,\n    c.skills,\n    c.speechstyle,\n    c.goals,\n    c.voiceid,\n    c.gender,\n    c.race,\n    c.refid\n   FROM bio_templates_custom c\nUNION ALL\n SELECT b.npc_name,\n    b.oghma_knowledge_tags,\n    b.core,\n    b.npc_static_bio,\n    b.appearance,\n    b.personality,\n    b.relationships,\n    b.occupation,\n    b.skills,\n    b.speechstyle,\n    b.goals,\n    b.voiceid,\n    b.gender,\n    b.race,\n    b.refid\n   FROM (bio_templates b\n     LEFT JOIN bio_templates_custom c ON (((b.npc_name)::text = (c.npc_name)::text)))\n  WHERE (c.npc_name IS NULL);",
+        "public.combined_core_action": "SELECT c.id,\n    c.code_name,\n    c.action_name,\n    c.description,\n    c.return_message,\n    c.available_to_npc,\n    c.available_to_followers,\n    c.available_to_narrator,\n    c.is_activated,\n    c.parameters_json,\n    c.metadata,\n    c.game_function,\n    c.import_version,\n    c.script_proxy_program,\n    c.created_at,\n    c.updated_at\n   FROM core_action_custom c\nUNION ALL\n SELECT b.id,\n    b.code_name,\n    b.action_name,\n    b.description,\n    b.return_message,\n    b.available_to_npc,\n    b.available_to_followers,\n    b.available_to_narrator,\n    b.is_activated,\n    b.parameters_json,\n    b.metadata,\n    b.game_function,\n    b.import_version,\n    b.script_proxy_program,\n    b.created_at,\n    b.updated_at\n   FROM (core_action b\n     LEFT JOIN core_action_custom c ON ((lower((b.code_name)::text) = lower((c.code_name)::text))))\n  WHERE (c.code_name IS NULL);",
+        "public.combined_descriptions": "SELECT c.plugin,\n    c.baseid,\n    c.name,\n    c.description\n   FROM descriptions_custom c\nUNION ALL\n SELECT i.plugin,\n    i.baseid,\n    i.name,\n    i.description\n   FROM (descriptions i\n     LEFT JOIN descriptions_custom c ON (((i.plugin = c.plugin) AND ((i.baseid)::text = (c.baseid)::text))))\n  WHERE (c.baseid IS NULL);",
+        "public.combined_npc_templates": "SELECT c.npc_name,\n    c.npc_pers,\n    c.npc_dynamic,\n    c.npc_misc,\n    c.melotts_voiceid,\n    c.xtts_voiceid,\n    c.xvasynth_voiceid,\n    c.npc_background,\n    c.npc_personality,\n    c.npc_appearance,\n    c.npc_relationships,\n    c.npc_occupation,\n    c.npc_skills,\n    c.npc_speechstyle,\n    c.npc_goals\n   FROM npc_templates_custom c\nUNION ALL\n SELECT t.npc_name,\n    t.npc_pers,\n    t.npc_dynamic,\n    t.npc_misc,\n    t.melotts_voiceid,\n    t.xtts_voiceid,\n    t.xvasynth_voiceid,\n    t.npc_background,\n    t.npc_personality,\n    t.npc_appearance,\n    t.npc_relationships,\n    t.npc_occupation,\n    t.npc_skills,\n    t.npc_speechstyle,\n    t.npc_goals\n   FROM (npc_templates t\n     LEFT JOIN npc_templates_custom c ON (((t.npc_name)::text = (c.npc_name)::text)))\n  WHERE (c.npc_name IS NULL);",
+        "public.eventlog_view": "SELECT e.type,\n    e.data,\n    e.sess,\n    e.gamets,\n    e.localts,\n    e.ts,\n    e.rowid,\n    e.people,\n    e.location,\n    e.party,\n    convert_gamets2skyrim_date(e.gamets) AS sk_date,\n    convert_gamets2skyrim_long_date(e.gamets) AS sk_long_date,\n    convert_gamets2days(e.gamets) AS sk_days,\n    convert_gamets2gregorian_date(e.gamets) AS gregorian_date\n   FROM eventlog e;",
+        "public.locations_v": "SELECT locations.name,\n    locations.formid,\n    locations.region,\n    locations.hold,\n    locations.tags,\n    locations.factions,\n    locations.is_interior,\n    locations.vanilla_location,\n    locations.coords,\n    locations.refs,\n    locations.cleared,\n    locations.updated_at,\n    locations.world,\n    locations.chim_added\n   FROM locations\n  WHERE\n        CASE\n            WHEN ((locations.formid = 102771) AND (locations.cleared = false)) THEN false\n            ELSE true\n        END;",
+        "public.memory_v": "SELECT subquery.message,\n    subquery.uid,\n    subquery.gamets,\n    subquery.speaker,\n    subquery.listener,\n    subquery.ts\n   FROM ( SELECT memory.message,\n            memory.uid,\n            memory.gamets,\n            '-'::text AS speaker,\n            '-'::text AS listener,\n            memory.ts\n           FROM memory\n          WHERE ((memory.message !~~ 'Dear Diary%'::text) AND (memory.message <> ''::text) AND ((memory.event)::text <> 'backgroundlife_diary'::text))\n        UNION\n         SELECT ((((('(Context Location:'::text || speech.location) || ') '::text) || speech.speaker) || ': '::text) || speech.speech),\n            (speech.rowid)::integer AS rowid,\n            speech.gamets,\n            speech.speaker,\n            speech.listener,\n            speech.ts\n           FROM speech\n          WHERE (speech.speech <> ''::text)\n        UNION\n         SELECT eventlog.data,\n            (eventlog.rowid)::integer AS rowid,\n            eventlog.gamets,\n            '-'::text AS text,\n            '-'::text AS listener,\n            eventlog.ts\n           FROM eventlog\n          WHERE ((eventlog.type)::text = ANY (ARRAY[('death'::character varying)::text, ('location'::character varying)::text]))) subquery\n  ORDER BY subquery.gamets, subquery.ts;",
+        "public.speech_view": "SELECT s.sess,\n    s.speaker,\n    s.speech,\n    s.location,\n    s.listener,\n    s.topic,\n    s.localts,\n    s.gamets,\n    s.ts,\n    s.rowid,\n    s.companions,\n    s.audios,\n    convert_gamets2skyrim_date(s.gamets) AS sk_date,\n    convert_gamets2skyrim_long_date(s.gamets) AS sk_long_date,\n    convert_gamets2days(s.gamets) AS sk_days,\n    convert_gamets2gregorian_date(s.gamets) AS gregorian_date\n   FROM speech s;"
+    },
+    "constraints": [
+        "public.actions_issued.actions_issued_pkey",
+        "public.audit_request.audit_request_primary",
+        "public.bgl_history.bgl_history_pkey",
+        "public.bio_templates.bio_templates_pkey",
+        "public.bio_templates_custom.bio_templates_custom_pkey",
+        "public.books.books_pidx",
+        "public.conf_opts.pid",
+        "public.core_action.core_action_code_name_key",
+        "public.core_action.core_action_pkey",
+        "public.core_action_custom.core_action_custom_code_name_key",
+        "public.core_action_custom.core_action_custom_pkey",
+        "public.core_api_badge.core_api_badge_label_unique",
+        "public.core_api_badge.my_table_pkey",
+        "public.core_itt_connector.itt_connector_api_badge_id_fkey",
+        "public.core_itt_connector.itt_connector_pkey",
+        "public.core_llm_connector.llm_connector_api_badge_id_fkey",
+        "public.core_llm_connector.llm_connector_pkey",
+        "public.core_narrator.core_narrator_pkey",
+        "public.core_npc_master.fk_profile_id",
+        "public.core_npc_master.npc_master_npc_name_key",
+        "public.core_npc_master.npc_master_pkey",
+        "public.core_npc_master_history.core_npc_master_history_pkey",
+        "public.core_player.core_player_pkey",
+        "public.core_profiles.fk_diary_connector",
+        "public.core_profiles.profiles_itt_connector_id_fkey",
+        "public.core_profiles.profiles_llm_fallback_id_fkey",
+        "public.core_profiles.profiles_llm_formatter_id_fkey",
+        "public.core_profiles.profiles_llm_primary_id_fkey",
+        "public.core_profiles.profiles_llm_quaternary_id_fkey",
+        "public.core_profiles.profiles_llm_secondary_id_fkey",
+        "public.core_profiles.profiles_llm_tertiary_id_fkey",
+        "public.core_profiles.profiles_pkey",
+        "public.core_profiles.profiles_tts_connector_id_fkey",
+        "public.core_stt_connector.stt_connector_api_badge_id_fkey",
+        "public.core_stt_connector.stt_connector_pkey",
+        "public.core_tts_connector.tts_connector_api_badge_id_fkey",
+        "public.core_tts_connector.tts_connector_pkey",
+        "public.core_tts_fallback.core_tts_fallback_gender_check",
+        "public.core_tts_fallback.core_tts_fallback_pkey",
+        "public.core_tts_fallback.core_tts_fallback_race_gender_key",
+        "public.currentmission.currentmission_pidx",
+        "public.database_versioning.database_versioning_pkey",
+        "public.descriptions.descriptions_pkey",
+        "public.descriptions_custom.descriptions_custom_pkey",
+        "public.diarylog.diarylog_pidx",
+        "public.dynamic_bio.dynamic_bio_pkey",
+        "public.eventlog.eventlog_primary",
+        "public.factions.factions_pkey",
+        "public.game_plugins.game_plugins_pkey",
+        "public.general_settings.general_settings_pkey",
+        "public.import_rules.import_rules_pkey",
+        "public.import_rules.import_rules_profile_fkey",
+        "public.json_personalities.json_personalities_pkey",
+        "public.market_cache.market_cache_pk",
+        "public.master_packages.master_packages_pk",
+        "public.memory.memory_pidx",
+        "public.memory_summary.memory_summary_pidx",
+        "public.moods_issued.moods_issued_pkey",
+        "public.named_cell.cell_id_door_id",
+        "public.npc_templates.npc_custom_name_key",
+        "public.npc_templates_custom.npc_name_key",
+        "public.npc_templates_trl.npc_templates_trl_pk",
+        "public.npc_templates_v2.npc_templates_v2_pkey",
+        "public.oghma.oghma_pkey",
+        "public.oghma_dynamic.oghma_dynamic_pkey",
+        "public.physical_npc_diaries.physical_npc_diaries_pkey",
+        "public.prompts.prompts_pkey",
+        "public.quest_asset_group_members.quest_asset_group_members_constraints_is_object",
+        "public.quest_asset_group_members.quest_asset_group_members_pkey",
+        "public.quest_asset_group_members.quest_asset_group_members_source_pack_dataset_name_group_k_fkey",
+        "public.quest_asset_group_members.quest_asset_group_members_source_pack_fkey",
+        "public.quest_asset_group_members.quest_asset_group_members_source_pack_stable_ref_fkey",
+        "public.quest_asset_group_members.quest_asset_group_members_weight",
+        "public.quest_asset_groups.quest_asset_groups_dataset",
+        "public.quest_asset_groups.quest_asset_groups_key_format",
+        "public.quest_asset_groups.quest_asset_groups_pkey",
+        "public.quest_asset_groups.quest_asset_groups_policy_is_object",
+        "public.quest_asset_groups.quest_asset_groups_source_pack_fkey",
+        "public.quest_asset_imports.quest_asset_imports_pkey",
+        "public.quest_asset_packs.quest_asset_packs_pkey",
+        "public.quest_asset_packs.quest_asset_packs_plugins_is_array",
+        "public.quest_assets.quest_assets_metadata_is_object",
+        "public.quest_assets.quest_assets_pkey",
+        "public.quest_assets.quest_assets_safety_status",
+        "public.quest_assets.quest_assets_source_pack_fkey",
+        "public.quest_assets.quest_assets_stable_ref_format",
+        "public.quest_item_types.quest_item_types_formids_json_is_array",
+        "public.quest_item_types.quest_item_types_pk",
+        "public.quest_npc_own_templates.quest_npc_own_templates_formids_json_is_array",
+        "public.quest_npc_own_templates.quest_npc_own_templates_pk",
+        "public.quest_npc_templates.quest_npc_templates_formids_json_is_array",
+        "public.quest_npc_templates.quest_npc_templates_pk",
+        "public.quest_outfits.quest_outfits_formids_json_is_array",
+        "public.quest_outfits.quest_outfits_pk",
+        "public.questlog.questlog_pkey",
+        "public.relationship_eval_queue.relationship_eval_queue_npc_id_key",
+        "public.relationship_eval_queue.relationship_eval_queue_pkey",
+        "public.relationship_init_queue.relationship_init_queue_npc_id_key",
+        "public.relationship_init_queue.relationship_init_queue_pkey",
+        "public.rolemaster.rolemaster_pk",
+        "public.skyrim_quest_action_outbox.skyrim_quest_action_outbox_pkey",
+        "public.skyrim_quest_action_outbox.skyrim_quest_action_outbox_quest_key_fkey",
+        "public.skyrim_quest_beat_state.skyrim_quest_beat_state_pkey",
+        "public.skyrim_quest_beat_state.skyrim_quest_beat_state_quest_key_fkey",
+        "public.skyrim_quest_definitions.skyrim_quest_definitions_pkey",
+        "public.skyrim_quest_events.skyrim_quest_events_pkey",
+        "public.skyrim_quest_events.skyrim_quest_events_quest_key_fkey",
+        "public.skyrim_quest_instances.skyrim_quest_instances_pkey",
+        "public.skyrim_quest_instances.skyrim_quest_instances_quest_key_fkey",
+        "public.sneq_quests.sneq_quests_pkey",
+        "public.sneq_quests_saved.sneq_quests_saved_id",
+        "public.translations.translation_pk",
+        "public.visual_context.visual_context_pkey"
+    ],
+    "indexes": [
+        "public.actions_issued.actions_issued_pkey",
+        "public.audit_request.audit_request_primary",
+        "public.bgl_history.bgl_history_pkey",
+        "public.bio_templates.bio_templates_pkey",
+        "public.bio_templates_custom.bio_templates_custom_pkey",
+        "public.books.books_pidx",
+        "public.conf_opts.pid",
+        "public.core_action.core_action_code_name_key",
+        "public.core_action.core_action_pkey",
+        "public.core_action.idx_core_action_action_name_lower",
+        "public.core_action.idx_core_action_available_to_followers",
+        "public.core_action.idx_core_action_available_to_narrator",
+        "public.core_action.idx_core_action_available_to_npc",
+        "public.core_action.idx_core_action_code_name_lower",
+        "public.core_action.idx_core_action_game_function",
+        "public.core_action.idx_core_action_is_activated",
+        "public.core_action_custom.core_action_custom_code_name_key",
+        "public.core_action_custom.core_action_custom_pkey",
+        "public.core_action_custom.idx_core_action_custom_action_name_lower",
+        "public.core_action_custom.idx_core_action_custom_available_to_followers",
+        "public.core_action_custom.idx_core_action_custom_available_to_narrator",
+        "public.core_action_custom.idx_core_action_custom_available_to_npc",
+        "public.core_action_custom.idx_core_action_custom_code_name_lower",
+        "public.core_action_custom.idx_core_action_custom_game_function",
+        "public.core_action_custom.idx_core_action_custom_is_activated",
+        "public.core_api_badge.core_api_badge_label_unique",
+        "public.core_api_badge.idx_core_api_badge_label_lower",
+        "public.core_api_badge.my_table_pkey",
+        "public.core_itt_connector.itt_connector_pkey",
+        "public.core_llm_connector.llm_connector_pkey",
+        "public.core_narrator.core_narrator_pkey",
+        "public.core_npc_master.npc_master_npc_name_key",
+        "public.core_npc_master.npc_master_pkey",
+        "public.core_npc_master_history.core_npc_master_history_pkey",
+        "public.core_player.core_player_pkey",
+        "public.core_profiles.core_profiles_slot_unique_idx",
+        "public.core_profiles.profiles_pkey",
+        "public.core_stt_connector.stt_connector_pkey",
+        "public.core_tts_connector.tts_connector_pkey",
+        "public.core_tts_fallback.core_tts_fallback_pkey",
+        "public.core_tts_fallback.core_tts_fallback_race_gender_key",
+        "public.currentmission.currentmission_pidx",
+        "public.database_versioning.database_versioning_pkey",
+        "public.descriptions.descriptions_pkey",
+        "public.descriptions_custom.descriptions_custom_pkey",
+        "public.diarylog.diarylog_pidx",
+        "public.diarylog.idx_diarylog_people_gamets",
+        "public.dynamic_bio.dynamic_bio_pkey",
+        "public.eventlog.event_log_type",
+        "public.eventlog.eventlog_primary",
+        "public.eventlog.idx_eventlog_delivery_state",
+        "public.eventlog.idx_eventlog_gamets_pos",
+        "public.eventlog.idx_eventlog_gamets_ts_pos",
+        "public.eventlog.idx_eventlog_people_trgm",
+        "public.eventlog.idx_eventlog_people_trgm2",
+        "public.eventlog.idx_eventlog_utterance_id",
+        "public.factions.factions_pkey",
+        "public.game_plugins.game_plugins_pkey",
+        "public.general_settings.general_settings_pkey",
+        "public.import_rules.import_rules_pkey",
+        "public.json_personalities.json_personalities_pkey",
+        "public.market_cache.market_cache_pk",
+        "public.master_packages.master_packages_mod_formid_idx",
+        "public.master_packages.master_packages_pk",
+        "public.memory.memory_pidx",
+        "public.memory_summary.memory_summary_pidx",
+        "public.moods_issued.moods_issued_pkey",
+        "public.named_cell.cell_id_door_id",
+        "public.npc_templates.npc_custom_name_key",
+        "public.npc_templates_custom.npc_name_key",
+        "public.npc_templates_trl.npc_templates_trl_pk",
+        "public.npc_templates_v2.npc_templates_v2_pkey",
+        "public.oghma.oghma_native_vector_idx",
+        "public.oghma.oghma_pkey",
+        "public.oghma_dynamic.oghma_dynamic_pkey",
+        "public.physical_npc_diaries.physical_npc_diaries_pkey",
+        "public.physical_npc_diaries.physical_npc_diaries_updated_idx",
+        "public.prompts.idx_prompts_prompt_key_unique",
+        "public.prompts.prompts_pkey",
+        "public.quest_asset_group_members.quest_asset_group_members_pkey",
+        "public.quest_asset_group_members.quest_asset_members_group_idx",
+        "public.quest_asset_group_members.quest_asset_members_pack_idx",
+        "public.quest_asset_groups.quest_asset_groups_pack_idx",
+        "public.quest_asset_groups.quest_asset_groups_pkey",
+        "public.quest_asset_imports.quest_asset_imports_pkey",
+        "public.quest_asset_packs.quest_asset_packs_pkey",
+        "public.quest_assets.quest_assets_pkey",
+        "public.quest_assets.quest_assets_safety_idx",
+        "public.quest_assets.quest_assets_signature_idx",
+        "public.quest_assets.quest_assets_source_pack_idx",
+        "public.quest_item_types.idx_quest_item_types_active",
+        "public.quest_item_types.quest_item_types_pk",
+        "public.quest_npc_own_templates.idx_quest_npc_own_templates_active",
+        "public.quest_npc_own_templates.quest_npc_own_templates_pk",
+        "public.quest_npc_templates.idx_quest_npc_templates_active",
+        "public.quest_npc_templates.quest_npc_templates_pk",
+        "public.quest_outfits.idx_quest_outfits_active",
+        "public.quest_outfits.quest_outfits_pk",
+        "public.questlog.questlog_pkey",
+        "public.relationship_eval_queue.relationship_eval_queue_npc_id_key",
+        "public.relationship_eval_queue.relationship_eval_queue_pkey",
+        "public.relationship_init_queue.relationship_init_queue_npc_id_key",
+        "public.relationship_init_queue.relationship_init_queue_pkey",
+        "public.rolemaster.rolemaster_pk",
+        "public.skyrim_quest_action_outbox.idx_skyrim_quest_action_outbox_gamets",
+        "public.skyrim_quest_action_outbox.idx_skyrim_quest_action_outbox_status_created",
+        "public.skyrim_quest_action_outbox.skyrim_quest_action_outbox_pkey",
+        "public.skyrim_quest_beat_state.skyrim_quest_beat_state_pkey",
+        "public.skyrim_quest_definitions.idx_skyrim_quest_definitions_editor_id",
+        "public.skyrim_quest_definitions.skyrim_quest_definitions_pkey",
+        "public.skyrim_quest_events.idx_skyrim_quest_events_gamets",
+        "public.skyrim_quest_events.idx_skyrim_quest_events_quest_created",
+        "public.skyrim_quest_events.idx_skyrim_quest_events_type_created",
+        "public.skyrim_quest_events.skyrim_quest_events_pkey",
+        "public.skyrim_quest_instances.idx_skyrim_quest_instances_run_state",
+        "public.skyrim_quest_instances.skyrim_quest_instances_pkey",
+        "public.sneq_quests.sneq_quests_pkey",
+        "public.sneq_quests_saved.sneq_quests_saved_id",
+        "public.speech.idx_speech_gamets_pos",
+        "public.speech.idx_speech_listener_trgm",
+        "public.speech.idx_speech_speaker_trgm",
+        "public.speech.idx_speech_utterance_id",
+        "public.translations.search_idx",
+        "public.translations.translation_pk",
+        "public.visual_context.visual_context_image_idx",
+        "public.visual_context.visual_context_location_idx",
+        "public.visual_context.visual_context_pkey",
+        "public.visual_context.visual_context_subject_idx"
+    ]
+}

--- a/database/legacy-baseline-repair.sql
+++ b/database/legacy-baseline-repair.sql
@@ -1,0 +1,105 @@
+-- Legacy process state can outlive a recreated database, and the legacy version
+-- table stores only the newest marker for a feature. Reassert the two structures
+-- known to be skipped by those behaviors before accepting the baseline.
+CREATE TABLE IF NOT EXISTS public.visual_context (
+    id BIGSERIAL PRIMARY KEY,
+    subject_type TEXT NOT NULL DEFAULT 'scene',
+    subject_key TEXT NOT NULL,
+    subject_name TEXT NOT NULL DEFAULT '',
+    plugin TEXT NOT NULL DEFAULT '',
+    baseid TEXT NOT NULL DEFAULT '',
+    refid TEXT NOT NULL DEFAULT '',
+    cell_id TEXT NOT NULL DEFAULT '',
+    location_name TEXT NOT NULL DEFAULT '',
+    image_path TEXT NOT NULL DEFAULT '',
+    image_sha256 TEXT NOT NULL DEFAULT '',
+    description TEXT NOT NULL DEFAULT '',
+    perspective TEXT NOT NULL DEFAULT 'first_person',
+    provider TEXT NOT NULL DEFAULT '',
+    model TEXT NOT NULL DEFAULT '',
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    locked BOOLEAN NOT NULL DEFAULT FALSE,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    user_edited BOOLEAN NOT NULL DEFAULT FALSE,
+    captured_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS visual_context_location_idx
+    ON public.visual_context (LOWER(location_name), active, captured_at DESC);
+CREATE INDEX IF NOT EXISTS visual_context_subject_idx
+    ON public.visual_context (subject_type, subject_key, active, captured_at DESC);
+CREATE INDEX IF NOT EXISTS visual_context_image_idx
+    ON public.visual_context (image_sha256);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_prompts_prompt_key_unique
+    ON public.prompts (prompt_key);
+
+-- ALTER TYPE is blocked while profile eventlog views depend on the column, even
+-- though the views remain semantically identical. Capture and rebuild all of
+-- those views atomically when needed.
+DO $$
+DECLARE
+    dependent_view record;
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'eventlog'
+          AND column_name = 'sess'
+          AND udt_name <> 'text'
+    ) THEN
+        CREATE TEMP TABLE migration_eventlog_sess_views ON COMMIT DROP AS
+        SELECT DISTINCT
+               view_namespace.nspname AS schema_name,
+               dependent.relname AS view_name,
+               pg_get_viewdef(dependent.oid, true) AS definition,
+               pg_get_userbyid(dependent.relowner) AS owner_name,
+               dependent.relacl,
+               dependent.reloptions
+        FROM pg_depend dependency
+        JOIN pg_rewrite rewrite ON dependency.objid = rewrite.oid
+        JOIN pg_class dependent ON rewrite.ev_class = dependent.oid
+        JOIN pg_namespace view_namespace ON view_namespace.oid = dependent.relnamespace
+        JOIN pg_attribute source_column
+          ON source_column.attrelid = dependency.refobjid
+         AND source_column.attnum = dependency.refobjsubid
+        WHERE dependency.refobjid = 'public.eventlog'::regclass
+          AND source_column.attname = 'sess'
+          AND dependent.relkind = 'v';
+
+        IF EXISTS (
+            SELECT 1 FROM migration_eventlog_sess_views
+            WHERE relacl IS NOT NULL OR reloptions IS NOT NULL
+        ) THEN
+            RAISE EXCEPTION 'eventlog sess migration found a view with custom grants or options; repair it manually';
+        END IF;
+
+        FOR dependent_view IN SELECT * FROM migration_eventlog_sess_views LOOP
+            EXECUTE format('DROP VIEW %I.%I', dependent_view.schema_name, dependent_view.view_name);
+        END LOOP;
+
+        ALTER TABLE public.eventlog ALTER COLUMN sess TYPE text;
+
+        FOR dependent_view IN SELECT * FROM migration_eventlog_sess_views LOOP
+            EXECUTE format(
+                'CREATE VIEW %I.%I AS %s',
+                dependent_view.schema_name,
+                dependent_view.view_name,
+                dependent_view.definition
+            );
+            EXECUTE format(
+                'ALTER VIEW %I.%I OWNER TO %I',
+                dependent_view.schema_name,
+                dependent_view.view_name,
+                dependent_view.owner_name
+            );
+        END LOOP;
+    END IF;
+END
+$$;
+
+INSERT INTO public.database_versioning (tablename, version)
+VALUES ('eventlog_session_payload', 20260807001)
+ON CONFLICT (tablename) DO UPDATE
+SET version = GREATEST(public.database_versioning.version, EXCLUDED.version);

--- a/database/migrations/202608120001_audit_request_response.sql
+++ b/database/migrations/202608120001_audit_request_response.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.audit_request
+    ADD COLUMN IF NOT EXISTS response text;

--- a/database/schema-contract.json
+++ b/database/schema-contract.json
@@ -1,0 +1,4141 @@
+{
+    "schema_version": 202608120001,
+    "extensions": [
+        "pg_trgm",
+        "vector"
+    ],
+    "tables": {
+        "public.actions_issued": {
+            "columns": {
+                "action": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "fullcall": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "actorname": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "original": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                }
+            }
+        },
+        "public.animations": {
+            "columns": {
+                "mood": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "animations": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                }
+            }
+        },
+        "public.animations_custom": {
+            "columns": {
+                "mood": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "animations": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                }
+            }
+        },
+        "public.audit_memory": {
+            "columns": {
+                "input": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "keywords": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rank_any": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "rank_all": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "memory": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "time": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.audit_request": {
+            "columns": {
+                "request": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "result": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "connector": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "usage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "response": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.bgl_history": {
+            "columns": {
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "category": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.bio_templates": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "oghma_knowledge_tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "core": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_static_bio": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "refid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.bio_templates_custom": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "oghma_knowledge_tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "core": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_static_bio": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "refid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.books": {
+            "columns": {
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "title": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "content": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.conf_opts": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "value": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_action": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "code_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "action_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "return_message": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "available_to_npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "available_to_followers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "available_to_narrator": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "is_activated": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "parameters_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "game_function": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "import_version": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "script_proxy_program": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_action_custom": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "code_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "action_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "return_message": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "available_to_npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "available_to_followers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "available_to_narrator": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "is_activated": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "parameters_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "game_function": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "import_version": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "script_proxy_program": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_api_badge": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "api_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                }
+            }
+        },
+        "public.core_itt_connector": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "driver": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "api_badge_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_llm_connector": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "model": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "provider": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "driver": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "reasoning_model": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "max_tokens": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "enforce_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "prefill_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "api_badge_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "json_schema": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "temperature": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "presence_penalty": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "frequency_penalty": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "repetition_penalty": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "top_p": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "top_k": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "min_p": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "top_a": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "service": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_narrator": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "value": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_npc_master": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "npc_favorite": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "lock_profile": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "prompt_head": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_static_bio": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "oghma_knowledge_tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "emote_moods": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "refid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "profile_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "dynamic_profile": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "extended_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "md5": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets_last_updated": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "core": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "base": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_npc_master_history": {
+            "columns": {
+                "history_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "npc_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_favorite": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "lock_profile": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "prompt_head": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_static_bio": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "oghma_knowledge_tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "emote_moods": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "refid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "profile_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "dynamic_profile": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "extended_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "md5": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets_last_updated": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "created": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "core": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "base": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_player": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "value": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_profiles": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "default_npc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "default_narrator": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tts_connector_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "itt_connector_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_primary_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_secondary_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_tertiary_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_quaternary_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_formatter_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "llm_fallback_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "diary_connector_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "slot": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "prompt": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_stt_connector": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "driver": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "api_badge_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_tts_connector": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "driver": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "api_badge_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "voice_field": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.core_tts_fallback": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.currentmission": {
+            "columns": {
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.database_versioning": {
+            "columns": {
+                "tablename": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "version": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.descriptions": {
+            "columns": {
+                "plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "baseid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.descriptions_custom": {
+            "columns": {
+                "plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "baseid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.diarylog": {
+            "columns": {
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "topic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "content": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "people": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "location": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.dynamic_bio": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "prompt": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                }
+            }
+        },
+        "public.eventlog": {
+            "columns": {
+                "type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "people": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "location": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "party": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "utterance_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "delivery_state": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.faction_vanilla": {
+            "columns": {
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "formid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.factions": {
+            "columns": {
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "formid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "vendor_cont": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "stock": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "gold": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "player_rank": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                }
+            }
+        },
+        "public.game_plugins": {
+            "columns": {
+                "plugin_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "is_light": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "compile_index": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "small_file_compile_index": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "partial_index": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "formid_prefix": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.general_settings": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "value": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.import_rules": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "match_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "match_race": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "match_gender": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "match_base": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "match_faction": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "match_mods": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "_text",
+                    "nullable": true
+                },
+                "action": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "profile": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "priority": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "enabled": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                }
+            }
+        },
+        "public.json_personalities": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                }
+            }
+        },
+        "public.locations": {
+            "columns": {
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "formid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "region": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "hold": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "factions": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "is_interior": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "vanilla_location": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                },
+                "coords": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "point",
+                    "nullable": true
+                },
+                "refs": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "cleared": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "world": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "chim_added": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                }
+            }
+        },
+        "public.log": {
+            "columns": {
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "prompt": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "response": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "url": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.market_cache": {
+            "columns": {
+                "baseid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "enchantment": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "price": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                }
+            }
+        },
+        "public.master_packages": {
+            "columns": {
+                "mod": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "formid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "start": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "change": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "end": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.memory": {
+            "columns": {
+                "speaker": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "message": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "session": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "uid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "listener": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "momentum": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "event": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                }
+            }
+        },
+        "public.memory_summary": {
+            "columns": {
+                "gamets_truncated": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "n": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "packed_message": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "summary": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "classifier": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "uid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "embedding": {
+                    "udt_schema": "public",
+                    "udt_name": "vector",
+                    "nullable": true
+                },
+                "companions": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "embedding768": {
+                    "udt_schema": "public",
+                    "udt_name": "vector",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "scope": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "native_vec": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "tsvector",
+                    "nullable": true
+                }
+            }
+        },
+        "public.moods_issued": {
+            "columns": {
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "speaker": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "mood": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "listener": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "emotion": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "emotion_intensity": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.named_cell": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "cell_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "location_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "interior": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "dest_door_cell_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "dest_door_exterior": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "door_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "vanilla_cell": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                },
+                "statics_list": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "worldspace": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "closed": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "door_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "door_x": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "door_y": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "numeric",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                }
+            }
+        },
+        "public.npc_profile_backup": {
+            "columns": {
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.npc_templates": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "npc_pers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "npc_misc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "melotts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "xtts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "xvasynth_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_dynamic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_background": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.npc_templates_custom": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "npc_pers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "npc_misc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "melotts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "xtts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "xvasynth_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_dynamic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_background": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_personality": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_appearance": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_relationships": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_occupation": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_skills": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_speechstyle": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_goals": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.npc_templates_trl": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "npc_pers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "npc_misc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "lang": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "orig_desc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "name_trl": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                }
+            }
+        },
+        "public.npc_templates_v2": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "npc_pers": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "npc_misc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "melotts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "xtts_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "xvasynth_voiceid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                }
+            }
+        },
+        "public.oghma": {
+            "columns": {
+                "topic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "topic_desc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "native_vector": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "tsvector",
+                    "nullable": true
+                },
+                "knowledge_class": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "topic_desc_basic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "knowledge_class_basic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "category": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "aliases": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "vector384": {
+                    "udt_schema": "public",
+                    "udt_name": "vector",
+                    "nullable": true
+                }
+            }
+        },
+        "public.oghma_dynamic": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "id_quest": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "topic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "topic_desc": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "knowledge_class": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "topic_desc_basic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "knowledge_class_basic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tags": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "category": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.physical_npc_diaries": {
+            "columns": {
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "title": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "last_diary_localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.prompts": {
+            "columns": {
+                "prompt_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "default_prompt": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "custom_prompt": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                }
+            }
+        },
+        "public.quest_asset_group_members": {
+            "columns": {
+                "dataset_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "group_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "stable_ref": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "weight": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "constraints_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "source_pack": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_asset_groups": {
+            "columns": {
+                "dataset_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "group_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "selection_policy_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "source_pack": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_asset_imports": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "pack_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "manifest_version": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "manifest_hash": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "source_file": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "asset_count": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "group_count": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "member_count": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "imported_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_asset_packs": {
+            "columns": {
+                "pack_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "label": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "game": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "manifest_version": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "required_plugins_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "source": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "manifest_hash": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "imported_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_assets": {
+            "columns": {
+                "source_pack": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "stable_ref": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "signature": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "editor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "display_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "source_plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "winning_plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "metadata_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "safety_status": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_item_types": {
+            "columns": {
+                "type_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "formids_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_npc_own_templates": {
+            "columns": {
+                "template_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "formids_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_npc_templates": {
+            "columns": {
+                "template_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "formids_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quest_outfits": {
+            "columns": {
+                "class_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "note": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "formids_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                }
+            }
+        },
+        "public.questlog": {
+            "columns": {
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "id_quest": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "editor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "giver_actor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "reward": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "target_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "is_unique": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                },
+                "mod": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "briefing": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "briefing2": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "status": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                }
+            }
+        },
+        "public.quests": {
+            "columns": {
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "id_quest": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": false
+                },
+                "name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "editor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "giver_actor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "reward": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "target_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "is_unique": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": true
+                },
+                "mod": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "briefing": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "briefing2": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "status": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.relationship_eval_queue": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "npc_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "eval_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "retry_count": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                }
+            }
+        },
+        "public.relationship_init_queue": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "npc_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "init_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamp",
+                    "nullable": true
+                },
+                "retry_count": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "last_error": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.responselog": {
+            "columns": {
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "sent": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "actor": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "text": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "action": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "tag": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.rolemaster": {
+            "columns": {
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ttl": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                }
+            }
+        },
+        "public.rumors": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "hold": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "content": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "rumor_length_days": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                }
+            }
+        },
+        "public.skyrim_quest_action_outbox": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "quest_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "beat_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "action_type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "action_gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "payload_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "status": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "result_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "applied_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                }
+            }
+        },
+        "public.skyrim_quest_beat_state": {
+            "columns": {
+                "quest_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "beat_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "fired": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "fired_order": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "fired_gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "evidence_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                }
+            }
+        },
+        "public.skyrim_quest_definitions": {
+            "columns": {
+                "quest_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "quest_editor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "title": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "source_plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "source_form_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "source_path": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "skeleton": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                }
+            }
+        },
+        "public.skyrim_quest_events": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "quest_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "event_type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "event_source": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "npc_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "location_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "payload_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                }
+            }
+        },
+        "public.skyrim_quest_instances": {
+            "columns": {
+                "quest_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "quest_editor_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "run_state": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "current_stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": true
+                },
+                "last_gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "state_json": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                }
+            }
+        },
+        "public.sneq_quests": {
+            "columns": {
+                "quest_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "code": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "quest_run_state": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "quest_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "title": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.sneq_quests_saved": {
+            "columns": {
+                "quest_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "code": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "quest_run_state": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "quest_data": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": true
+                },
+                "created_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": true
+                },
+                "title": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "stage": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "state": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "history_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                }
+            }
+        },
+        "public.speech": {
+            "columns": {
+                "sess": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "varchar",
+                    "nullable": true
+                },
+                "speaker": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "speech": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "location": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "listener": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "topic": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "localts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "gamets": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "ts": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": true
+                },
+                "rowid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "companions": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "audios": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "utterance_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "mood": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "emotion": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "emotion_intensity": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                }
+            }
+        },
+        "public.translations": {
+            "columns": {
+                "source_word": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "translated_word": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "expansion": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": true
+                },
+                "sense": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int4",
+                    "nullable": false
+                }
+            }
+        },
+        "public.visual_context": {
+            "columns": {
+                "id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "int8",
+                    "nullable": false
+                },
+                "subject_type": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "subject_key": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "subject_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "plugin": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "baseid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "refid": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "cell_id": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "location_name": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "image_path": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "image_sha256": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "description": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "perspective": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "provider": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "model": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "text",
+                    "nullable": false
+                },
+                "metadata": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "jsonb",
+                    "nullable": false
+                },
+                "locked": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "active": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "user_edited": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "bool",
+                    "nullable": false
+                },
+                "captured_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                },
+                "updated_at": {
+                    "udt_schema": "pg_catalog",
+                    "udt_name": "timestamptz",
+                    "nullable": false
+                }
+            }
+        }
+    },
+    "views": {
+        "public.combined_animations": "SELECT c.mood,\n    c.animations,\n    c.npc\n   FROM animations_custom c\nUNION ALL\n SELECT t.mood,\n    t.animations,\n    t.npc\n   FROM (animations t\n     LEFT JOIN animations_custom c ON (((t.mood)::text = (c.mood)::text)))\n  WHERE (c.mood IS NULL);",
+        "public.combined_bio_templates": "SELECT c.npc_name,\n    c.oghma_knowledge_tags,\n    c.core,\n    c.npc_static_bio,\n    c.appearance,\n    c.personality,\n    c.relationships,\n    c.occupation,\n    c.skills,\n    c.speechstyle,\n    c.goals,\n    c.voiceid,\n    c.gender,\n    c.race,\n    c.refid\n   FROM bio_templates_custom c\nUNION ALL\n SELECT b.npc_name,\n    b.oghma_knowledge_tags,\n    b.core,\n    b.npc_static_bio,\n    b.appearance,\n    b.personality,\n    b.relationships,\n    b.occupation,\n    b.skills,\n    b.speechstyle,\n    b.goals,\n    b.voiceid,\n    b.gender,\n    b.race,\n    b.refid\n   FROM (bio_templates b\n     LEFT JOIN bio_templates_custom c ON (((b.npc_name)::text = (c.npc_name)::text)))\n  WHERE (c.npc_name IS NULL);",
+        "public.combined_core_action": "SELECT c.id,\n    c.code_name,\n    c.action_name,\n    c.description,\n    c.return_message,\n    c.available_to_npc,\n    c.available_to_followers,\n    c.available_to_narrator,\n    c.is_activated,\n    c.parameters_json,\n    c.metadata,\n    c.game_function,\n    c.import_version,\n    c.script_proxy_program,\n    c.created_at,\n    c.updated_at\n   FROM core_action_custom c\nUNION ALL\n SELECT b.id,\n    b.code_name,\n    b.action_name,\n    b.description,\n    b.return_message,\n    b.available_to_npc,\n    b.available_to_followers,\n    b.available_to_narrator,\n    b.is_activated,\n    b.parameters_json,\n    b.metadata,\n    b.game_function,\n    b.import_version,\n    b.script_proxy_program,\n    b.created_at,\n    b.updated_at\n   FROM (core_action b\n     LEFT JOIN core_action_custom c ON ((lower((b.code_name)::text) = lower((c.code_name)::text))))\n  WHERE (c.code_name IS NULL);",
+        "public.combined_descriptions": "SELECT c.plugin,\n    c.baseid,\n    c.name,\n    c.description\n   FROM descriptions_custom c\nUNION ALL\n SELECT i.plugin,\n    i.baseid,\n    i.name,\n    i.description\n   FROM (descriptions i\n     LEFT JOIN descriptions_custom c ON (((i.plugin = c.plugin) AND ((i.baseid)::text = (c.baseid)::text))))\n  WHERE (c.baseid IS NULL);",
+        "public.combined_npc_templates": "SELECT c.npc_name,\n    c.npc_pers,\n    c.npc_dynamic,\n    c.npc_misc,\n    c.melotts_voiceid,\n    c.xtts_voiceid,\n    c.xvasynth_voiceid,\n    c.npc_background,\n    c.npc_personality,\n    c.npc_appearance,\n    c.npc_relationships,\n    c.npc_occupation,\n    c.npc_skills,\n    c.npc_speechstyle,\n    c.npc_goals\n   FROM npc_templates_custom c\nUNION ALL\n SELECT t.npc_name,\n    t.npc_pers,\n    t.npc_dynamic,\n    t.npc_misc,\n    t.melotts_voiceid,\n    t.xtts_voiceid,\n    t.xvasynth_voiceid,\n    t.npc_background,\n    t.npc_personality,\n    t.npc_appearance,\n    t.npc_relationships,\n    t.npc_occupation,\n    t.npc_skills,\n    t.npc_speechstyle,\n    t.npc_goals\n   FROM (npc_templates t\n     LEFT JOIN npc_templates_custom c ON (((t.npc_name)::text = (c.npc_name)::text)))\n  WHERE (c.npc_name IS NULL);",
+        "public.eventlog_view": "SELECT e.type,\n    e.data,\n    e.sess,\n    e.gamets,\n    e.localts,\n    e.ts,\n    e.rowid,\n    e.people,\n    e.location,\n    e.party,\n    convert_gamets2skyrim_date(e.gamets) AS sk_date,\n    convert_gamets2skyrim_long_date(e.gamets) AS sk_long_date,\n    convert_gamets2days(e.gamets) AS sk_days,\n    convert_gamets2gregorian_date(e.gamets) AS gregorian_date\n   FROM eventlog e;",
+        "public.locations_v": "SELECT locations.name,\n    locations.formid,\n    locations.region,\n    locations.hold,\n    locations.tags,\n    locations.factions,\n    locations.is_interior,\n    locations.vanilla_location,\n    locations.coords,\n    locations.refs,\n    locations.cleared,\n    locations.updated_at,\n    locations.world,\n    locations.chim_added\n   FROM locations\n  WHERE\n        CASE\n            WHEN ((locations.formid = 102771) AND (locations.cleared = false)) THEN false\n            ELSE true\n        END;",
+        "public.memory_v": "SELECT subquery.message,\n    subquery.uid,\n    subquery.gamets,\n    subquery.speaker,\n    subquery.listener,\n    subquery.ts\n   FROM ( SELECT memory.message,\n            memory.uid,\n            memory.gamets,\n            '-'::text AS speaker,\n            '-'::text AS listener,\n            memory.ts\n           FROM memory\n          WHERE ((memory.message !~~ 'Dear Diary%'::text) AND (memory.message <> ''::text) AND ((memory.event)::text <> 'backgroundlife_diary'::text))\n        UNION\n         SELECT ((((('(Context Location:'::text || speech.location) || ') '::text) || speech.speaker) || ': '::text) || speech.speech),\n            (speech.rowid)::integer AS rowid,\n            speech.gamets,\n            speech.speaker,\n            speech.listener,\n            speech.ts\n           FROM speech\n          WHERE (speech.speech <> ''::text)\n        UNION\n         SELECT eventlog.data,\n            (eventlog.rowid)::integer AS rowid,\n            eventlog.gamets,\n            '-'::text AS text,\n            '-'::text AS listener,\n            eventlog.ts\n           FROM eventlog\n          WHERE ((eventlog.type)::text = ANY (ARRAY[('death'::character varying)::text, ('location'::character varying)::text]))) subquery\n  ORDER BY subquery.gamets, subquery.ts;",
+        "public.speech_view": "SELECT s.sess,\n    s.speaker,\n    s.speech,\n    s.location,\n    s.listener,\n    s.topic,\n    s.localts,\n    s.gamets,\n    s.ts,\n    s.rowid,\n    s.companions,\n    s.audios,\n    convert_gamets2skyrim_date(s.gamets) AS sk_date,\n    convert_gamets2skyrim_long_date(s.gamets) AS sk_long_date,\n    convert_gamets2days(s.gamets) AS sk_days,\n    convert_gamets2gregorian_date(s.gamets) AS gregorian_date\n   FROM speech s;"
+    },
+    "constraints": [
+        "public.actions_issued.actions_issued_pkey",
+        "public.audit_request.audit_request_primary",
+        "public.bgl_history.bgl_history_pkey",
+        "public.bio_templates.bio_templates_pkey",
+        "public.bio_templates_custom.bio_templates_custom_pkey",
+        "public.books.books_pidx",
+        "public.conf_opts.pid",
+        "public.core_action.core_action_code_name_key",
+        "public.core_action.core_action_pkey",
+        "public.core_action_custom.core_action_custom_code_name_key",
+        "public.core_action_custom.core_action_custom_pkey",
+        "public.core_api_badge.core_api_badge_label_unique",
+        "public.core_api_badge.my_table_pkey",
+        "public.core_itt_connector.itt_connector_api_badge_id_fkey",
+        "public.core_itt_connector.itt_connector_pkey",
+        "public.core_llm_connector.llm_connector_api_badge_id_fkey",
+        "public.core_llm_connector.llm_connector_pkey",
+        "public.core_narrator.core_narrator_pkey",
+        "public.core_npc_master.fk_profile_id",
+        "public.core_npc_master.npc_master_npc_name_key",
+        "public.core_npc_master.npc_master_pkey",
+        "public.core_npc_master_history.core_npc_master_history_pkey",
+        "public.core_player.core_player_pkey",
+        "public.core_profiles.fk_diary_connector",
+        "public.core_profiles.profiles_itt_connector_id_fkey",
+        "public.core_profiles.profiles_llm_fallback_id_fkey",
+        "public.core_profiles.profiles_llm_formatter_id_fkey",
+        "public.core_profiles.profiles_llm_primary_id_fkey",
+        "public.core_profiles.profiles_llm_quaternary_id_fkey",
+        "public.core_profiles.profiles_llm_secondary_id_fkey",
+        "public.core_profiles.profiles_llm_tertiary_id_fkey",
+        "public.core_profiles.profiles_pkey",
+        "public.core_profiles.profiles_tts_connector_id_fkey",
+        "public.core_stt_connector.stt_connector_api_badge_id_fkey",
+        "public.core_stt_connector.stt_connector_pkey",
+        "public.core_tts_connector.tts_connector_api_badge_id_fkey",
+        "public.core_tts_connector.tts_connector_pkey",
+        "public.core_tts_fallback.core_tts_fallback_gender_check",
+        "public.core_tts_fallback.core_tts_fallback_pkey",
+        "public.core_tts_fallback.core_tts_fallback_race_gender_key",
+        "public.currentmission.currentmission_pidx",
+        "public.database_versioning.database_versioning_pkey",
+        "public.descriptions.descriptions_pkey",
+        "public.descriptions_custom.descriptions_custom_pkey",
+        "public.diarylog.diarylog_pidx",
+        "public.dynamic_bio.dynamic_bio_pkey",
+        "public.eventlog.eventlog_primary",
+        "public.factions.factions_pkey",
+        "public.game_plugins.game_plugins_pkey",
+        "public.general_settings.general_settings_pkey",
+        "public.import_rules.import_rules_pkey",
+        "public.import_rules.import_rules_profile_fkey",
+        "public.json_personalities.json_personalities_pkey",
+        "public.market_cache.market_cache_pk",
+        "public.master_packages.master_packages_pk",
+        "public.memory.memory_pidx",
+        "public.memory_summary.memory_summary_pidx",
+        "public.moods_issued.moods_issued_pkey",
+        "public.named_cell.cell_id_door_id",
+        "public.npc_templates.npc_custom_name_key",
+        "public.npc_templates_custom.npc_name_key",
+        "public.npc_templates_trl.npc_templates_trl_pk",
+        "public.npc_templates_v2.npc_templates_v2_pkey",
+        "public.oghma.oghma_pkey",
+        "public.oghma_dynamic.oghma_dynamic_pkey",
+        "public.physical_npc_diaries.physical_npc_diaries_pkey",
+        "public.prompts.prompts_pkey",
+        "public.quest_asset_group_members.quest_asset_group_members_constraints_is_object",
+        "public.quest_asset_group_members.quest_asset_group_members_pkey",
+        "public.quest_asset_group_members.quest_asset_group_members_source_pack_dataset_name_group_k_fkey",
+        "public.quest_asset_group_members.quest_asset_group_members_source_pack_fkey",
+        "public.quest_asset_group_members.quest_asset_group_members_source_pack_stable_ref_fkey",
+        "public.quest_asset_group_members.quest_asset_group_members_weight",
+        "public.quest_asset_groups.quest_asset_groups_dataset",
+        "public.quest_asset_groups.quest_asset_groups_key_format",
+        "public.quest_asset_groups.quest_asset_groups_pkey",
+        "public.quest_asset_groups.quest_asset_groups_policy_is_object",
+        "public.quest_asset_groups.quest_asset_groups_source_pack_fkey",
+        "public.quest_asset_imports.quest_asset_imports_pkey",
+        "public.quest_asset_packs.quest_asset_packs_pkey",
+        "public.quest_asset_packs.quest_asset_packs_plugins_is_array",
+        "public.quest_assets.quest_assets_metadata_is_object",
+        "public.quest_assets.quest_assets_pkey",
+        "public.quest_assets.quest_assets_safety_status",
+        "public.quest_assets.quest_assets_source_pack_fkey",
+        "public.quest_assets.quest_assets_stable_ref_format",
+        "public.quest_item_types.quest_item_types_formids_json_is_array",
+        "public.quest_item_types.quest_item_types_pk",
+        "public.quest_npc_own_templates.quest_npc_own_templates_formids_json_is_array",
+        "public.quest_npc_own_templates.quest_npc_own_templates_pk",
+        "public.quest_npc_templates.quest_npc_templates_formids_json_is_array",
+        "public.quest_npc_templates.quest_npc_templates_pk",
+        "public.quest_outfits.quest_outfits_formids_json_is_array",
+        "public.quest_outfits.quest_outfits_pk",
+        "public.questlog.questlog_pkey",
+        "public.relationship_eval_queue.relationship_eval_queue_npc_id_key",
+        "public.relationship_eval_queue.relationship_eval_queue_pkey",
+        "public.relationship_init_queue.relationship_init_queue_npc_id_key",
+        "public.relationship_init_queue.relationship_init_queue_pkey",
+        "public.rolemaster.rolemaster_pk",
+        "public.skyrim_quest_action_outbox.skyrim_quest_action_outbox_pkey",
+        "public.skyrim_quest_action_outbox.skyrim_quest_action_outbox_quest_key_fkey",
+        "public.skyrim_quest_beat_state.skyrim_quest_beat_state_pkey",
+        "public.skyrim_quest_beat_state.skyrim_quest_beat_state_quest_key_fkey",
+        "public.skyrim_quest_definitions.skyrim_quest_definitions_pkey",
+        "public.skyrim_quest_events.skyrim_quest_events_pkey",
+        "public.skyrim_quest_events.skyrim_quest_events_quest_key_fkey",
+        "public.skyrim_quest_instances.skyrim_quest_instances_pkey",
+        "public.skyrim_quest_instances.skyrim_quest_instances_quest_key_fkey",
+        "public.sneq_quests.sneq_quests_pkey",
+        "public.sneq_quests_saved.sneq_quests_saved_id",
+        "public.translations.translation_pk",
+        "public.visual_context.visual_context_pkey"
+    ],
+    "indexes": [
+        "public.actions_issued.actions_issued_pkey",
+        "public.audit_request.audit_request_primary",
+        "public.bgl_history.bgl_history_pkey",
+        "public.bio_templates.bio_templates_pkey",
+        "public.bio_templates_custom.bio_templates_custom_pkey",
+        "public.books.books_pidx",
+        "public.conf_opts.pid",
+        "public.core_action.core_action_code_name_key",
+        "public.core_action.core_action_pkey",
+        "public.core_action.idx_core_action_action_name_lower",
+        "public.core_action.idx_core_action_available_to_followers",
+        "public.core_action.idx_core_action_available_to_narrator",
+        "public.core_action.idx_core_action_available_to_npc",
+        "public.core_action.idx_core_action_code_name_lower",
+        "public.core_action.idx_core_action_game_function",
+        "public.core_action.idx_core_action_is_activated",
+        "public.core_action_custom.core_action_custom_code_name_key",
+        "public.core_action_custom.core_action_custom_pkey",
+        "public.core_action_custom.idx_core_action_custom_action_name_lower",
+        "public.core_action_custom.idx_core_action_custom_available_to_followers",
+        "public.core_action_custom.idx_core_action_custom_available_to_narrator",
+        "public.core_action_custom.idx_core_action_custom_available_to_npc",
+        "public.core_action_custom.idx_core_action_custom_code_name_lower",
+        "public.core_action_custom.idx_core_action_custom_game_function",
+        "public.core_action_custom.idx_core_action_custom_is_activated",
+        "public.core_api_badge.core_api_badge_label_unique",
+        "public.core_api_badge.idx_core_api_badge_label_lower",
+        "public.core_api_badge.my_table_pkey",
+        "public.core_itt_connector.itt_connector_pkey",
+        "public.core_llm_connector.llm_connector_pkey",
+        "public.core_narrator.core_narrator_pkey",
+        "public.core_npc_master.npc_master_npc_name_key",
+        "public.core_npc_master.npc_master_pkey",
+        "public.core_npc_master_history.core_npc_master_history_pkey",
+        "public.core_player.core_player_pkey",
+        "public.core_profiles.core_profiles_slot_unique_idx",
+        "public.core_profiles.profiles_pkey",
+        "public.core_stt_connector.stt_connector_pkey",
+        "public.core_tts_connector.tts_connector_pkey",
+        "public.core_tts_fallback.core_tts_fallback_pkey",
+        "public.core_tts_fallback.core_tts_fallback_race_gender_key",
+        "public.currentmission.currentmission_pidx",
+        "public.database_versioning.database_versioning_pkey",
+        "public.descriptions.descriptions_pkey",
+        "public.descriptions_custom.descriptions_custom_pkey",
+        "public.diarylog.diarylog_pidx",
+        "public.diarylog.idx_diarylog_people_gamets",
+        "public.dynamic_bio.dynamic_bio_pkey",
+        "public.eventlog.event_log_type",
+        "public.eventlog.eventlog_primary",
+        "public.eventlog.idx_eventlog_delivery_state",
+        "public.eventlog.idx_eventlog_gamets_pos",
+        "public.eventlog.idx_eventlog_gamets_ts_pos",
+        "public.eventlog.idx_eventlog_people_trgm",
+        "public.eventlog.idx_eventlog_people_trgm2",
+        "public.eventlog.idx_eventlog_utterance_id",
+        "public.factions.factions_pkey",
+        "public.game_plugins.game_plugins_pkey",
+        "public.general_settings.general_settings_pkey",
+        "public.import_rules.import_rules_pkey",
+        "public.json_personalities.json_personalities_pkey",
+        "public.market_cache.market_cache_pk",
+        "public.master_packages.master_packages_mod_formid_idx",
+        "public.master_packages.master_packages_pk",
+        "public.memory.memory_pidx",
+        "public.memory_summary.memory_summary_pidx",
+        "public.moods_issued.moods_issued_pkey",
+        "public.named_cell.cell_id_door_id",
+        "public.npc_templates.npc_custom_name_key",
+        "public.npc_templates_custom.npc_name_key",
+        "public.npc_templates_trl.npc_templates_trl_pk",
+        "public.npc_templates_v2.npc_templates_v2_pkey",
+        "public.oghma.oghma_native_vector_idx",
+        "public.oghma.oghma_pkey",
+        "public.oghma_dynamic.oghma_dynamic_pkey",
+        "public.physical_npc_diaries.physical_npc_diaries_pkey",
+        "public.physical_npc_diaries.physical_npc_diaries_updated_idx",
+        "public.prompts.idx_prompts_prompt_key_unique",
+        "public.prompts.prompts_pkey",
+        "public.quest_asset_group_members.quest_asset_group_members_pkey",
+        "public.quest_asset_group_members.quest_asset_members_group_idx",
+        "public.quest_asset_group_members.quest_asset_members_pack_idx",
+        "public.quest_asset_groups.quest_asset_groups_pack_idx",
+        "public.quest_asset_groups.quest_asset_groups_pkey",
+        "public.quest_asset_imports.quest_asset_imports_pkey",
+        "public.quest_asset_packs.quest_asset_packs_pkey",
+        "public.quest_assets.quest_assets_pkey",
+        "public.quest_assets.quest_assets_safety_idx",
+        "public.quest_assets.quest_assets_signature_idx",
+        "public.quest_assets.quest_assets_source_pack_idx",
+        "public.quest_item_types.idx_quest_item_types_active",
+        "public.quest_item_types.quest_item_types_pk",
+        "public.quest_npc_own_templates.idx_quest_npc_own_templates_active",
+        "public.quest_npc_own_templates.quest_npc_own_templates_pk",
+        "public.quest_npc_templates.idx_quest_npc_templates_active",
+        "public.quest_npc_templates.quest_npc_templates_pk",
+        "public.quest_outfits.idx_quest_outfits_active",
+        "public.quest_outfits.quest_outfits_pk",
+        "public.questlog.questlog_pkey",
+        "public.relationship_eval_queue.relationship_eval_queue_npc_id_key",
+        "public.relationship_eval_queue.relationship_eval_queue_pkey",
+        "public.relationship_init_queue.relationship_init_queue_npc_id_key",
+        "public.relationship_init_queue.relationship_init_queue_pkey",
+        "public.rolemaster.rolemaster_pk",
+        "public.skyrim_quest_action_outbox.idx_skyrim_quest_action_outbox_gamets",
+        "public.skyrim_quest_action_outbox.idx_skyrim_quest_action_outbox_status_created",
+        "public.skyrim_quest_action_outbox.skyrim_quest_action_outbox_pkey",
+        "public.skyrim_quest_beat_state.skyrim_quest_beat_state_pkey",
+        "public.skyrim_quest_definitions.idx_skyrim_quest_definitions_editor_id",
+        "public.skyrim_quest_definitions.skyrim_quest_definitions_pkey",
+        "public.skyrim_quest_events.idx_skyrim_quest_events_gamets",
+        "public.skyrim_quest_events.idx_skyrim_quest_events_quest_created",
+        "public.skyrim_quest_events.idx_skyrim_quest_events_type_created",
+        "public.skyrim_quest_events.skyrim_quest_events_pkey",
+        "public.skyrim_quest_instances.idx_skyrim_quest_instances_run_state",
+        "public.skyrim_quest_instances.skyrim_quest_instances_pkey",
+        "public.sneq_quests.sneq_quests_pkey",
+        "public.sneq_quests_saved.sneq_quests_saved_id",
+        "public.speech.idx_speech_gamets_pos",
+        "public.speech.idx_speech_listener_trgm",
+        "public.speech.idx_speech_speaker_trgm",
+        "public.speech.idx_speech_utterance_id",
+        "public.translations.search_idx",
+        "public.translations.translation_pk",
+        "public.visual_context.visual_context_image_idx",
+        "public.visual_context.visual_context_location_idx",
+        "public.visual_context.visual_context_pkey",
+        "public.visual_context.visual_context_subject_idx"
+    ]
+}

--- a/debug/apply_db_updates.php
+++ b/debug/apply_db_updates.php
@@ -61,4 +61,17 @@ require_once($rootEnginePath . "lib" .DIRECTORY_SEPARATOR."{$GLOBALS["DBDRIVER"]
 require_once($rootEnginePath . "lib" .DIRECTORY_SEPARATOR."chat_helper_functions.php");
 $db = new sql();
 require_once(__DIR__."/db_updates.php");
+
+require_once($rootEnginePath . "lib" . DIRECTORY_SEPARATOR . "database" . DIRECTORY_SEPARATOR . "MigrationRunner.php");
+$commit = getenv('HERIKA_APPLICATION_COMMIT') ?: null;
+$migrationRunner = \HerikaServer\Database\MigrationRunner::connect($rootEnginePath, null, $commit);
+$migrationRunner->repairLegacyBaseline();
+$appliedMigrations = $migrationRunner->migrate();
+$migrationProblems = $migrationRunner->verify();
+if ($migrationProblems !== []) {
+    throw new RuntimeException("Database verification failed:\n- " . implode("\n- ", $migrationProblems));
+}
+echo $appliedMigrations === []
+    ? "Schema migrations already current.\n"
+    : "Applied schema migrations: " . implode(', ', $appliedMigrations) . "\n";
 ?>

--- a/debug/db_updates.php
+++ b/debug/db_updates.php
@@ -1,5 +1,8 @@
 <?php 
 
+// Frozen legacy compatibility bridge. New schema changes belong in database/migrations.
+// This file may only be invoked by explicit install, test, or operator migration flows.
+
 require_once(dirname(__DIR__).DIRECTORY_SEPARATOR."lib/logger.php");
 require_once(dirname(__DIR__).DIRECTORY_SEPARATOR."lib/settings.php");
 require_once(dirname(__DIR__).DIRECTORY_SEPARATOR."lib/oghma_aliases.php");
@@ -7865,24 +7868,19 @@ if ($checkVersion("default_npc_tags") < 20260805003) {
 if ($checkVersion("eventlog_session_payload") < 20260807001) {
     Logger::debug("Applying eventlog_session_payload 20260807001 - allow complete routing snapshots");
 
-    $migrationOk = $db->execQuery(
-        "ALTER TABLE public.eventlog ALTER COLUMN sess TYPE text"
-    ) !== false;
+    $sessionColumn = $db->fetchOne(
+        "SELECT udt_name FROM information_schema.columns
+         WHERE table_schema='public' AND table_name='eventlog' AND column_name='sess'"
+    );
+    $migrationOk = strval($sessionColumn['udt_name'] ?? '') === 'text';
 
     if ($migrationOk) {
         $updateVersion("eventlog_session_payload", 20260807001);
         Logger::info("Applied patch eventlog_session_payload 20260807001");
     } else {
-        Logger::error("Failed to apply patch eventlog_session_payload 20260807001");
+        Logger::warn("Deferred eventlog_session_payload 20260807001 to the transactional legacy baseline repair");
     }
 }
-
-//----------------------------------------------------
-// AUDIT REQUEST RESPONSE - Store the response text for audit requests
-// Version 20260806001
-//----------------------------------------------------
-$db->execQuery("ALTER TABLE public.audit_request ADD COLUMN IF NOT EXISTS \"response\"  text");
-
 
 Logger::info(__FILE__." update file processed");
 

--- a/lib/database/MigrationRunner.php
+++ b/lib/database/MigrationRunner.php
@@ -1,0 +1,557 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HerikaServer\Database;
+
+use RuntimeException;
+use Throwable;
+
+final class MigrationRunner
+{
+    public const BASELINE_VERSION = 202608110000;
+    public const LEDGER = 'chim_meta.schema_migrations';
+
+    private const LOCK_ID = 4_843_749_526_024_081;
+
+    /** @var resource|\PgSql\Connection */
+    private $connection;
+    private string $root;
+    private ?string $applicationCommit;
+    private bool $ownsConnection;
+
+    /**
+     * The runner owns migration ordering, locking, transactions, and ledger writes.
+     *
+     * @param resource|\PgSql\Connection $connection
+     */
+    public function __construct($connection, string $root, ?string $applicationCommit = null, bool $ownsConnection = false)
+    {
+        if (!$connection) {
+            throw new RuntimeException('A PostgreSQL connection is required.');
+        }
+
+        $this->connection = $connection;
+        $this->root = rtrim($root, DIRECTORY_SEPARATOR);
+        $this->applicationCommit = $applicationCommit;
+        $this->ownsConnection = $ownsConnection;
+    }
+
+    public static function connect(string $root, ?string $dsn = null, ?string $applicationCommit = null): self
+    {
+        if (!function_exists('pg_connect')) {
+            throw new RuntimeException('The PostgreSQL PHP extension is required.');
+        }
+
+        $dsn = $dsn ?: (getenv('HERIKA_DATABASE_DSN') ?: 'host=localhost port=5432 dbname=dwemer user=dwemer password=dwemer connect_timeout=15');
+        $connection = @pg_connect($dsn, PGSQL_CONNECT_FORCE_NEW);
+        if (!$connection) {
+            throw new RuntimeException('Could not connect to PostgreSQL for database migrations.');
+        }
+
+        return new self($connection, $root, $applicationCommit, true);
+    }
+
+    public function __destruct()
+    {
+        if ($this->ownsConnection && $this->connection) {
+            try {
+                @pg_close($this->connection);
+            } catch (Throwable) {
+                // Destructors must not mask the command or request result.
+            }
+        }
+    }
+
+    public static function latestVersion(string $root): int
+    {
+        return max(array_keys(self::sourceManifest($root)));
+    }
+
+    /** @return array<int,array{version:int,name:string,type:string,path:string,checksum:string}> */
+    public static function sourceManifest(string $root): array
+    {
+        $root = rtrim($root, DIRECTORY_SEPARATOR);
+        $contractPath = $root . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'baseline'
+            . DIRECTORY_SEPARATOR . self::BASELINE_VERSION . '_contract.json';
+        $contract = @file_get_contents($contractPath);
+        if ($contract === false || trim($contract) === '') {
+            throw new RuntimeException("Baseline contract is missing or empty: {$contractPath}");
+        }
+
+        $migrations = [
+            self::BASELINE_VERSION => [
+                'version' => self::BASELINE_VERSION,
+                'name' => 'legacy_baseline',
+                'type' => 'baseline',
+                'path' => $contractPath,
+                'checksum' => hash('sha256', $contract),
+            ],
+        ];
+        $directory = rtrim($root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'migrations';
+        $paths = glob($directory . DIRECTORY_SEPARATOR . '*.{sql,php}', GLOB_BRACE) ?: [];
+        sort($paths, SORT_STRING);
+        foreach ($paths as $path) {
+            $filename = basename($path);
+            if (preg_match('/^(\d{12})_([a-z0-9_]+)\.(sql|php)$/D', $filename, $match) !== 1) {
+                throw new RuntimeException("Invalid migration filename: {$filename}");
+            }
+            $version = (int) $match[1];
+            if ($version <= self::BASELINE_VERSION) {
+                throw new RuntimeException("Migration {$filename} must be newer than the legacy baseline.");
+            }
+            if (isset($migrations[$version])) {
+                throw new RuntimeException("Duplicate migration version: {$version}");
+            }
+            $contents = @file_get_contents($path);
+            if ($contents === false || trim($contents) === '') {
+                throw new RuntimeException("Migration is missing or empty: {$filename}");
+            }
+            if ($match[3] === 'sql' && self::containsTransactionControl($contents)) {
+                throw new RuntimeException("Migration {$filename} controls transactions; the runner must own the transaction.");
+            }
+            $migrations[$version] = [
+                'version' => $version,
+                'name' => $match[2],
+                'type' => $match[3],
+                'path' => $path,
+                'checksum' => hash('sha256', $contents),
+            ];
+        }
+        ksort($migrations, SORT_NUMERIC);
+        return $migrations;
+    }
+
+    /** @return array{ready:bool,ledger_exists:bool,baseline_problems:list<string>,schema_problems:list<string>,applied:list<array<string,mixed>>,pending:list<array<string,mixed>>} */
+    public function status(): array
+    {
+        $migrations = $this->discover();
+        $ledgerExists = $this->ledgerExists();
+        $applied = $ledgerExists ? $this->applied() : [];
+        $baselineProblems = isset($applied[self::BASELINE_VERSION]) ? [] : $this->validateBaseline();
+
+        if ($ledgerExists) {
+            $this->assertNoDrift($migrations, $applied);
+        }
+
+        $pending = [];
+        foreach ($migrations as $version => $migration) {
+            if (!isset($applied[$version])) {
+                $pending[] = $migration;
+            }
+        }
+        $schemaProblems = $baselineProblems === [] && $pending === []
+            ? $this->validateContract($this->schemaContractPath(), false)
+            : [];
+
+        return [
+            'ready' => $baselineProblems === [] && $pending === [] && $schemaProblems === [],
+            'ledger_exists' => $ledgerExists,
+            'baseline_problems' => $baselineProblems,
+            'schema_problems' => $schemaProblems,
+            'applied' => array_values($applied),
+            'pending' => $pending,
+        ];
+    }
+
+    /** @return list<int> */
+    public function migrate(): array
+    {
+        return $this->locked(function (): array {
+            $migrations = $this->discover();
+            $ledgerExists = $this->ledgerExists();
+            $applied = $ledgerExists ? $this->applied() : [];
+
+            if (!isset($applied[self::BASELINE_VERSION])) {
+                $problems = $this->validateBaseline();
+                if ($problems !== []) {
+                    throw new RuntimeException(
+                        "Legacy baseline reconciliation failed:\n- " . implode("\n- ", $problems)
+                        . "\nNo schema migration was recorded. Run the explicit legacy bridge on a backup or repair the reported schema differences."
+                    );
+                }
+                $this->ensureLedger();
+                $this->recordBaseline($migrations[self::BASELINE_VERSION]);
+                $applied = $this->applied();
+            }
+
+            $this->assertNoDrift($migrations, $applied);
+            $ran = [];
+            foreach ($migrations as $version => $migration) {
+                if (isset($applied[$version])) {
+                    continue;
+                }
+                $this->apply($migration);
+                $ran[] = $version;
+            }
+
+            $schemaProblems = $this->validateContract($this->schemaContractPath(), false);
+            if ($schemaProblems !== []) {
+                throw new RuntimeException("Post-migration schema verification failed:\n- " . implode("\n- ", $schemaProblems));
+            }
+
+            return $ran;
+        });
+    }
+
+    public function repairLegacyBaseline(): void
+    {
+        $this->locked(function (): void {
+            if ($this->ledgerExists() && isset($this->applied()[self::BASELINE_VERSION])) {
+                return;
+            }
+
+            $path = $this->root . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'legacy-baseline-repair.sql';
+            $sql = @file_get_contents($path);
+            if ($sql === false || trim($sql) === '') {
+                throw new RuntimeException("Legacy baseline repair is missing or empty: {$path}");
+            }
+            if (self::containsTransactionControl($sql)) {
+                throw new RuntimeException('Legacy baseline repair controls transactions; the runner must own the transaction.');
+            }
+
+            $this->transaction(function () use ($sql): void {
+                $this->execute($sql);
+                $problems = $this->validateBaseline();
+                if ($problems !== []) {
+                    throw new RuntimeException("Legacy baseline remains incompatible after repair:\n- " . implode("\n- ", $problems));
+                }
+            });
+        });
+    }
+
+    /** @return list<string> */
+    public function verify(): array
+    {
+        $status = $this->status();
+        $problems = array_merge($status['baseline_problems'], $status['schema_problems']);
+        foreach ($status['pending'] as $migration) {
+            $problems[] = "Pending migration {$migration['version']} {$migration['name']}";
+        }
+        return $problems;
+    }
+
+    /** @return array<int,array{version:int,name:string,type:string,path:string,checksum:string,applied_at?:string,execution_time_ms?:string,application_commit?:?string}> */
+    private function discover(): array
+    {
+        return self::sourceManifest($this->root);
+    }
+
+    private static function containsTransactionControl(string $sql): bool
+    {
+        $withoutDollarBodies = preg_replace('/\$([A-Za-z_][A-Za-z0-9_]*)\$.*?\$\1\$/s', '', $sql);
+        if ($withoutDollarBodies !== null) {
+            $withoutDollarBodies = preg_replace('/\$\$.*?\$\$/s', '', $withoutDollarBodies);
+        }
+        if ($withoutDollarBodies === null) {
+            throw new RuntimeException('Could not inspect migration transaction control.');
+        }
+        return preg_match('/(^|;)\s*(BEGIN|START\s+TRANSACTION|COMMIT|ROLLBACK)\b/i', $withoutDollarBodies) === 1;
+    }
+
+    private function contractPath(): string
+    {
+        return $this->root . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'baseline'
+            . DIRECTORY_SEPARATOR . self::BASELINE_VERSION . '_contract.json';
+    }
+
+    private function schemaContractPath(): string
+    {
+        return $this->root . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'schema-contract.json';
+    }
+
+    /** @return list<string> */
+    private function validateBaseline(): array
+    {
+        return $this->validateContract($this->contractPath(), true);
+    }
+
+    /** @return list<string> */
+    private function validateContract(string $path, bool $requireBaselineVersion): array
+    {
+        $raw = @file_get_contents($path);
+        $contract = $raw === false ? null : json_decode($raw, true);
+        if (!is_array($contract)) {
+            throw new RuntimeException("Schema contract is invalid: {$path}");
+        }
+        if ($requireBaselineVersion && (int) ($contract['baseline_version'] ?? 0) !== self::BASELINE_VERSION) {
+            throw new RuntimeException("Baseline contract version is invalid: {$path}");
+        }
+        if (!$requireBaselineVersion && (int) ($contract['schema_version'] ?? 0) !== self::latestVersion($this->root)) {
+            throw new RuntimeException("Current schema contract version does not match the latest migration: {$path}");
+        }
+
+        $problems = [];
+        $extensions = $this->columnValues('SELECT extname FROM pg_extension', 'extname');
+        foreach (($contract['extensions'] ?? []) as $extension) {
+            if (!isset($extensions[$extension])) {
+                $problems[] = "Missing extension {$extension}";
+            }
+        }
+
+        $relations = $this->rows(
+            "SELECT table_schema, table_name, table_type FROM information_schema.tables "
+            . "WHERE table_schema IN ('public','chim_meta')"
+        );
+        $relationMap = [];
+        foreach ($relations as $row) {
+            $relationMap[$row['table_schema'] . '.' . $row['table_name']] = $row['table_type'];
+        }
+
+        $columns = $this->rows(
+            "SELECT table_schema, table_name, column_name, udt_schema, udt_name, is_nullable "
+            . "FROM information_schema.columns WHERE table_schema IN ('public','chim_meta')"
+        );
+        $columnMap = [];
+        foreach ($columns as $row) {
+            $columnMap[$row['table_schema'] . '.' . $row['table_name']][$row['column_name']] = [
+                'udt_schema' => $row['udt_schema'],
+                'udt_name' => $row['udt_name'],
+                'nullable' => $row['is_nullable'] === 'YES',
+            ];
+        }
+
+        foreach (($contract['tables'] ?? []) as $relation => $definition) {
+            if (($relationMap[$relation] ?? null) !== 'BASE TABLE') {
+                $problems[] = "Missing table {$relation}";
+                continue;
+            }
+            foreach (($definition['columns'] ?? []) as $column => $expected) {
+                $actual = $columnMap[$relation][$column] ?? null;
+                if ($actual === null) {
+                    $problems[] = "Missing column {$relation}.{$column}";
+                    continue;
+                }
+                foreach (['udt_schema', 'udt_name', 'nullable'] as $property) {
+                    if (($actual[$property] ?? null) !== ($expected[$property] ?? null)) {
+                        $actualValue = is_bool($actual[$property] ?? null) ? (($actual[$property] ?? false) ? 'true' : 'false') : strval($actual[$property] ?? 'null');
+                        $expectedValue = is_bool($expected[$property] ?? null) ? (($expected[$property] ?? false) ? 'true' : 'false') : strval($expected[$property] ?? 'null');
+                        $problems[] = "Column {$relation}.{$column} {$property} is {$actualValue}; expected {$expectedValue}";
+                    }
+                }
+            }
+        }
+
+        $viewDefinitions = [];
+        foreach ($this->rows("SELECT schemaname, viewname, definition FROM pg_views WHERE schemaname IN ('public','chim_meta')") as $row) {
+            $viewDefinitions[$row['schemaname'] . '.' . $row['viewname']] = trim($row['definition']);
+        }
+        foreach (($contract['views'] ?? []) as $view => $expectedDefinition) {
+            if (($relationMap[$view] ?? null) !== 'VIEW') {
+                $problems[] = "Missing view {$view}";
+            } elseif (($viewDefinitions[$view] ?? null) !== trim(strval($expectedDefinition))) {
+                $problems[] = "View definition drift detected for {$view}";
+            }
+        }
+
+        $constraintRows = $this->rows(
+            "SELECT n.nspname AS schema_name, c.relname AS table_name, con.conname "
+            . "FROM pg_constraint con JOIN pg_class c ON c.oid=con.conrelid JOIN pg_namespace n ON n.oid=c.relnamespace "
+            . "WHERE n.nspname IN ('public','chim_meta')"
+        );
+        $constraints = [];
+        foreach ($constraintRows as $row) {
+            $constraints[$row['schema_name'] . '.' . $row['table_name'] . '.' . $row['conname']] = true;
+        }
+        foreach (($contract['constraints'] ?? []) as $constraint) {
+            if (!isset($constraints[$constraint])) {
+                $problems[] = "Missing constraint {$constraint}";
+            }
+        }
+
+        $indexRows = $this->rows("SELECT schemaname, tablename, indexname FROM pg_indexes WHERE schemaname IN ('public','chim_meta')");
+        $indexes = [];
+        foreach ($indexRows as $row) {
+            $indexes[$row['schemaname'] . '.' . $row['tablename'] . '.' . $row['indexname']] = true;
+        }
+        foreach (($contract['indexes'] ?? []) as $index) {
+            if (!isset($indexes[$index])) {
+                $problems[] = "Missing index {$index}";
+            }
+        }
+
+        return $problems;
+    }
+
+    private function ledgerExists(): bool
+    {
+        $result = $this->value("SELECT to_regclass('" . self::LEDGER . "')");
+        return $result === self::LEDGER;
+    }
+
+    private function ensureLedger(): void
+    {
+        $this->execute('CREATE SCHEMA IF NOT EXISTS chim_meta');
+        $this->execute(
+            'CREATE TABLE IF NOT EXISTS ' . self::LEDGER . ' ('
+            . 'version bigint PRIMARY KEY, '
+            . 'name text NOT NULL, '
+            . 'checksum char(64) NOT NULL, '
+            . 'applied_at timestamptz NOT NULL DEFAULT clock_timestamp(), '
+            . 'execution_time_ms numeric(14,3) NOT NULL, '
+            . 'application_commit text)'
+        );
+    }
+
+    /** @return array<int,array{version:int,name:string,type:string,path:string,checksum:string,applied_at:string,execution_time_ms:string,application_commit:?string}> */
+    private function applied(): array
+    {
+        $rows = $this->rows(
+            'SELECT version, name, checksum, applied_at, execution_time_ms, application_commit '
+            . 'FROM ' . self::LEDGER . ' ORDER BY version'
+        );
+        $applied = [];
+        foreach ($rows as $row) {
+            $version = (int) $row['version'];
+            $applied[$version] = [
+                'version' => $version,
+                'name' => $row['name'],
+                'type' => $version === self::BASELINE_VERSION ? 'baseline' : 'applied',
+                'path' => '',
+                'checksum' => rtrim($row['checksum']),
+                'applied_at' => $row['applied_at'],
+                'execution_time_ms' => $row['execution_time_ms'],
+                'application_commit' => $row['application_commit'],
+            ];
+        }
+        return $applied;
+    }
+
+    private function assertNoDrift(array $migrations, array $applied): void
+    {
+        $encounteredPending = false;
+        foreach ($migrations as $version => $migration) {
+            if (!isset($applied[$version])) {
+                $encounteredPending = true;
+                continue;
+            }
+            if ($encounteredPending) {
+                throw new RuntimeException("Applied migration history has a gap before {$version}.");
+            }
+            if ($applied[$version]['name'] !== $migration['name']) {
+                throw new RuntimeException("Migration name drift detected at {$version}.");
+            }
+            if (!hash_equals($migration['checksum'], $applied[$version]['checksum'])) {
+                throw new RuntimeException("Migration checksum drift detected at {$version}.");
+            }
+        }
+        foreach ($applied as $version => $migration) {
+            if (!isset($migrations[$version])) {
+                throw new RuntimeException("Applied migration {$version} is absent from source control.");
+            }
+        }
+    }
+
+    private function recordBaseline(array $baseline): void
+    {
+        $this->transaction(function () use ($baseline): void {
+            $this->insertLedger($baseline, 0.0);
+        });
+    }
+
+    private function apply(array $migration): void
+    {
+        $started = microtime(true);
+        $this->transaction(function () use ($migration, $started): void {
+            if ($migration['type'] === 'sql') {
+                $sql = file_get_contents($migration['path']);
+                if ($sql === false) {
+                    throw new RuntimeException("Could not read migration {$migration['version']}.");
+                }
+                $this->execute($sql);
+            } elseif ($migration['type'] === 'php') {
+                $callable = require $migration['path'];
+                if (!is_callable($callable)) {
+                    throw new RuntimeException("PHP migration {$migration['version']} must return a callable.");
+                }
+                $callable($this->connection);
+            } else {
+                throw new RuntimeException("Unsupported migration type {$migration['type']}.");
+            }
+            $this->insertLedger($migration, (microtime(true) - $started) * 1000);
+        });
+    }
+
+    private function insertLedger(array $migration, float $executionTimeMs): void
+    {
+        $statement = @pg_query_params(
+            $this->connection,
+            'INSERT INTO ' . self::LEDGER . ' (version, name, checksum, execution_time_ms, application_commit) VALUES ($1,$2,$3,$4,$5)',
+            [
+                (string) $migration['version'],
+                $migration['name'],
+                $migration['checksum'],
+                number_format($executionTimeMs, 3, '.', ''),
+                $this->applicationCommit,
+            ]
+        );
+        if (!$statement) {
+            throw new RuntimeException('Could not record migration: ' . pg_last_error($this->connection));
+        }
+    }
+
+    private function transaction(callable $callback): void
+    {
+        $this->execute('BEGIN');
+        try {
+            $this->execute('SET LOCAL search_path TO public, pg_temp');
+            $callback();
+            $this->execute('COMMIT');
+        } catch (Throwable $error) {
+            @pg_query($this->connection, 'ROLLBACK');
+            throw $error;
+        }
+    }
+
+    private function locked(callable $callback): mixed
+    {
+        $result = @pg_query_params($this->connection, 'SELECT pg_advisory_lock($1)', [(string) self::LOCK_ID]);
+        if (!$result) {
+            throw new RuntimeException('Could not acquire migration lock: ' . pg_last_error($this->connection));
+        }
+        try {
+            return $callback();
+        } finally {
+            @pg_query_params($this->connection, 'SELECT pg_advisory_unlock($1)', [(string) self::LOCK_ID]);
+        }
+    }
+
+    private function execute(string $sql): void
+    {
+        if (!@pg_query($this->connection, $sql)) {
+            throw new RuntimeException(pg_last_error($this->connection));
+        }
+    }
+
+    /** @return list<array<string,string|null>> */
+    private function rows(string $sql): array
+    {
+        $result = @pg_query($this->connection, $sql);
+        if (!$result) {
+            throw new RuntimeException(pg_last_error($this->connection));
+        }
+        return pg_fetch_all($result) ?: [];
+    }
+
+    private function value(string $sql): ?string
+    {
+        $result = @pg_query($this->connection, $sql);
+        if (!$result) {
+            throw new RuntimeException(pg_last_error($this->connection));
+        }
+        $value = pg_fetch_result($result, 0, 0);
+        return $value === false || $value === null ? null : (string) $value;
+    }
+
+    /** @return array<string,true> */
+    private function columnValues(string $sql, string $column): array
+    {
+        $values = [];
+        foreach ($this->rows($sql) as $row) {
+            if (isset($row[$column])) {
+                $values[$row[$column]] = true;
+            }
+        }
+        return $values;
+    }
+}

--- a/lib/phpunit.class.php
+++ b/lib/phpunit.class.php
@@ -2,13 +2,13 @@
 
 class sql
 {
-    private static $link = null;
+    private $link = null;
 
     public function __construct()
     {
-        $connString = "host=localhost dbname=testdb user=dwemer password=dwemer";
-        self::$link = pg_connect($connString);
-        if (!self::$link) {
+        $connString = getenv('HERIKA_TEST_DATABASE_DSN') ?: "host=localhost dbname=testdb user=dwemer password=dwemer";
+        $this->link = pg_connect($connString, PGSQL_CONNECT_FORCE_NEW);
+        if (!$this->link) {
             die("Error in connection: " . pg_last_error());
         }
     }
@@ -20,9 +20,9 @@ class sql
 
     public function close()
     {
-        if (self::$link) {
-            pg_close(self::$link);
-            self::$link = null;
+        if ($this->link) {
+            pg_close($this->link);
+            $this->link = null;
         }
     }
 
@@ -39,42 +39,43 @@ class sql
         //error_log($query);
         $params = array_values($data);
         //error_log(print_r($params,true));
-        $result = pg_query_params(self::$link, $query, $params);
+        $result = pg_query_params($this->link, $query, $params);
         if (!$result) {
-            Logger::error(pg_last_error(self::$link) . print_r(debug_backtrace(), true));
+            Logger::error(pg_last_error($this->link) . print_r(debug_backtrace(), true));
         }
     }
 
     public function query($query)
     {
-        return pg_query(self::$link, $query);
+        return pg_query($this->link, $query);
     }
 
     public function delete($table, $where = "FALSE")
     {
         $query = "DELETE FROM $table WHERE $where";
-        pg_query(self::$link, $query);
+        pg_query($this->link, $query);
     }
 
     public function update($table, $set, $where = "FALSE")
     {
         $query = "UPDATE $table SET $set WHERE $where";
-        pg_query(self::$link, $query);
+        pg_query($this->link, $query);
     }
 
     public function execQuery($sqlquery)
     {
-        $result = pg_query(self::$link, $sqlquery);
+        $result = pg_query($this->link, $sqlquery);
         if (!$result) {
-            Logger::error(pg_last_error(self::$link) . print_r(debug_backtrace(), true));
+            Logger::error(pg_last_error($this->link) . print_r(debug_backtrace(), true));
         }
+        return $result;
     }
 
     public function fetchAll($q)
     {
-        $result = pg_query(self::$link, $q);
+        $result = pg_query($this->link, $q);
         if (!$result) {
-            Logger::error(pg_last_error(self::$link));
+            Logger::error(pg_last_error($this->link));
             return [];
         }
 
@@ -89,9 +90,9 @@ class sql
     
     public function fetchOne($q)
     {
-        $result = pg_query(self::$link, $q);
+        $result = pg_query($this->link, $q);
         if (!$result) {
-            Logger::error(pg_last_error(self::$link));
+            Logger::error(pg_last_error($this->link));
             return [];
         }
 
@@ -113,7 +114,15 @@ class sql
     public function escape($string)
     {
         if ($string)
-            return pg_escape_string(self::$link,$string);
+            return pg_escape_string($this->link,$string);
+        else
+            return "";
+    }
+
+    public function escapeLiteral($string)
+    {
+        if ($string !== null)
+            return pg_escape_literal($this->link, strval($string));
         else
             return "";
     }
@@ -133,9 +142,9 @@ class sql
 
         $query = "UPDATE $table SET $set WHERE $where";
         
-        $result = pg_query_params(self::$link, $query, $params);
+        $result = pg_query_params($this->link, $query, $params);
         if (!$result) {
-            Logger::error(pg_last_error(self::$link) . print_r(debug_backtrace(), true));
+            Logger::error(pg_last_error($this->link) . print_r(debug_backtrace(), true));
         }
         return $result !== false;
     }
@@ -143,10 +152,10 @@ class sql
     public function upsertRow($table, $data, $where) {
         // Check if the row exists
         $checkQuery = "SELECT 1 FROM $table WHERE $where LIMIT 1";
-        $checkResult = pg_query(self::$link, $checkQuery);
+        $checkResult = pg_query($this->link, $checkQuery);
 
         if (!$checkResult) {
-            Logger::error(pg_last_error(self::$link) . print_r(debug_backtrace(), true));
+            Logger::error(pg_last_error($this->link) . print_r(debug_backtrace(), true));
             return false;
         }
 
@@ -182,9 +191,9 @@ class sql
         }
 
         // Execute the query
-        $result = pg_query_params(self::$link, $query, $params);
+        $result = pg_query_params($this->link, $query, $params);
         if (!$result) {
-            Logger::error(pg_last_error(self::$link) . print_r(debug_backtrace(), true));
+            Logger::error(pg_last_error($this->link) . print_r(debug_backtrace(), true));
             return false;
         }
 
@@ -193,7 +202,7 @@ class sql
 
     public function upsertRowTrx($table, $data, $whereCondition) {
         // Start a transaction
-        pg_query(self::$link, "BEGIN");
+        pg_query($this->link, "BEGIN");
     
         try {
             // Extract WHERE condition keys and values
@@ -211,10 +220,10 @@ class sql
     
             // Check if the row exists and lock it
             $checkQuery = "SELECT 1 FROM $table WHERE $whereSql FOR UPDATE";
-            $checkResult = pg_query_params(self::$link, $checkQuery, $whereParams);
+            $checkResult = pg_query_params($this->link, $checkQuery, $whereParams);
     
             if (!$checkResult) {
-                throw new Exception(pg_last_error(self::$link));
+                throw new Exception(pg_last_error($this->link));
             }
     
             if (pg_num_rows($checkResult) > 0) {
@@ -257,18 +266,18 @@ class sql
             // error_log($query . " " . print_r($params, true));
     
             // Execute the query
-            $result = pg_query_params(self::$link, $query, $params);
+            $result = pg_query_params($this->link, $query, $params);
             if (!$result) {
-                throw new Exception(pg_last_error(self::$link));
+                throw new Exception(pg_last_error($this->link));
             }
     
             // Commit transaction
-            pg_query(self::$link, "COMMIT");
+            pg_query($this->link, "COMMIT");
     
             return true;
         } catch (Exception $e) {
             // Rollback on error
-            pg_query(self::$link, "ROLLBACK");
+            pg_query($this->link, "ROLLBACK");
             Logger::error($e->getMessage() . print_r(debug_backtrace(), true));
             return false;
         }
@@ -281,7 +290,7 @@ class sql
     
         // Take care of escaping here instead of requiring it before every upsert call
         $values = array_map(function($value) {
-            return pg_escape_literal(self::$link, $value);
+            return pg_escape_literal($this->link, $value);
         }, array_values($data));
         $valuesString = implode(', ', $values);
     
@@ -298,10 +307,10 @@ class sql
         $sqlquery = "INSERT INTO $tableName ($columns) VALUES ($valuesString) " .
                     "ON CONFLICT ($conflictTarget) DO UPDATE SET $updateString;";
     
-        $result = pg_query(self::$link, $sqlquery);
+        $result = pg_query($this->link, $sqlquery);
     
         if (!$result) {
-            Logger::error(pg_last_error(self::$link) . print_r(debug_backtrace(), true));
+            Logger::error(pg_last_error($this->link) . print_r(debug_backtrace(), true));
             return false; // Indicate failure
         }
     

--- a/lib/runtime_bootstrap.php
+++ b/lib/runtime_bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(__DIR__ . DIRECTORY_SEPARATOR . "settings.php");
+require_once(__DIR__ . DIRECTORY_SEPARATOR . "database" . DIRECTORY_SEPARATOR . "MigrationRunner.php");
 
 if (!function_exists('chimRuntimeNeedsDbUpdates')) {
     function chimRuntimeNeedsDbUpdates(): bool
@@ -12,76 +13,51 @@ if (!function_exists('chimRuntimeNeedsDbUpdates')) {
 
         $db = $GLOBALS["db"] ?? null;
         if (!$db) {
-            $decision = false;
-            return $decision;
+            return false;
         }
-
-        $requiredTables = [
-            'database_versioning',
-            'general_settings',
-            'core_stt_connector',
-            'core_itt_connector',
-            'core_tts_connector',
-        ];
 
         try {
-            $tableRows = $db->fetchAll(
-                "SELECT table_name
-                 FROM information_schema.tables
-                 WHERE table_schema='public'
-                   AND table_name IN ('database_versioning','general_settings','core_stt_connector','core_itt_connector','core_tts_connector')"
-            );
-        } catch (\Throwable $e) {
-            $decision = false;
-            return $decision;
-        }
-
-        $existingTables = [];
-        foreach ($tableRows as $row) {
-            $tableName = strval($row['table_name'] ?? '');
-            if ($tableName !== '') {
-                $existingTables[$tableName] = true;
-            }
-        }
-
-        foreach ($requiredTables as $requiredTable) {
-            if (empty($existingTables[$requiredTable])) {
-                $decision = true;
-                return $decision;
-            }
-        }
-
-        $requiredVersions = [
-            'general_settings' => 20260720002,
-            'core_stt_connector' => 20260502002,
-            'core_itt_connector' => 20260502002,
-            'descriptions_defaults' => 20260611005,
-            'prompts' => 20260615001,
-            'skyrim_quest_definitions' => 20260628003,
-            'core_tts_connector_omnivoice' => 20260708001,
-        ];
-
-        try {
-            $versionRows = $db->fetchAll(
-                "SELECT tablename, version
-                 FROM public.database_versioning
-                 WHERE tablename IN ('general_settings','core_stt_connector','core_itt_connector','descriptions_defaults','prompts','skyrim_quest_definitions','core_tts_connector_omnivoice')"
+            $relations = $db->fetchAll(
+                "SELECT to_regclass('public.database_versioning') AS legacy_ledger,
+                        to_regclass('chim_meta.schema_migrations') AS migration_ledger"
             );
         } catch (\Throwable $e) {
             $decision = true;
             return $decision;
         }
 
-        $versions = [];
-        foreach ($versionRows as $row) {
-            $tableName = strval($row['tablename'] ?? '');
-            if ($tableName !== '') {
-                $versions[$tableName] = intval($row['version'] ?? -1);
-            }
+        $legacyLedger = strval($relations[0]['legacy_ledger'] ?? '');
+        $migrationLedger = strval($relations[0]['migration_ledger'] ?? '');
+        if ($migrationLedger === '') {
+            // An entirely empty database is allowed through to the installer.
+            $decision = $legacyLedger !== '';
+            return $decision;
         }
 
-        foreach ($requiredVersions as $tableName => $requiredVersion) {
-            if (intval($versions[$tableName] ?? -1) < $requiredVersion) {
+        try {
+            $root = dirname(__DIR__);
+            $manifest = \HerikaServer\Database\MigrationRunner::sourceManifest($root);
+            $rows = $db->fetchAll('SELECT version, name, checksum FROM chim_meta.schema_migrations ORDER BY version');
+        } catch (\Throwable $e) {
+            $decision = true;
+            return $decision;
+        }
+
+        $applied = [];
+        foreach ($rows as $row) {
+            $applied[intval($row['version'] ?? 0)] = [
+                'name' => strval($row['name'] ?? ''),
+                'checksum' => rtrim(strval($row['checksum'] ?? '')),
+            ];
+        }
+
+        if (count($applied) !== count($manifest)) {
+            $decision = true;
+            return $decision;
+        }
+        foreach ($manifest as $version => $migration) {
+            if (($applied[$version]['name'] ?? null) !== $migration['name']
+                || !hash_equals($migration['checksum'], $applied[$version]['checksum'] ?? '')) {
                 $decision = true;
                 return $decision;
             }
@@ -120,11 +96,18 @@ if (!function_exists('chimRuntimeEnsureDbUpdates')) {
             return;
         }
 
-        $updatesPath = $enginePath . "debug" . DIRECTORY_SEPARATOR . "db_updates.php";
-        $db=$GLOBALS["db"] ?? null;
-        if (file_exists($updatesPath)) {
-            require_once($updatesPath);
+        $message = "HerikaServer database schema is not synchronized with this code. "
+            . "Back up the database, then run: php scripts/database.php legacy-bridge";
+        error_log('[RuntimeBootstrap] ' . $message);
+
+        if (PHP_SAPI === 'cli') {
+            throw new \RuntimeException($message);
         }
+
+        http_response_code(503);
+        header('Content-Type: text/plain; charset=utf-8');
+        echo $message . "\n";
+        exit;
     }
 }
 

--- a/scripts/database.php
+++ b/scripts/database.php
@@ -1,0 +1,69 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use HerikaServer\Database\MigrationRunner;
+
+$root = dirname(__DIR__);
+require_once $root . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'MigrationRunner.php';
+
+$usage = static function (): never {
+    fwrite(STDERR, "Usage: php scripts/database.php <status|migrate|verify|doctor|legacy-bridge>\n");
+    exit(2);
+};
+
+try {
+    $command = $argv[1] ?? null;
+    if (!in_array($command, ['status', 'migrate', 'verify', 'doctor', 'legacy-bridge'], true)) {
+        $usage();
+    }
+
+    if ($command === 'legacy-bridge') {
+        if (getenv('HERIKA_DATABASE_DSN')) {
+            throw new RuntimeException('legacy-bridge targets the configured HerikaServer database and does not accept HERIKA_DATABASE_DSN overrides.');
+        }
+        require $root . DIRECTORY_SEPARATOR . 'debug' . DIRECTORY_SEPARATOR . 'apply_db_updates.php';
+        exit(0);
+    }
+
+    $nullDevice = PHP_OS_FAMILY === 'Windows' ? 'NUL' : '/dev/null';
+    $commit = trim((string) @shell_exec('git -C ' . escapeshellarg($root) . ' rev-parse HEAD 2>' . $nullDevice)) ?: null;
+    $runner = MigrationRunner::connect($root, null, $commit);
+
+    if ($command === 'migrate') {
+        $ran = $runner->migrate();
+        fwrite(STDOUT, $ran === [] ? "Database is already current.\n" : 'Applied: ' . implode(', ', $ran) . "\n");
+        exit(0);
+    }
+
+    $status = $runner->status();
+    if ($command === 'status') {
+        printf("Legacy baseline: %s\n", $status['baseline_problems'] === [] ? 'compatible' : 'not reconciled');
+        foreach ($status['applied'] as $migration) {
+            printf("%012d %-40s applied %s\n", $migration['version'], $migration['name'], $migration['checksum']);
+        }
+        foreach ($status['pending'] as $migration) {
+            printf("%012d %-40s pending %s\n", $migration['version'], $migration['name'], $migration['checksum']);
+        }
+        exit($status['ready'] ? 0 : 1);
+    }
+
+    $problems = $runner->verify();
+    if ($command === 'doctor') {
+        if ($problems === []) {
+            fwrite(STDOUT, "Database schema and migration history are healthy.\n");
+            exit(0);
+        }
+        fwrite(STDOUT, "Database requires attention:\n- " . implode("\n- ", $problems) . "\n");
+        exit(1);
+    }
+
+    if ($problems !== []) {
+        throw new RuntimeException("Database verification failed:\n- " . implode("\n- ", $problems));
+    }
+    fwrite(STDOUT, "Database schema and migration history are current.\n");
+} catch (Throwable $error) {
+    fwrite(STDERR, 'Database command failed: ' . $error->getMessage() . "\n");
+    exit(1);
+}

--- a/scripts/generate-schema-contract.php
+++ b/scripts/generate-schema-contract.php
@@ -1,0 +1,111 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use HerikaServer\Database\MigrationRunner;
+
+$root = dirname(__DIR__);
+require_once $root . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'MigrationRunner.php';
+
+$mode = $argv[1] ?? '';
+if (!in_array($mode, ['baseline', 'current'], true)) {
+    fwrite(STDERR, "Usage: php scripts/generate-schema-contract.php <baseline|current> [output-path]\n");
+    exit(2);
+}
+
+$dsn = getenv('HERIKA_DATABASE_DSN');
+if (!$dsn) {
+    fwrite(STDERR, "HERIKA_DATABASE_DSN is required so the contract cannot be generated accidentally from a user database.\n");
+    exit(2);
+}
+
+$connection = @pg_connect($dsn);
+if (!$connection) {
+    fwrite(STDERR, "Could not connect to the contract source database.\n");
+    exit(1);
+}
+
+$queryRows = static function (string $sql) use ($connection): array {
+    $result = @pg_query($connection, $sql);
+    if (!$result) {
+        throw new RuntimeException(pg_last_error($connection));
+    }
+    return pg_fetch_all($result) ?: [];
+};
+
+try {
+    $contract = [
+        'extensions' => [],
+        'tables' => [],
+        'views' => [],
+        'constraints' => [],
+        'indexes' => [],
+    ];
+    if ($mode === 'baseline') {
+        $contract = ['baseline_version' => MigrationRunner::BASELINE_VERSION] + $contract;
+    } else {
+        $contract = ['schema_version' => MigrationRunner::latestVersion($root)] + $contract;
+    }
+
+    foreach ($queryRows("SELECT extname FROM pg_extension WHERE extname NOT IN ('plpgsql') ORDER BY extname") as $row) {
+        $contract['extensions'][] = $row['extname'];
+    }
+    foreach ($queryRows("SELECT table_schema, table_name, table_type FROM information_schema.tables WHERE table_schema IN ('public','chim_meta') ORDER BY table_schema, table_name") as $row) {
+        $relation = $row['table_schema'] . '.' . $row['table_name'];
+        if ($row['table_type'] === 'VIEW') {
+            $contract['views'][$relation] = '';
+        } elseif ($row['table_type'] === 'BASE TABLE' && $relation !== MigrationRunner::LEDGER) {
+            $contract['tables'][$relation] = ['columns' => []];
+        }
+    }
+    foreach ($queryRows("SELECT schemaname, viewname, definition FROM pg_views WHERE schemaname IN ('public','chim_meta') ORDER BY schemaname, viewname") as $row) {
+        $relation = $row['schemaname'] . '.' . $row['viewname'];
+        if (array_key_exists($relation, $contract['views'])) {
+            $contract['views'][$relation] = trim($row['definition']);
+        }
+    }
+    foreach ($queryRows("SELECT table_schema, table_name, column_name, udt_schema, udt_name, is_nullable FROM information_schema.columns WHERE table_schema IN ('public','chim_meta') ORDER BY table_schema, table_name, ordinal_position") as $row) {
+        $relation = $row['table_schema'] . '.' . $row['table_name'];
+        if (!isset($contract['tables'][$relation])) {
+            continue;
+        }
+        $contract['tables'][$relation]['columns'][$row['column_name']] = [
+            'udt_schema' => $row['udt_schema'],
+            'udt_name' => $row['udt_name'],
+            'nullable' => $row['is_nullable'] === 'YES',
+        ];
+    }
+    foreach ($queryRows("SELECT n.nspname AS schema_name, c.relname AS table_name, con.conname FROM pg_constraint con JOIN pg_class c ON c.oid=con.conrelid JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname IN ('public','chim_meta') ORDER BY 1,2,3") as $row) {
+        if ($row['schema_name'] . '.' . $row['table_name'] === MigrationRunner::LEDGER) {
+            continue;
+        }
+        $contract['constraints'][] = $row['schema_name'] . '.' . $row['table_name'] . '.' . $row['conname'];
+    }
+    foreach ($queryRows("SELECT schemaname, tablename, indexname FROM pg_indexes WHERE schemaname IN ('public','chim_meta') ORDER BY 1,2,3") as $row) {
+        if ($row['schemaname'] . '.' . $row['tablename'] === MigrationRunner::LEDGER) {
+            continue;
+        }
+        $contract['indexes'][] = $row['schemaname'] . '.' . $row['tablename'] . '.' . $row['indexname'];
+    }
+
+    $json = json_encode($contract, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+    $outputPath = $argv[2] ?? null;
+    if ($outputPath !== null) {
+        $directory = dirname($outputPath);
+        if (!is_dir($directory) && !mkdir($directory, 0775, true) && !is_dir($directory)) {
+            throw new RuntimeException("Could not create contract directory: {$directory}");
+        }
+        if (file_put_contents($outputPath, $json) === false) {
+            throw new RuntimeException("Could not write contract: {$outputPath}");
+        }
+        fwrite(STDOUT, "Wrote {$outputPath}\n");
+    } else {
+        fwrite(STDOUT, $json);
+    }
+} catch (Throwable $error) {
+    fwrite(STDERR, 'Contract generation failed: ' . $error->getMessage() . "\n");
+    exit(1);
+} finally {
+    pg_close($connection);
+}

--- a/ui/cmd/install-db.php
+++ b/ui/cmd/install-db.php
@@ -75,6 +75,17 @@ if (file_exists($coreActionSeedFile) && trim(strval(file_get_contents($coreActio
 
 echo "Import completed.\n";
 
+require($enginePath . '/debug/db_updates.php');
+require_once($enginePath . '/lib/database/MigrationRunner.php');
+$runner = \HerikaServer\Database\MigrationRunner::connect($enginePath);
+$runner->repairLegacyBaseline();
+$runner->migrate();
+$migrationProblems = $runner->verify();
+if ($migrationProblems !== []) {
+    throw new RuntimeException("Database verification failed after installation:\n- " . implode("\n- ", $migrationProblems));
+}
+echo "Database schema migrations applied and verified.\n";
+
 
 
 ?>

--- a/ui/core/tts_connectors.php
+++ b/ui/core/tts_connectors.php
@@ -23,11 +23,6 @@ if ($webRoot === '/') {
 $webRoot = rtrim($webRoot, '/');
 $isEmbed = isset($_GET['embed']) && strval($_GET['embed']) === '1';
 
-try {
-    require_once($enginePath . "debug" . DIRECTORY_SEPARATOR . "db_updates.php");
-} catch (Throwable $_e) {
-}
-
 $ttsConnector = new TTSConnector();
 
 function h($value): string

--- a/ui/home.php
+++ b/ui/home.php
@@ -80,7 +80,6 @@ try {
 
 /* Check for database updates only in index.php with no parms*/
 if (sizeof($_GET)==0) {
-    require_once(__DIR__."/../debug/db_updates.php");
     require_once(__DIR__."/../debug/npc_removal.php");
     require_once(__DIR__."/../lib/log_trim.php");
     

--- a/ui/index.php
+++ b/ui/index.php
@@ -133,7 +133,6 @@ $db = new sql();
 
 /* Check for database updates only in index.php with no parms*/
 if (sizeof($_GET)==0) {
-    require_once(__DIR__."/../debug/db_updates.php");
     require_once(__DIR__."/../debug/npc_removal.php");
     
     // Ensure helper daemon is running (self-heals when it is down).

--- a/ui/itt_connectors.php
+++ b/ui/itt_connectors.php
@@ -13,11 +13,6 @@ chimRuntimeBootstrap($enginePath, [
     'load_itt_connector' => false,
 ]);
 
-try {
-    require_once($enginePath . "debug" . DIRECTORY_SEPARATOR . "db_updates.php");
-} catch (Throwable $_e) {
-}
-
 $connector = new ITTConnector();
 $isEmbed = isset($_GET['embed']) && strval($_GET['embed']) === '1';
 

--- a/ui/quickstart.php
+++ b/ui/quickstart.php
@@ -309,8 +309,6 @@ if (isset($_GET['minime_probe']) && strval($_GET['minime_probe']) === '1') {
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['qs_action'])) {
     try { require_once($rootPath . "lib" .DIRECTORY_SEPARATOR."{$GLOBALS["DBDRIVER"]}.class.php"); } catch (Throwable $_e) {}
     try { if (!isset($GLOBALS['db']) || !$GLOBALS['db']) { $GLOBALS['db'] = new sql(); } } catch (Throwable $_e) {}
-    // Ensure database schema/tables exist before handling any quicksave actions
-    try { require_once($rootPath . "debug" . DIRECTORY_SEPARATOR . "db_updates.php"); } catch (Throwable $_e) {}
     try { require_once($rootPath . "lib" . DIRECTORY_SEPARATOR . "llm_randomizer.php"); } catch (Throwable $_e) {}
     header('Content-Type: application/json');
 

--- a/ui/stt_connectors.php
+++ b/ui/stt_connectors.php
@@ -13,11 +13,6 @@ chimRuntimeBootstrap($enginePath, [
     'load_itt_connector' => false,
 ]);
 
-try {
-    require_once($enginePath . "debug" . DIRECTORY_SEPARATOR . "db_updates.php");
-} catch (Throwable $_e) {
-}
-
 $connector = new STTConnector();
 $isEmbed = isset($_GET['embed']) && strval($_GET['embed']) === '1';
 

--- a/unittests/tests/DatabaseTestCase.php
+++ b/unittests/tests/DatabaseTestCase.php
@@ -39,23 +39,23 @@ abstract class DatabaseTestCase extends TestCase
         $connString = "host=localhost dbname=dwemer user=dwemer password=dwemer";
         $mainConnection = pg_connect($connString);
         if (!$mainConnection) {
-            $this->fail("Failed to connect to main database.");
+            throw new RuntimeException("Failed to connect to main database.");
         }
 
         // Drop the test database if it already exists
         $dropResult = pg_query($mainConnection, "DROP DATABASE IF EXISTS ".self::$testDatabaseName." WITH (FORCE)");
         if (!$dropResult) {
-            $this->fail("Failed to drop test database: " . pg_last_error($mainConnection));
+            throw new RuntimeException("Failed to drop test database: " . pg_last_error($mainConnection));
         }
         $dropResult = pg_query($mainConnection, "DROP DATABASE IF EXISTS ".self::$testDatabaseBkpName." WITH (FORCE)");
         if (!$dropResult) {
-            $this->fail("Failed to drop test database: " . pg_last_error($mainConnection));
+            throw new RuntimeException("Failed to drop test database: " . pg_last_error($mainConnection));
         }
 
         // Create the test database
         $createResult = pg_query($mainConnection, "CREATE DATABASE ".self::$testDatabaseName);
         if (!$createResult) {
-            $this->fail("Failed to create test database: " . pg_last_error($mainConnection));
+            throw new RuntimeException("Failed to create test database: " . pg_last_error($mainConnection));
         }
 
         pg_close($mainConnection);
@@ -74,33 +74,50 @@ abstract class DatabaseTestCase extends TestCase
         pg_close($testConnection);
 
         // Command to import SQL file using psql
-        $path = __DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..";
-        $sqlFile = $path.DIRECTORY_SEPARATOR."data".DIRECTORY_SEPARATOR."database_default.sql";
-        $psqlCommand = "PGPASSWORD=dwemer psql -h localhost -p 5432 -U dwemer -d ".self::$testDatabaseName." -f $sqlFile";
+        $projectRoot = realpath(__DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."..");
+        $sqlFile = $projectRoot.DIRECTORY_SEPARATOR."data".DIRECTORY_SEPARATOR."database_default.sql";
+        $psqlCommand = "PGPASSWORD=dwemer psql -q -h localhost -p 5432 -U dwemer -d ".self::$testDatabaseName
+            ." -v ON_ERROR_STOP=1 -f ".escapeshellarg($sqlFile);
 
         // Execute psql command
         $output = [];
         $returnVar = 0;
         exec($psqlCommand, $output, $returnVar);
+        if ($returnVar !== 0) {
+            throw new RuntimeException("Failed to import test database schema:\n" . implode("\n", $output));
+        }
 
-        require_once($path.DIRECTORY_SEPARATOR."lib".DIRECTORY_SEPARATOR."phpunit.class.php");
+        require_once($projectRoot.DIRECTORY_SEPARATOR."lib".DIRECTORY_SEPARATOR."phpunit.class.php");
 
         // apply database updates
         $db = new sql();
         $GLOBALS["db"]=$db;
-        require($path.DIRECTORY_SEPARATOR."debug".DIRECTORY_SEPARATOR."db_updates.php");
+        require($projectRoot.DIRECTORY_SEPARATOR."debug".DIRECTORY_SEPARATOR."db_updates.php");
+
+        require_once($projectRoot.DIRECTORY_SEPARATOR."lib".DIRECTORY_SEPARATOR."database".DIRECTORY_SEPARATOR."MigrationRunner.php");
+        $runner = \HerikaServer\Database\MigrationRunner::connect(
+            $projectRoot,
+            "host=localhost dbname=".self::$testDatabaseName." user=dwemer password=dwemer"
+        );
+        $runner->repairLegacyBaseline();
+        $runner->migrate();
+        $migrationProblems = $runner->verify();
+        if ($migrationProblems !== []) {
+            throw new RuntimeException("Test database migration verification failed:\n- " . implode("\n- ", $migrationProblems));
+        }
 
         $db->close();
         unset($db);
         unset($GLOBALS["db"]);
+        unset($runner);
 
-        // Connect to the new test database
-        $connString = "host=localhost dbname=".self::$testDatabaseName." user=dwemer password=dwemer";
+        // Copy from a separate maintenance database so the template has no active session.
+        $connString = "host=localhost dbname=dwemer user=dwemer password=dwemer";
         $testConnection = pg_connect($connString);
         // Copy the test database to a backup for reuse
         $createResult = pg_query($testConnection, "CREATE DATABASE ".self::$testDatabaseBkpName." WITH TEMPLATE ".self::$testDatabaseName);
-        if (!$dropResult) {
-            $this->fail("Failed to copy test database: " . pg_last_error($testConnection));
+        if (!$createResult) {
+            throw new RuntimeException("Failed to copy test database: " . pg_last_error($testConnection));
         }
         pg_close($testConnection);
     }

--- a/unittests/tests/MigrationRunnerTest.php
+++ b/unittests/tests/MigrationRunnerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+require_once(__DIR__ . DIRECTORY_SEPARATOR . 'DatabaseTestCase.php');
+require_once(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'MigrationRunner.php');
+
+use HerikaServer\Database\MigrationRunner;
+
+final class MigrationRunnerTest extends DatabaseTestCase
+{
+    private function runner(): MigrationRunner
+    {
+        return MigrationRunner::connect(
+            dirname(__DIR__, 2),
+            'host=localhost dbname=testdb user=dwemer password=dwemer'
+        );
+    }
+
+    public function testMigrateIsIdempotent(): void
+    {
+        $this->assertSame([], $this->runner()->migrate());
+        $this->assertSame([], $this->runner()->verify());
+    }
+
+    public function testVerifyDetectsStructuralSchemaDrift(): void
+    {
+        $connection = pg_connect('host=localhost dbname=testdb user=dwemer password=dwemer');
+        pg_query($connection, 'ALTER TABLE public.audit_request DROP COLUMN response');
+
+        $this->assertContains('Missing column public.audit_request.response', $this->runner()->verify());
+    }
+
+    public function testVerifyRejectsMigrationChecksumDrift(): void
+    {
+        $connection = pg_connect('host=localhost dbname=testdb user=dwemer password=dwemer');
+        pg_query_params(
+            $connection,
+            'UPDATE chim_meta.schema_migrations SET checksum=$1 WHERE version=$2',
+            [str_repeat('0', 64), '202608120001']
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Migration checksum drift detected at 202608120001');
+        $this->runner()->verify();
+    }
+
+    public function testFailedSqlMigrationRollsBackSchemaAndLedger(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $fixture = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'herika_migration_' . bin2hex(random_bytes(8));
+        $baselineDirectory = $fixture . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'baseline';
+        $migrationDirectory = $fixture . DIRECTORY_SEPARATOR . 'database' . DIRECTORY_SEPARATOR . 'migrations';
+        mkdir($baselineDirectory, 0775, true);
+        mkdir($migrationDirectory, 0775, true);
+
+        $baselineName = MigrationRunner::BASELINE_VERSION . '_contract.json';
+        copy($root . '/database/baseline/' . $baselineName, $baselineDirectory . '/' . $baselineName);
+        copy($root . '/database/schema-contract.json', $fixture . '/database/schema-contract.json');
+        copy(
+            $root . '/database/migrations/202608120001_audit_request_response.sql',
+            $migrationDirectory . '/202608120001_audit_request_response.sql'
+        );
+        $failingMigration = $migrationDirectory . '/202608120002_rollback_probe.sql';
+        file_put_contents(
+            $failingMigration,
+            "CREATE TABLE public.migration_rollback_probe (id integer);\n"
+            . "INSERT INTO public.migration_table_that_does_not_exist (id) VALUES (1);\n"
+        );
+
+        $connection = pg_connect('host=localhost dbname=testdb user=dwemer password=dwemer');
+        try {
+            $runner = new MigrationRunner($connection, $fixture);
+            try {
+                $runner->migrate();
+                $this->fail('The deliberately failing migration unexpectedly succeeded.');
+            } catch (RuntimeException $error) {
+                $this->assertStringContainsString('migration_table_that_does_not_exist', $error->getMessage());
+            }
+
+            $table = pg_fetch_result(pg_query($connection, "SELECT to_regclass('public.migration_rollback_probe')"), 0, 0);
+            $ledger = pg_fetch_result(
+                pg_query($connection, 'SELECT count(*) FROM chim_meta.schema_migrations WHERE version=202608120002'),
+                0,
+                0
+            );
+            $this->assertSame('', strval($table));
+            $this->assertSame('0', $ledger);
+        } finally {
+            pg_close($connection);
+            unlink($failingMigration);
+            unlink($migrationDirectory . '/202608120001_audit_request_response.sql');
+            unlink($fixture . '/database/schema-contract.json');
+            unlink($baselineDirectory . '/' . $baselineName);
+            rmdir($migrationDirectory);
+            rmdir($baselineDirectory);
+            rmdir($fixture . '/database');
+            rmdir($fixture);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a native PostgreSQL migration runner with global ordering, advisory locking, per-migration transactions, checksums, gap/drift detection, and an append-only `chim_meta.schema_migrations` ledger
- establish an audited `202608110000` legacy baseline plus generated baseline/current schema contracts
- freeze `debug/db_updates.php` as an explicit compatibility bridge and remove schema writes from normal UI/game request paths
- move the unversioned `audit_request.response` DDL into the first raw SQL migration
- make fresh install and database test setup run the legacy bridge, migrations, and verification
- add operator/generator commands and migration authoring documentation

## Baseline transition

The compatibility repair reasserts two structures that the legacy latest-per-feature markers or process-static state can hide (`visual_context` and the prompts unique index). It also upgrades `eventlog.sess` transactionally while discovering, rebuilding, and owner-preserving every dependent profile view. It refuses profile views with custom grants/options rather than silently losing them.

Normal runtime requests now compare every source migration version, name, and SHA-256 checksum to the ledger. Stale or drifted databases fail closed with the operator bridge command; runtime requests do not execute DDL.

## Validation

- PHP lint: all 17 changed/new PHP files passed
- focused PHPUnit: `MigrationRunnerTest` passed, 4 tests / 8 assertions
  - idempotence
  - structural drift detection
  - checksum drift rejection
  - failed migration transaction/ledger rollback
- fresh database: imported `database_default.sql`, ran frozen updater + audited repair, applied migration, verified current schema, and confirmed second migrate was a no-op
- real upgrade shape: restored a dump of the local user database into an isolated database, upgraded it, and verified all three `eventlog.sess` dependent views remained present with their owners
- concurrency: two simultaneous runners both succeeded; migration table and ledger row were created exactly once
- runtime gate: a corrupted ledger checksum was rejected and CLI runtime failed closed
- local deployment: deployed exact commit `21b9c3152e770606bd04c7b7c2817f24c80ec51f` to the DwemerAI4Skyrim3 HerikaServer runtime after a 198,783,649-byte compressed backup
- deployed database: `status`, `verify`, and `doctor` passed; `eventlog.sess` is `text`; `audit_request.response` exists
- HTTP smoke: index, home, STT, ITT, and TTS pages returned 200; the ledger hash was unchanged across requests
- preservation audit: restored the exact pre-deploy backup and compared 263 pre-existing tables (203 non-empty); no row-count decreases

## Full-suite limits

The full PHPUnit invocation ran 261 tests / 2,635 assertions before ending non-green. It exposed the repository's existing duplicate `sql` test-class architecture and unrelated existing assertions in faction ordering and historic-context behavior. The migration-specific suite is green; this PR does not claim the entire legacy suite is green.

## Review / overlap

The unstable guard returned `PR_REQUIRED` for size, generated contract growth, sensitive lifecycle code, and recent/open work overlap. In particular, `debug/db_updates.php` overlaps open PRs #690, #594, and #536. This PR only freezes the file and changes the `eventlog_session_payload` handoff/removes the unversioned audit DDL; historical feature blocks are not rewritten.

## Deployment scope

HerikaServer only. No CHIM DLL was rebuilt or deployed. No release/version bump was made.