### PR TITLE
Keep Player TTS disabled by default

### DIFF
--- a/ui/quickstart.php
+++ b/ui/quickstart.php
@@ -208,20 +208,8 @@ function herikaQuickstartApplyTtsSelection(TTSConnector $connector, $selectedDri
     if ($previousPreferredId > 0 && $previousPreferredId !== $selectedId) {
         $GLOBALS['db']->query("UPDATE core_profiles SET tts_connector_id = {$selectedId} WHERE tts_connector_id = {$previousPreferredId}");
     }
+    // QuickStart configures NPC and narrator TTS; Player TTS remains opt-in in Player Management.
     $GLOBALS['db']->query("UPDATE core_profiles SET tts_connector_id = {$selectedId} WHERE tts_connector_id IS NULL OR default_narrator = '1' OR default_npc = '1'");
-
-    if (!class_exists('Player')) {
-        require_once(__DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "lib" . DIRECTORY_SEPARATOR . "core" . DIRECTORY_SEPARATOR . "player.class.php");
-    }
-
-    try {
-        $player = new Player();
-        $currentPlayerConnectorId = intval($player->get('tts_connector_id') ?? 0);
-        if ($currentPlayerConnectorId <= 0 || $currentPlayerConnectorId === $previousPreferredId || $currentPlayerConnectorId === $selectedId) {
-            $player->set('tts_connector_id', strval($selectedId));
-        }
-    } catch (Throwable $_e) {
-    }
 
     return $selectedId;
 }


### PR DESCRIPTION
## Summary

- keep Player TTS disabled on fresh installs
- limit QuickStart TTS selection to NPC and narrator profiles
- preserve existing Player TTS choices as an opt-in setting in Player Management

## Root cause

QuickStart copied its selected default TTS connector into `core_player.tts_connector_id`, silently enabling Player TTS during initial setup.

## Compatibility

No schema or migration changes. Existing Player TTS settings are not modified. PR #693 also touches `ui/quickstart.php`, but in a separate request-bootstrap block.

## Validation

- `php -l ui/quickstart.php`
- `git diff --check`
- QuickStart Player TTS opt-in source invariant
- fresh `core_player` schema seed check
- PHPUnit: 4 tests, 7 assertions

## Deployment

Not deployed. Fresh-install behavior has not been exercised through the full installer UI.