### PR TITLE
Pause scheduled LLM work while Skyrim is inactive

### DIFF
--- a/lib/game_activity.php
+++ b/lib/game_activity.php
@@ -1,0 +1,92 @@
+<?php
+
+const CHIM_GAME_ACTIVITY_TTL = 180;
+const CHIM_GAME_ACTIVITY_WRITE_INTERVAL = 15;
+
+function chimGameActivityGetOption(string $id, string $default = ''): string
+{
+    $db = $GLOBALS['db'] ?? null;
+    if (!$db) {
+        return $default;
+    }
+
+    $escapedId = $db->escape($id);
+    $row = $db->fetchOne("SELECT value FROM conf_opts WHERE id='{$escapedId}' LIMIT 1");
+    return is_array($row) && array_key_exists('value', $row) ? strval($row['value']) : $default;
+}
+
+function chimGameActivitySetOption(string $id, string $value): bool
+{
+    $db = $GLOBALS['db'] ?? null;
+    if (!$db) {
+        return false;
+    }
+
+    return (bool)$db->upsertRowOnConflict('conf_opts', [
+        'id' => $id,
+        'value' => $value,
+    ], 'id');
+}
+
+function chimGameActivityReadTimestamp(string $id, string $legacyId): int
+{
+    $timestamp = intval(chimGameActivityGetOption($id, '0'));
+    if ($timestamp <= 0) {
+        $timestamp = intval(chimGameActivityGetOption($legacyId, '0'));
+    }
+
+    return $timestamp;
+}
+
+function chimGameActivityWriteTimestamp(string $id, string $legacyId, int $timestamp): void
+{
+    $value = strval($timestamp);
+    chimGameActivitySetOption($id, $value);
+    chimGameActivitySetOption($legacyId, $value);
+}
+
+function chimGetLastGameActivityTimestamp(): int
+{
+    return chimGameActivityReadTimestamp('CHIM_GAME_LAST_ACTIVITY_TS', 'PLAYER2_GAME_LAST_ACTIVITY_TS');
+}
+
+function chimGetGameActivitySessionStartedTimestamp(): int
+{
+    return chimGameActivityReadTimestamp('CHIM_GAME_SESSION_STARTED_TS', 'PLAYER2_GAME_SESSION_STARTED_TS');
+}
+
+/**
+ * Mark normal Skyrim traffic and report whether it starts a new activity session.
+ */
+function chimMarkGameActivity(?int $now = null): bool
+{
+    $now = $now ?? time();
+    $lastActivity = chimGetLastGameActivityTimestamp();
+    $newSession = $lastActivity <= 0 || ($now - $lastActivity) > CHIM_GAME_ACTIVITY_TTL;
+
+    if ($newSession) {
+        chimGameActivityWriteTimestamp('CHIM_GAME_SESSION_STARTED_TS', 'PLAYER2_GAME_SESSION_STARTED_TS', $now);
+    }
+    if ($newSession || ($now - $lastActivity) >= CHIM_GAME_ACTIVITY_WRITE_INTERVAL) {
+        chimGameActivityWriteTimestamp('CHIM_GAME_LAST_ACTIVITY_TS', 'PLAYER2_GAME_LAST_ACTIVITY_TS', $now);
+    }
+
+    $GLOBALS['CHIM_GAME_REQUEST_ACTIVE'] = true;
+    $GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE'] = true;
+
+    return $newSession;
+}
+
+function chimHasRecentGameActivity(?int $now = null, int $ttl = CHIM_GAME_ACTIVITY_TTL): bool
+{
+    $now = $now ?? time();
+    $ttl = max(1, $ttl);
+    $lastActivity = chimGetLastGameActivityTimestamp();
+
+    return $lastActivity > 0 && ($now - $lastActivity) <= $ttl;
+}
+
+function chimIsGameRequestActive(): bool
+{
+    return !empty($GLOBALS['CHIM_GAME_REQUEST_ACTIVE']) || !empty($GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE']);
+}

--- a/lib/player2_health.php
+++ b/lib/player2_health.php
@@ -1,7 +1,10 @@
 <?php
 
-const CHIM_PLAYER2_HEALTH_ACTIVITY_TTL = 180;
-const CHIM_PLAYER2_HEALTH_ACTIVITY_WRITE_INTERVAL = 15;
+require_once __DIR__ . '/game_activity.php';
+
+// Compatibility aliases for integrations that still reference the original Player2-owned activity constants.
+const CHIM_PLAYER2_HEALTH_ACTIVITY_TTL = CHIM_GAME_ACTIVITY_TTL;
+const CHIM_PLAYER2_HEALTH_ACTIVITY_WRITE_INTERVAL = CHIM_GAME_ACTIVITY_WRITE_INTERVAL;
 const CHIM_PLAYER2_HEALTH_USE_TTL = 300;
 const CHIM_PLAYER2_HEALTH_INTERVAL = 60;
 const CHIM_PLAYER2_HEALTH_LOCK_ID = 873421;
@@ -56,45 +59,22 @@ function chimPlayer2HealthSetOption(string $id, string $value): bool
     ], 'id');
 }
 
+/** @deprecated Use chimMarkGameActivity() for shared game activity. */
 function chimPlayer2HealthMarkGameActivity(?int $now = null): bool
 {
-    $now = $now ?? time();
-    $lastActivity = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'));
-    $newSession = $lastActivity <= 0 || ($now - $lastActivity) > CHIM_PLAYER2_HEALTH_ACTIVITY_TTL;
-
-    if ($newSession) {
-        chimPlayer2HealthSetOption('PLAYER2_GAME_SESSION_STARTED_TS', strval($now));
-    }
-    if ($newSession || ($now - $lastActivity) >= CHIM_PLAYER2_HEALTH_ACTIVITY_WRITE_INTERVAL) {
-        chimPlayer2HealthSetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', strval($now));
-    }
-    $GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE'] = true;
-
-    return $newSession;
-}
-
-/**
- * Report whether HerikaServer has received normal game traffic recently.
- */
-function chimPlayer2HealthHasRecentGameActivity(?int $now = null, int $ttl = CHIM_PLAYER2_HEALTH_ACTIVITY_TTL): bool
-{
-    $now = $now ?? time();
-    $ttl = max(1, $ttl);
-    $lastActivity = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'));
-
-    return $lastActivity > 0 && ($now - $lastActivity) <= $ttl;
+    return chimMarkGameActivity($now);
 }
 
 function chimPlayer2HealthMarkUsed(string $connectorUrl, ?int $now = null): bool
 {
-    if (empty($GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE'])) {
+    if (!chimIsGameRequestActive()) {
         return false;
     }
 
     $now = $now ?? time();
-    $sessionStarted = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_SESSION_STARTED_TS', '0'));
-    $lastActivity = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'));
-    if ($sessionStarted <= 0 || $lastActivity <= 0 || ($now - $lastActivity) > CHIM_PLAYER2_HEALTH_ACTIVITY_TTL) {
+    $sessionStarted = chimGetGameActivitySessionStartedTimestamp();
+    $lastActivity = chimGetLastGameActivityTimestamp();
+    if ($sessionStarted <= 0 || $lastActivity <= 0 || ($now - $lastActivity) > CHIM_GAME_ACTIVITY_TTL) {
         return false;
     }
 
@@ -115,7 +95,7 @@ function chimPlayer2HealthShouldPing(array $state, int $now): bool
 
     return $healthUrl !== ''
         && $lastActivity > 0
-        && ($now - $lastActivity) <= CHIM_PLAYER2_HEALTH_ACTIVITY_TTL
+        && ($now - $lastActivity) <= CHIM_GAME_ACTIVITY_TTL
         && $sessionStarted > 0
         && $activeSession === $sessionStarted
         && $lastUsed > 0
@@ -178,8 +158,8 @@ function chimPlayer2HealthTick(?int $now = null, ?callable $transport = null): b
 
     $now = $now ?? time();
     $state = [
-        'last_activity' => chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'),
-        'session_started' => chimPlayer2HealthGetOption('PLAYER2_GAME_SESSION_STARTED_TS', '0'),
+        'last_activity' => chimGetLastGameActivityTimestamp(),
+        'session_started' => chimGetGameActivitySessionStartedTimestamp(),
         'active_session' => chimPlayer2HealthGetOption('PLAYER2_HEALTH_ACTIVE_SESSION_TS', '0'),
         'last_used' => chimPlayer2HealthGetOption('PLAYER2_HEALTH_LAST_USED_TS', '0'),
         'last_attempt' => chimPlayer2HealthGetOption('PLAYER2_HEALTH_LAST_ATTEMPT_TS', '0'),

--- a/lib/player2_health.php
+++ b/lib/player2_health.php
@@ -73,6 +73,18 @@ function chimPlayer2HealthMarkGameActivity(?int $now = null): bool
     return $newSession;
 }
 
+/**
+ * Report whether HerikaServer has received normal game traffic recently.
+ */
+function chimPlayer2HealthHasRecentGameActivity(?int $now = null, int $ttl = CHIM_PLAYER2_HEALTH_ACTIVITY_TTL): bool
+{
+    $now = $now ?? time();
+    $ttl = max(1, $ttl);
+    $lastActivity = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'));
+
+    return $lastActivity > 0 && ($now - $lastActivity) <= $ttl;
+}
+
 function chimPlayer2HealthMarkUsed(string $connectorUrl, ?int $now = null): bool
 {
     if (empty($GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE'])) {

--- a/main.php
+++ b/main.php
@@ -33,7 +33,7 @@ chimRuntimeBootstrap($path, [
     'load_player_name' => true,
     'load_narrator' => true,
 ]);
-require_once($path . "lib/player2_health.php");
+require_once($path . "lib/game_activity.php");
 require_once($path . "lib/background_processor.php");
 if (!headers_sent() && function_exists('chimGetNarratorDisplayNameHeaderValue')) {
     header('X-Narrator-Display-Name: ' . chimGetNarratorDisplayNameHeaderValue());
@@ -165,8 +165,8 @@ $db = $GLOBALS["db"] ?? new sql();
 $GLOBALS["db"] = $db;
 
 if (PHP_SAPI !== 'cli' && !getenv('PHPUNIT_TEST') && $gameRequest[0] !== 'request') {
-    $player2NewGameSession = chimPlayer2HealthMarkGameActivity();
-    if ($player2NewGameSession && function_exists('herikaEnsureBackgroundProcessorRunning')) {
+    $newGameActivitySession = chimMarkGameActivity();
+    if ($newGameActivitySession && function_exists('herikaEnsureBackgroundProcessorRunning')) {
         herikaEnsureBackgroundProcessorRunning(false);
     }
 }

--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -11,6 +11,12 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         $GLOBALS["db"] = new sql();
     }
 
+    require_once($enginePath . "lib/player2_health.php");
+    if (!chimPlayer2HealthHasRecentGameActivity()) {
+        Logger::debug("[MIDDLETERM] Skipping scheduled LLM work because no recent game activity was detected");
+        return;
+    }
+
     require_once($enginePath . "prompts/command_prompt.php");
     require_once($enginePath . "lib/chat_helper_functions.php");
     require_once($enginePath . "lib/data_functions.php");

--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -11,8 +11,8 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         $GLOBALS["db"] = new sql();
     }
 
-    require_once($enginePath . "lib/player2_health.php");
-    if (!chimPlayer2HealthHasRecentGameActivity()) {
+    require_once($enginePath . "lib/game_activity.php");
+    if (!chimHasRecentGameActivity()) {
         Logger::debug("[MIDDLETERM] Skipping scheduled LLM work because no recent game activity was detected");
         return;
     }


### PR DESCRIPTION
## Problem

HerikaServer's scheduled middle-term service keeps running after Skyrim stops sending game traffic. Its global summary and middle-term connector defaults can use DeepSeek V4 Pro independently of every profile, so the background loop can continue consuming OpenRouter credits while the game is closed.

Discord source: [Open Discord thread](https://discord.com/channels/1109612896482246826/1537526616870363217/1537526616870363217)

## Changes

- move shared Skyrim activity tracking into `lib/game_activity.php`
- use global `chimMarkGameActivity()` and `chimHasRecentGameActivity()` APIs from the request path and scheduled middle-term gate
- stop scheduled middle-term memory, Background Life, and memory-compaction LLM work after the existing three-minute activity window expires
- resume the scheduler automatically when normal game traffic updates the same activity marker
- keep Player2 health as a consumer of the shared activity session instead of its owner
- mirror the legacy Player2 option keys and retain compatibility aliases during the rename

The timing and scheduler behavior are unchanged. No schema or configuration migration is required.

## Validation

- PHP lint passed for `lib/game_activity.php`, `lib/player2_health.php`, `main.php`, and `service/processors/middleterm/entrypoint.php`
- existing `Player2HealthTest`: 2 tests, 7 assertions passed
- focused activity probe: 12 assertions passed for generic state, legacy fallback/mirroring, fresh, stale, and missing activity
- focused Player2 integration probe passed for generic request activity and session arming
- focused inactive scheduler probe confirmed return at the generic activity gate before LLM work
- `git diff --check`
- CHIM unstable push guard: PR required for sensitive runtime paths, guarded-author history, and open-PR overlap

## Deployment and limits

The original two-file implementation was deployed locally and verified through two inactive scheduler cycles. This naming/ownership refactor adds a new shared module and has **not** been redeployed, so the local WSL runtime does not yet represent this commit.

Active-game resume and in-game behavior remain untested. Draft PR #690 touches the same scheduler file and draft PR #704 touches `main.php`; GitHub currently reports this branch as cleanly mergeable, but either PR may require rechecking if its branch changes.