### PR TITLE
Honor request-local chat mode overrides

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -2842,6 +2842,7 @@ function chimDecodePlayerRoutingSnapshotField($rawField)
     $result = [
         "audience" => "",
         "present_actors" => [],
+        "execution_mode" => "",
     ];
     $rawField = trim((string)$rawField);
     if ($rawField === "") {
@@ -2865,6 +2866,21 @@ function chimDecodePlayerRoutingSnapshotField($rawField)
     }
 
     $result["present_actors"] = chimNormalizePresentActors($payload["present_actors"] ?? []);
+    $executionMode = strtoupper(trim((string)($payload["execution_mode"] ?? "")));
+    if (in_array($executionMode, [
+        "STANDARD",
+        "WHISPER",
+        "CLOSE",
+        "SHOUT",
+        "NARRATOR",
+        "DIRECTOR",
+        "CHEATMODE",
+        "AUTOCHAT",
+        "INJECTION_LOG",
+        "INJECTION_CHAT",
+    ], true)) {
+        $result["execution_mode"] = $executionMode;
+    }
     return $result;
 }
 

--- a/main.php
+++ b/main.php
@@ -133,6 +133,11 @@ MAIN FLOW
 $gameRequest = explode("|", $receivedData);
 $GLOBALS["gameRequest"] = &$gameRequest;
 unset($GLOBALS["CHIM_TURN_PEOPLE_SNAPSHOT"]);
+unset($GLOBALS["CHIM_REQUEST_EXECUTION_MODE"]);
+$requestRoutingSnapshot = chimDecodePlayerRoutingSnapshotField($gameRequest[4] ?? "");
+if (($requestRoutingSnapshot["execution_mode"] ?? "") !== "") {
+    $GLOBALS["CHIM_REQUEST_EXECUTION_MODE"] = $requestRoutingSnapshot["execution_mode"];
+}
 
 
 $startTime = microtime(true);
@@ -1704,7 +1709,6 @@ if (!isset($GLOBALS["CACHE_PARTY"])) {
     $GLOBALS["CACHE_PARTY"]=DataGetCurrentPartyConf();
 } 
 
-$requestRoutingSnapshot = chimDecodePlayerRoutingSnapshotField($gameRequest[4] ?? "");
 $requestAudienceSnapshot = (string)($requestRoutingSnapshot["audience"] ?? "");
 $requestPresentActorsSnapshot = chimSetCurrentTurnPresentActorsSnapshot(
     $requestRoutingSnapshot["present_actors"] ?? []

--- a/processor/chim_modes.php
+++ b/processor/chim_modes.php
@@ -47,6 +47,11 @@ $EXECUTION_MODE_=$db->fetchOne("SELECT value FROM conf_opts WHERE id='chim_mode'
 $EXECUTION_MODE=isset($EXECUTION_MODE_["value"])?$EXECUTION_MODE_["value"]:"STANDARD";
 
 $EXECUTION_MODE=strtoupper($EXECUTION_MODE);
+// A validated plugin routing snapshot can override the saved mode for this request only.
+$REQUEST_EXECUTION_MODE = strtoupper(trim((string)($GLOBALS["CHIM_REQUEST_EXECUTION_MODE"] ?? "")));
+if ($REQUEST_EXECUTION_MODE !== "") {
+    $EXECUTION_MODE = $REQUEST_EXECUTION_MODE;
+}
 
 // Retire the old free-form Spawn mode without leaving upgraded installs stuck in it.
 if ($EXECUTION_MODE === "SPAWN") {

--- a/unittests/tests/PlayerPresenceSnapshotTest.php
+++ b/unittests/tests/PlayerPresenceSnapshotTest.php
@@ -88,6 +88,30 @@ final class PlayerPresenceSnapshotTest extends TestCase
         $this->assertSame([], $snapshot['present_actors']);
     }
 
+    public function testRequestExecutionModeIsDecodedFromRoutingSnapshot(): void
+    {
+        $encoded = base64_encode((string)json_encode([
+            'source' => 'plugin_player_routing_v2',
+            'execution_mode' => 'whisper',
+        ]));
+
+        $snapshot = chimDecodePlayerRoutingSnapshotField($encoded);
+
+        $this->assertSame('WHISPER', $snapshot['execution_mode']);
+        $this->assertSame('', $snapshot['audience']);
+    }
+
+    public function testUnknownRequestExecutionModeIsIgnored(): void
+    {
+        $encoded = base64_encode((string)json_encode([
+            'execution_mode' => 'unsupported-mode',
+        ]));
+
+        $snapshot = chimDecodePlayerRoutingSnapshotField($encoded);
+
+        $this->assertSame('', $snapshot['execution_mode']);
+    }
+
     public function testDirectivePeopleIncludeSelectedSpeakerAndExplicitListener(): void
     {
         $people = chimBuildDirectivePeoplePipe(


### PR DESCRIPTION
## Summary
- accept a validated request-local CHIM execution mode from the client routing snapshot
- apply the override for one request without changing the saved `chim_mode`
- preserve the existing mode-specific request transformations, including narrator, cheat, auto-chat, and injection handling

## Paired change
- Requires Dwemer-Dynamics/CHIM#129

## Validation
- PHP lint passed for all four changed files
- `PlayerPresenceSnapshotTest.php`: 10 tests, 19 assertions passed
- focused mode probes passed for Whisper, Close, Shout, Narrator, Cheat Mode, Auto Chat, Event Inject, and Inject & Chat
- full PHPUnit suite was attempted but remains blocked by unrelated environment/schema issues, including unavailable PostgreSQL state, missing `ZipArchive`, a missing `OghmaContextRulesTest` class, and two unrelated existing assertions

## Limits
- not deployed
- not tested in game