### PR TITLE
Parse chat mode shortcuts server-side

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -2885,7 +2885,6 @@ function chimDecodePlayerRoutingSnapshotField($rawField)
         "audience" => "",
         "present_actors" => [],
         "chat_shortcut_routed" => false,
-        "execution_mode" => "",
     ];
     $rawField = trim((string)$rawField);
     if ($rawField === "") {
@@ -2912,21 +2911,6 @@ function chimDecodePlayerRoutingSnapshotField($rawField)
     $result["chat_shortcut_routed"] =
         ($payload["source"] ?? "") === "plugin_player_routing_v2" &&
         ($payload["chat_shortcut_routed"] ?? false) === true;
-    $executionMode = strtoupper(trim((string)($payload["execution_mode"] ?? "")));
-    if (in_array($executionMode, [
-        "STANDARD",
-        "WHISPER",
-        "CLOSE",
-        "SHOUT",
-        "NARRATOR",
-        "DIRECTOR",
-        "CHEATMODE",
-        "AUTOCHAT",
-        "INJECTION_LOG",
-        "INJECTION_CHAT",
-    ], true)) {
-        $result["execution_mode"] = $executionMode;
-    }
     return $result;
 }
 

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -2837,11 +2837,54 @@ function chimNormalizePresentActors($actors)
     return $normalized;
 }
 
+// Parse a one-shot chat shortcut while leaving the saved CHIM mode unchanged.
+function chimParseChatModeShortcut($message)
+{
+    $message = (string)$message;
+    $rules = [
+        ["prefix" => "((", "mode" => "INJECTION_LOG", "suffix" => "))"],
+        ["prefix" => "~~", "mode" => "CLOSE", "suffix" => ""],
+        ["prefix" => "!!", "mode" => "SHOUT", "suffix" => ""],
+        ["prefix" => "**", "mode" => "AUTOCHAT", "suffix" => ""],
+        ["prefix" => "~", "mode" => "WHISPER", "suffix" => ""],
+        ["prefix" => "@", "mode" => "NARRATOR", "suffix" => ""],
+        ["prefix" => ">", "mode" => "DIRECTOR", "suffix" => ""],
+        ["prefix" => "#", "mode" => "CHEATMODE", "suffix" => ""],
+        ["prefix" => "(", "mode" => "INJECTION_CHAT", "suffix" => ")"],
+    ];
+
+    foreach ($rules as $rule) {
+        if (!str_starts_with($message, $rule["prefix"])) {
+            continue;
+        }
+
+        $content = trim(substr($message, strlen($rule["prefix"])));
+        if ($rule["suffix"] !== "" && str_ends_with($content, $rule["suffix"])) {
+            $content = trim(substr($content, 0, -strlen($rule["suffix"])));
+        }
+
+        return [
+            "matched" => true,
+            "mode" => $rule["mode"],
+            "symbol" => $rule["prefix"],
+            "content" => $content,
+        ];
+    }
+
+    return [
+        "matched" => false,
+        "mode" => "",
+        "symbol" => "",
+        "content" => $message,
+    ];
+}
+
 function chimDecodePlayerRoutingSnapshotField($rawField)
 {
     $result = [
         "audience" => "",
         "present_actors" => [],
+        "chat_shortcut_routed" => false,
         "execution_mode" => "",
     ];
     $rawField = trim((string)$rawField);
@@ -2866,6 +2909,9 @@ function chimDecodePlayerRoutingSnapshotField($rawField)
     }
 
     $result["present_actors"] = chimNormalizePresentActors($payload["present_actors"] ?? []);
+    $result["chat_shortcut_routed"] =
+        ($payload["source"] ?? "") === "plugin_player_routing_v2" &&
+        ($payload["chat_shortcut_routed"] ?? false) === true;
     $executionMode = strtoupper(trim((string)($payload["execution_mode"] ?? "")));
     if (in_array($executionMode, [
         "STANDARD",

--- a/main.php
+++ b/main.php
@@ -134,9 +134,13 @@ $gameRequest = explode("|", $receivedData);
 $GLOBALS["gameRequest"] = &$gameRequest;
 unset($GLOBALS["CHIM_TURN_PEOPLE_SNAPSHOT"]);
 unset($GLOBALS["CHIM_REQUEST_EXECUTION_MODE"]);
+unset($GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"]);
 $requestRoutingSnapshot = chimDecodePlayerRoutingSnapshotField($gameRequest[4] ?? "");
 if (($requestRoutingSnapshot["execution_mode"] ?? "") !== "") {
     $GLOBALS["CHIM_REQUEST_EXECUTION_MODE"] = $requestRoutingSnapshot["execution_mode"];
+}
+if (($requestRoutingSnapshot["chat_shortcut_routed"] ?? false) === true) {
+    $GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"] = true;
 }
 
 

--- a/main.php
+++ b/main.php
@@ -133,12 +133,8 @@ MAIN FLOW
 $gameRequest = explode("|", $receivedData);
 $GLOBALS["gameRequest"] = &$gameRequest;
 unset($GLOBALS["CHIM_TURN_PEOPLE_SNAPSHOT"]);
-unset($GLOBALS["CHIM_REQUEST_EXECUTION_MODE"]);
 unset($GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"]);
 $requestRoutingSnapshot = chimDecodePlayerRoutingSnapshotField($gameRequest[4] ?? "");
-if (($requestRoutingSnapshot["execution_mode"] ?? "") !== "") {
-    $GLOBALS["CHIM_REQUEST_EXECUTION_MODE"] = $requestRoutingSnapshot["execution_mode"];
-}
 if (($requestRoutingSnapshot["chat_shortcut_routed"] ?? false) === true) {
     $GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"] = true;
 }

--- a/processor/chim_modes.php
+++ b/processor/chim_modes.php
@@ -47,11 +47,40 @@ $EXECUTION_MODE_=$db->fetchOne("SELECT value FROM conf_opts WHERE id='chim_mode'
 $EXECUTION_MODE=isset($EXECUTION_MODE_["value"])?$EXECUTION_MODE_["value"]:"STANDARD";
 
 $EXECUTION_MODE=strtoupper($EXECUTION_MODE);
-// A validated plugin routing snapshot can override the saved mode for this request only.
+$PLAYER_INPUT_REQUEST = in_array(
+    $gameRequest[0],
+    ["inputtext", "inputtext_s", "ginputtext", "ginputtext_s", "narrator_inputtext"],
+    true
+);
+$SYMBOL_MODE_OVERRIDE = false;
 $REQUEST_EXECUTION_MODE = strtoupper(trim((string)($GLOBALS["CHIM_REQUEST_EXECUTION_MODE"] ?? "")));
-if ($REQUEST_EXECUTION_MODE !== "") {
+$CHAT_SHORTCUT_ROUTED = ($GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"] ?? false) === true;
+
+if ($PLAYER_INPUT_REQUEST && $CHAT_SHORTCUT_ROUTED && isset($gameRequest[3]) && is_string($gameRequest[3])) {
+    $speakerSeparator = strpos($gameRequest[3], ":");
+    $speakerPrefix = $speakerSeparator === false ? "" : substr($gameRequest[3], 0, $speakerSeparator + 1);
+    $playerDialogue = $speakerSeparator === false
+        ? $gameRequest[3]
+        : substr($gameRequest[3], $speakerSeparator + 1);
+    $symbolMode = chimParseChatModeShortcut($playerDialogue);
+
+    if ($symbolMode["matched"]) {
+        if ($symbolMode["content"] === "") {
+            Logger::warn("[chim_modes] Ignored symbol-only player submission");
+            terminate();
+        }
+
+        $SYMBOL_MODE_OVERRIDE = true;
+        $EXECUTION_MODE = $symbolMode["mode"];
+        $gameRequest[3] = $speakerPrefix . $symbolMode["content"];
+    }
+}
+
+// CHIM 3.2.4 stripped symbols client-side, so retain its validated request mode as a fallback.
+if (!$SYMBOL_MODE_OVERRIDE && $REQUEST_EXECUTION_MODE !== "") {
     $EXECUTION_MODE = $REQUEST_EXECUTION_MODE;
 }
+$REQUEST_LOCAL_MODE_OVERRIDE = $SYMBOL_MODE_OVERRIDE || $REQUEST_EXECUTION_MODE !== "";
 
 // Retire the old free-form Spawn mode without leaving upgraded installs stuck in it.
 if ($EXECUTION_MODE === "SPAWN") {
@@ -66,7 +95,7 @@ if ($EXECUTION_MODE === "SPAWN") {
     $EXECUTION_MODE = "STANDARD";
 }
 
-if (!in_array($gameRequest[0],["inputtext","inputtext_s","ginputtext","ginputtext_s","narrator_inputtext"])) {
+if (!$PLAYER_INPUT_REQUEST) {
     $EXECUTION_MODE="STANDARD";
 }
 
@@ -91,27 +120,28 @@ if ($EXECUTION_MODE=="STANDARD") {
     
     ignore_user_abort(true);
 
-    // Expected format input|ts|gamets|PLAYER_NAME::
-    $gameRequest = explode("|", $receivedData);
-    
-    $userWish=explode(":",$gameRequest[3]);
+    $userWish = preg_replace('/^[^:]+:\s*/', '', $gameRequest[3]);
     $output='';
-    $instruction=escapeshellarg("{$userWish[1]}");
-    $db->upsertRow(
-        'conf_opts',
-        array(
-            'id' => 'chim_mode',
-            'value' => 'STANDARD'
-        ),
-        "id='chim_mode'"
-    );
+    $instruction=escapeshellarg($userWish);
+    if (!$REQUEST_LOCAL_MODE_OVERRIDE) {
+        $db->upsertRow(
+            'conf_opts',
+            array(
+                'id' => 'chim_mode',
+                'value' => 'STANDARD'
+            ),
+            "id='chim_mode'"
+        );
+    }
     exec("php /var/www/html/HerikaServer/service/manager.php rolemaster instruction \"$instruction\" notify", $output, $returnCode);
     terminate();
 
 } else if ($EXECUTION_MODE=="CHEATMODE") {
     // Process all input as cheat commands
     $cleaned_player_dialogue = preg_replace('/^[^:]+:/', '', $gameRequest[3]);
-    $newSpeech = strtr($cleaned_player_dialogue, ["#"=>""]);
+    $newSpeech = $REQUEST_LOCAL_MODE_OVERRIDE
+        ? $cleaned_player_dialogue
+        : strtr($cleaned_player_dialogue, ["#"=>""]);
     $gameRequest[0] = "cheatmode";
     $gameRequest[3] = "<$newSpeech>";
     $GLOBALS["FUNCTIONS_ARE_ENABLED"] = true;

--- a/processor/chim_modes.php
+++ b/processor/chim_modes.php
@@ -53,7 +53,6 @@ $PLAYER_INPUT_REQUEST = in_array(
     true
 );
 $SYMBOL_MODE_OVERRIDE = false;
-$REQUEST_EXECUTION_MODE = strtoupper(trim((string)($GLOBALS["CHIM_REQUEST_EXECUTION_MODE"] ?? "")));
 $CHAT_SHORTCUT_ROUTED = ($GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"] ?? false) === true;
 
 if ($PLAYER_INPUT_REQUEST && $CHAT_SHORTCUT_ROUTED && isset($gameRequest[3]) && is_string($gameRequest[3])) {
@@ -75,12 +74,7 @@ if ($PLAYER_INPUT_REQUEST && $CHAT_SHORTCUT_ROUTED && isset($gameRequest[3]) && 
         $gameRequest[3] = $speakerPrefix . $symbolMode["content"];
     }
 }
-
-// CHIM 3.2.4 stripped symbols client-side, so retain its validated request mode as a fallback.
-if (!$SYMBOL_MODE_OVERRIDE && $REQUEST_EXECUTION_MODE !== "") {
-    $EXECUTION_MODE = $REQUEST_EXECUTION_MODE;
-}
-$REQUEST_LOCAL_MODE_OVERRIDE = $SYMBOL_MODE_OVERRIDE || $REQUEST_EXECUTION_MODE !== "";
+$REQUEST_LOCAL_MODE_OVERRIDE = $SYMBOL_MODE_OVERRIDE;
 
 // Retire the old free-form Spawn mode without leaving upgraded installs stuck in it.
 if ($EXECUTION_MODE === "SPAWN") {

--- a/unittests/tests/AsteriskParsingTest.php
+++ b/unittests/tests/AsteriskParsingTest.php
@@ -37,6 +37,41 @@ final class AsteriskParsingTest extends TestCase
         );
     }
 
+    public function testChatModeShortcutsAreParsedServerSide(): void
+    {
+        $cases = [
+            '~ Keep this quiet' => ['WHISPER', 'Keep this quiet'],
+            '~~ Only you should hear this' => ['CLOSE', 'Only you should hear this'],
+            '!! Everyone, run!' => ['SHOUT', 'Everyone, run!'],
+            '@ Describe the room' => ['NARRATOR', 'Describe the room'],
+            '> Have Lydia inspect the doorway' => ['DIRECTOR', 'Have Lydia inspect the doorway'],
+            '# Give me 1000 gold' => ['CHEATMODE', 'Give me 1000 gold'],
+            '** Warn them about the dragon' => ['AUTOCHAT', 'Warn them about the dragon'],
+            '((A dragon lands nearby.))' => ['INJECTION_LOG', 'A dragon lands nearby.'],
+            '(A dragon lands nearby.)' => ['INJECTION_CHAT', 'A dragon lands nearby.'],
+        ];
+
+        foreach ($cases as $input => [$mode, $content]) {
+            $parsed = chimParseChatModeShortcut($input);
+
+            $this->assertTrue($parsed['matched'], $input);
+            $this->assertSame($mode, $parsed['mode'], $input);
+            $this->assertSame($content, $parsed['content'], $input);
+        }
+    }
+
+    public function testChatModeShortcutParserPreservesPlainAndSymbolOnlyInput(): void
+    {
+        $plain = chimParseChatModeShortcut('Hello there');
+        $symbolOnly = chimParseChatModeShortcut('~~   ');
+
+        $this->assertFalse($plain['matched']);
+        $this->assertSame('Hello there', $plain['content']);
+        $this->assertTrue($symbolOnly['matched']);
+        $this->assertSame('CLOSE', $symbolOnly['mode']);
+        $this->assertSame('', $symbolOnly['content']);
+    }
+
     public function testFullWrappedNarrationBlockDoesNotSplitMidReply(): void
     {
         $wrappedReply = "*A slight chuckle escapes me as I straighten a few more apples, my eyes crinkling at the corners. 'Wow,' you say? I hope that's a good 'wow,' Your Majesty. My produce is usually met with enthusiasm for its quality, not surprise. Though, I suppose a king might have seen grander displays of... apples.*";

--- a/unittests/tests/PlayerPresenceSnapshotTest.php
+++ b/unittests/tests/PlayerPresenceSnapshotTest.php
@@ -88,30 +88,28 @@ final class PlayerPresenceSnapshotTest extends TestCase
         $this->assertSame([], $snapshot['present_actors']);
     }
 
-    public function testRequestMetadataIsDecodedFromRoutingSnapshot(): void
+    public function testChatShortcutRoutingMarkerIsDecodedFromRoutingSnapshot(): void
     {
         $encoded = base64_encode((string)json_encode([
             'source' => 'plugin_player_routing_v2',
             'chat_shortcut_routed' => true,
+        ]));
+
+        $snapshot = chimDecodePlayerRoutingSnapshotField($encoded);
+
+        $this->assertTrue($snapshot['chat_shortcut_routed']);
+        $this->assertSame('', $snapshot['audience']);
+    }
+
+    public function testRequestExecutionModeIsIgnored(): void
+    {
+        $encoded = base64_encode((string)json_encode([
             'execution_mode' => 'whisper',
         ]));
 
         $snapshot = chimDecodePlayerRoutingSnapshotField($encoded);
 
-        $this->assertSame('WHISPER', $snapshot['execution_mode']);
-        $this->assertTrue($snapshot['chat_shortcut_routed']);
-        $this->assertSame('', $snapshot['audience']);
-    }
-
-    public function testUnknownRequestExecutionModeIsIgnored(): void
-    {
-        $encoded = base64_encode((string)json_encode([
-            'execution_mode' => 'unsupported-mode',
-        ]));
-
-        $snapshot = chimDecodePlayerRoutingSnapshotField($encoded);
-
-        $this->assertSame('', $snapshot['execution_mode']);
+        $this->assertArrayNotHasKey('execution_mode', $snapshot);
     }
 
     public function testDirectivePeopleIncludeSelectedSpeakerAndExplicitListener(): void

--- a/unittests/tests/PlayerPresenceSnapshotTest.php
+++ b/unittests/tests/PlayerPresenceSnapshotTest.php
@@ -88,16 +88,18 @@ final class PlayerPresenceSnapshotTest extends TestCase
         $this->assertSame([], $snapshot['present_actors']);
     }
 
-    public function testRequestExecutionModeIsDecodedFromRoutingSnapshot(): void
+    public function testRequestMetadataIsDecodedFromRoutingSnapshot(): void
     {
         $encoded = base64_encode((string)json_encode([
             'source' => 'plugin_player_routing_v2',
+            'chat_shortcut_routed' => true,
             'execution_mode' => 'whisper',
         ]));
 
         $snapshot = chimDecodePlayerRoutingSnapshotField($encoded);
 
         $this->assertSame('WHISPER', $snapshot['execution_mode']);
+        $this->assertTrue($snapshot['chat_shortcut_routed']);
         $this->assertSame('', $snapshot['audience']);
     }
 


### PR DESCRIPTION
## Summary

- parse validated one-shot chat symbols in HerikaServer
- strip shortcut wrappers and apply request-local modes without changing the saved CHIM mode
- require the plugin's boolean chat_shortcut_routed marker before parsing raw symbols
- ignore client-provided execution_mode values so the server is the only mode authority
- keep the Director shortcut request-local instead of resetting the saved mode to Standard

## Paired change

- Requires Dwemer-Dynamics/CHIM#133

## Validation

- PHP syntax checks passed for all five changed files
- focused PHPUnit suite passed: 55 tests, 127 assertions
- git diff --check passed

## Review note

- The unstable push guard found file overlap with abeiro/HerikaServer#701 in main.php. This branch is isolated and should be reviewed for integration order.

## Limits

- Not deployed
- Not tested in game
- Director and Event Inject external side effects were not invoked by local runtime probes