### PR TITLE
Promote latest unstable changes to dev

### DIFF
--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -2885,7 +2885,6 @@ function chimDecodePlayerRoutingSnapshotField($rawField)
         "audience" => "",
         "present_actors" => [],
         "chat_shortcut_routed" => false,
-        "execution_mode" => "",
     ];
     $rawField = trim((string)$rawField);
     if ($rawField === "") {
@@ -2912,21 +2911,6 @@ function chimDecodePlayerRoutingSnapshotField($rawField)
     $result["chat_shortcut_routed"] =
         ($payload["source"] ?? "") === "plugin_player_routing_v2" &&
         ($payload["chat_shortcut_routed"] ?? false) === true;
-    $executionMode = strtoupper(trim((string)($payload["execution_mode"] ?? "")));
-    if (in_array($executionMode, [
-        "STANDARD",
-        "WHISPER",
-        "CLOSE",
-        "SHOUT",
-        "NARRATOR",
-        "DIRECTOR",
-        "CHEATMODE",
-        "AUTOCHAT",
-        "INJECTION_LOG",
-        "INJECTION_CHAT",
-    ], true)) {
-        $result["execution_mode"] = $executionMode;
-    }
     return $result;
 }
 

--- a/lib/chat_helper_functions.php
+++ b/lib/chat_helper_functions.php
@@ -2837,11 +2837,54 @@ function chimNormalizePresentActors($actors)
     return $normalized;
 }
 
+// Parse a one-shot chat shortcut while leaving the saved CHIM mode unchanged.
+function chimParseChatModeShortcut($message)
+{
+    $message = (string)$message;
+    $rules = [
+        ["prefix" => "((", "mode" => "INJECTION_LOG", "suffix" => "))"],
+        ["prefix" => "~~", "mode" => "CLOSE", "suffix" => ""],
+        ["prefix" => "!!", "mode" => "SHOUT", "suffix" => ""],
+        ["prefix" => "**", "mode" => "AUTOCHAT", "suffix" => ""],
+        ["prefix" => "~", "mode" => "WHISPER", "suffix" => ""],
+        ["prefix" => "@", "mode" => "NARRATOR", "suffix" => ""],
+        ["prefix" => ">", "mode" => "DIRECTOR", "suffix" => ""],
+        ["prefix" => "#", "mode" => "CHEATMODE", "suffix" => ""],
+        ["prefix" => "(", "mode" => "INJECTION_CHAT", "suffix" => ")"],
+    ];
+
+    foreach ($rules as $rule) {
+        if (!str_starts_with($message, $rule["prefix"])) {
+            continue;
+        }
+
+        $content = trim(substr($message, strlen($rule["prefix"])));
+        if ($rule["suffix"] !== "" && str_ends_with($content, $rule["suffix"])) {
+            $content = trim(substr($content, 0, -strlen($rule["suffix"])));
+        }
+
+        return [
+            "matched" => true,
+            "mode" => $rule["mode"],
+            "symbol" => $rule["prefix"],
+            "content" => $content,
+        ];
+    }
+
+    return [
+        "matched" => false,
+        "mode" => "",
+        "symbol" => "",
+        "content" => $message,
+    ];
+}
+
 function chimDecodePlayerRoutingSnapshotField($rawField)
 {
     $result = [
         "audience" => "",
         "present_actors" => [],
+        "chat_shortcut_routed" => false,
         "execution_mode" => "",
     ];
     $rawField = trim((string)$rawField);
@@ -2866,6 +2909,9 @@ function chimDecodePlayerRoutingSnapshotField($rawField)
     }
 
     $result["present_actors"] = chimNormalizePresentActors($payload["present_actors"] ?? []);
+    $result["chat_shortcut_routed"] =
+        ($payload["source"] ?? "") === "plugin_player_routing_v2" &&
+        ($payload["chat_shortcut_routed"] ?? false) === true;
     $executionMode = strtoupper(trim((string)($payload["execution_mode"] ?? "")));
     if (in_array($executionMode, [
         "STANDARD",

--- a/lib/game_activity.php
+++ b/lib/game_activity.php
@@ -1,0 +1,92 @@
+<?php
+
+const CHIM_GAME_ACTIVITY_TTL = 180;
+const CHIM_GAME_ACTIVITY_WRITE_INTERVAL = 15;
+
+function chimGameActivityGetOption(string $id, string $default = ''): string
+{
+    $db = $GLOBALS['db'] ?? null;
+    if (!$db) {
+        return $default;
+    }
+
+    $escapedId = $db->escape($id);
+    $row = $db->fetchOne("SELECT value FROM conf_opts WHERE id='{$escapedId}' LIMIT 1");
+    return is_array($row) && array_key_exists('value', $row) ? strval($row['value']) : $default;
+}
+
+function chimGameActivitySetOption(string $id, string $value): bool
+{
+    $db = $GLOBALS['db'] ?? null;
+    if (!$db) {
+        return false;
+    }
+
+    return (bool)$db->upsertRowOnConflict('conf_opts', [
+        'id' => $id,
+        'value' => $value,
+    ], 'id');
+}
+
+function chimGameActivityReadTimestamp(string $id, string $legacyId): int
+{
+    $timestamp = intval(chimGameActivityGetOption($id, '0'));
+    if ($timestamp <= 0) {
+        $timestamp = intval(chimGameActivityGetOption($legacyId, '0'));
+    }
+
+    return $timestamp;
+}
+
+function chimGameActivityWriteTimestamp(string $id, string $legacyId, int $timestamp): void
+{
+    $value = strval($timestamp);
+    chimGameActivitySetOption($id, $value);
+    chimGameActivitySetOption($legacyId, $value);
+}
+
+function chimGetLastGameActivityTimestamp(): int
+{
+    return chimGameActivityReadTimestamp('CHIM_GAME_LAST_ACTIVITY_TS', 'PLAYER2_GAME_LAST_ACTIVITY_TS');
+}
+
+function chimGetGameActivitySessionStartedTimestamp(): int
+{
+    return chimGameActivityReadTimestamp('CHIM_GAME_SESSION_STARTED_TS', 'PLAYER2_GAME_SESSION_STARTED_TS');
+}
+
+/**
+ * Mark normal Skyrim traffic and report whether it starts a new activity session.
+ */
+function chimMarkGameActivity(?int $now = null): bool
+{
+    $now = $now ?? time();
+    $lastActivity = chimGetLastGameActivityTimestamp();
+    $newSession = $lastActivity <= 0 || ($now - $lastActivity) > CHIM_GAME_ACTIVITY_TTL;
+
+    if ($newSession) {
+        chimGameActivityWriteTimestamp('CHIM_GAME_SESSION_STARTED_TS', 'PLAYER2_GAME_SESSION_STARTED_TS', $now);
+    }
+    if ($newSession || ($now - $lastActivity) >= CHIM_GAME_ACTIVITY_WRITE_INTERVAL) {
+        chimGameActivityWriteTimestamp('CHIM_GAME_LAST_ACTIVITY_TS', 'PLAYER2_GAME_LAST_ACTIVITY_TS', $now);
+    }
+
+    $GLOBALS['CHIM_GAME_REQUEST_ACTIVE'] = true;
+    $GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE'] = true;
+
+    return $newSession;
+}
+
+function chimHasRecentGameActivity(?int $now = null, int $ttl = CHIM_GAME_ACTIVITY_TTL): bool
+{
+    $now = $now ?? time();
+    $ttl = max(1, $ttl);
+    $lastActivity = chimGetLastGameActivityTimestamp();
+
+    return $lastActivity > 0 && ($now - $lastActivity) <= $ttl;
+}
+
+function chimIsGameRequestActive(): bool
+{
+    return !empty($GLOBALS['CHIM_GAME_REQUEST_ACTIVE']) || !empty($GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE']);
+}

--- a/lib/player2_health.php
+++ b/lib/player2_health.php
@@ -1,7 +1,10 @@
 <?php
 
-const CHIM_PLAYER2_HEALTH_ACTIVITY_TTL = 180;
-const CHIM_PLAYER2_HEALTH_ACTIVITY_WRITE_INTERVAL = 15;
+require_once __DIR__ . '/game_activity.php';
+
+// Compatibility aliases for integrations that still reference the original Player2-owned activity constants.
+const CHIM_PLAYER2_HEALTH_ACTIVITY_TTL = CHIM_GAME_ACTIVITY_TTL;
+const CHIM_PLAYER2_HEALTH_ACTIVITY_WRITE_INTERVAL = CHIM_GAME_ACTIVITY_WRITE_INTERVAL;
 const CHIM_PLAYER2_HEALTH_USE_TTL = 300;
 const CHIM_PLAYER2_HEALTH_INTERVAL = 60;
 const CHIM_PLAYER2_HEALTH_LOCK_ID = 873421;
@@ -56,45 +59,22 @@ function chimPlayer2HealthSetOption(string $id, string $value): bool
     ], 'id');
 }
 
+/** @deprecated Use chimMarkGameActivity() for shared game activity. */
 function chimPlayer2HealthMarkGameActivity(?int $now = null): bool
 {
-    $now = $now ?? time();
-    $lastActivity = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'));
-    $newSession = $lastActivity <= 0 || ($now - $lastActivity) > CHIM_PLAYER2_HEALTH_ACTIVITY_TTL;
-
-    if ($newSession) {
-        chimPlayer2HealthSetOption('PLAYER2_GAME_SESSION_STARTED_TS', strval($now));
-    }
-    if ($newSession || ($now - $lastActivity) >= CHIM_PLAYER2_HEALTH_ACTIVITY_WRITE_INTERVAL) {
-        chimPlayer2HealthSetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', strval($now));
-    }
-    $GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE'] = true;
-
-    return $newSession;
-}
-
-/**
- * Report whether HerikaServer has received normal game traffic recently.
- */
-function chimPlayer2HealthHasRecentGameActivity(?int $now = null, int $ttl = CHIM_PLAYER2_HEALTH_ACTIVITY_TTL): bool
-{
-    $now = $now ?? time();
-    $ttl = max(1, $ttl);
-    $lastActivity = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'));
-
-    return $lastActivity > 0 && ($now - $lastActivity) <= $ttl;
+    return chimMarkGameActivity($now);
 }
 
 function chimPlayer2HealthMarkUsed(string $connectorUrl, ?int $now = null): bool
 {
-    if (empty($GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE'])) {
+    if (!chimIsGameRequestActive()) {
         return false;
     }
 
     $now = $now ?? time();
-    $sessionStarted = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_SESSION_STARTED_TS', '0'));
-    $lastActivity = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'));
-    if ($sessionStarted <= 0 || $lastActivity <= 0 || ($now - $lastActivity) > CHIM_PLAYER2_HEALTH_ACTIVITY_TTL) {
+    $sessionStarted = chimGetGameActivitySessionStartedTimestamp();
+    $lastActivity = chimGetLastGameActivityTimestamp();
+    if ($sessionStarted <= 0 || $lastActivity <= 0 || ($now - $lastActivity) > CHIM_GAME_ACTIVITY_TTL) {
         return false;
     }
 
@@ -115,7 +95,7 @@ function chimPlayer2HealthShouldPing(array $state, int $now): bool
 
     return $healthUrl !== ''
         && $lastActivity > 0
-        && ($now - $lastActivity) <= CHIM_PLAYER2_HEALTH_ACTIVITY_TTL
+        && ($now - $lastActivity) <= CHIM_GAME_ACTIVITY_TTL
         && $sessionStarted > 0
         && $activeSession === $sessionStarted
         && $lastUsed > 0
@@ -178,8 +158,8 @@ function chimPlayer2HealthTick(?int $now = null, ?callable $transport = null): b
 
     $now = $now ?? time();
     $state = [
-        'last_activity' => chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'),
-        'session_started' => chimPlayer2HealthGetOption('PLAYER2_GAME_SESSION_STARTED_TS', '0'),
+        'last_activity' => chimGetLastGameActivityTimestamp(),
+        'session_started' => chimGetGameActivitySessionStartedTimestamp(),
         'active_session' => chimPlayer2HealthGetOption('PLAYER2_HEALTH_ACTIVE_SESSION_TS', '0'),
         'last_used' => chimPlayer2HealthGetOption('PLAYER2_HEALTH_LAST_USED_TS', '0'),
         'last_attempt' => chimPlayer2HealthGetOption('PLAYER2_HEALTH_LAST_ATTEMPT_TS', '0'),

--- a/lib/player2_health.php
+++ b/lib/player2_health.php
@@ -73,6 +73,18 @@ function chimPlayer2HealthMarkGameActivity(?int $now = null): bool
     return $newSession;
 }
 
+/**
+ * Report whether HerikaServer has received normal game traffic recently.
+ */
+function chimPlayer2HealthHasRecentGameActivity(?int $now = null, int $ttl = CHIM_PLAYER2_HEALTH_ACTIVITY_TTL): bool
+{
+    $now = $now ?? time();
+    $ttl = max(1, $ttl);
+    $lastActivity = intval(chimPlayer2HealthGetOption('PLAYER2_GAME_LAST_ACTIVITY_TS', '0'));
+
+    return $lastActivity > 0 && ($now - $lastActivity) <= $ttl;
+}
+
 function chimPlayer2HealthMarkUsed(string $connectorUrl, ?int $now = null): bool
 {
     if (empty($GLOBALS['PLAYER2_GAME_REQUEST_ACTIVE'])) {

--- a/main.php
+++ b/main.php
@@ -134,9 +134,13 @@ $gameRequest = explode("|", $receivedData);
 $GLOBALS["gameRequest"] = &$gameRequest;
 unset($GLOBALS["CHIM_TURN_PEOPLE_SNAPSHOT"]);
 unset($GLOBALS["CHIM_REQUEST_EXECUTION_MODE"]);
+unset($GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"]);
 $requestRoutingSnapshot = chimDecodePlayerRoutingSnapshotField($gameRequest[4] ?? "");
 if (($requestRoutingSnapshot["execution_mode"] ?? "") !== "") {
     $GLOBALS["CHIM_REQUEST_EXECUTION_MODE"] = $requestRoutingSnapshot["execution_mode"];
+}
+if (($requestRoutingSnapshot["chat_shortcut_routed"] ?? false) === true) {
+    $GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"] = true;
 }
 
 

--- a/main.php
+++ b/main.php
@@ -33,7 +33,7 @@ chimRuntimeBootstrap($path, [
     'load_player_name' => true,
     'load_narrator' => true,
 ]);
-require_once($path . "lib/player2_health.php");
+require_once($path . "lib/game_activity.php");
 require_once($path . "lib/background_processor.php");
 if (!headers_sent() && function_exists('chimGetNarratorDisplayNameHeaderValue')) {
     header('X-Narrator-Display-Name: ' . chimGetNarratorDisplayNameHeaderValue());
@@ -165,8 +165,8 @@ $db = $GLOBALS["db"] ?? new sql();
 $GLOBALS["db"] = $db;
 
 if (PHP_SAPI !== 'cli' && !getenv('PHPUNIT_TEST') && $gameRequest[0] !== 'request') {
-    $player2NewGameSession = chimPlayer2HealthMarkGameActivity();
-    if ($player2NewGameSession && function_exists('herikaEnsureBackgroundProcessorRunning')) {
+    $newGameActivitySession = chimMarkGameActivity();
+    if ($newGameActivitySession && function_exists('herikaEnsureBackgroundProcessorRunning')) {
         herikaEnsureBackgroundProcessorRunning(false);
     }
 }

--- a/main.php
+++ b/main.php
@@ -133,12 +133,8 @@ MAIN FLOW
 $gameRequest = explode("|", $receivedData);
 $GLOBALS["gameRequest"] = &$gameRequest;
 unset($GLOBALS["CHIM_TURN_PEOPLE_SNAPSHOT"]);
-unset($GLOBALS["CHIM_REQUEST_EXECUTION_MODE"]);
 unset($GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"]);
 $requestRoutingSnapshot = chimDecodePlayerRoutingSnapshotField($gameRequest[4] ?? "");
-if (($requestRoutingSnapshot["execution_mode"] ?? "") !== "") {
-    $GLOBALS["CHIM_REQUEST_EXECUTION_MODE"] = $requestRoutingSnapshot["execution_mode"];
-}
 if (($requestRoutingSnapshot["chat_shortcut_routed"] ?? false) === true) {
     $GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"] = true;
 }

--- a/processor/chim_modes.php
+++ b/processor/chim_modes.php
@@ -47,11 +47,40 @@ $EXECUTION_MODE_=$db->fetchOne("SELECT value FROM conf_opts WHERE id='chim_mode'
 $EXECUTION_MODE=isset($EXECUTION_MODE_["value"])?$EXECUTION_MODE_["value"]:"STANDARD";
 
 $EXECUTION_MODE=strtoupper($EXECUTION_MODE);
-// A validated plugin routing snapshot can override the saved mode for this request only.
+$PLAYER_INPUT_REQUEST = in_array(
+    $gameRequest[0],
+    ["inputtext", "inputtext_s", "ginputtext", "ginputtext_s", "narrator_inputtext"],
+    true
+);
+$SYMBOL_MODE_OVERRIDE = false;
 $REQUEST_EXECUTION_MODE = strtoupper(trim((string)($GLOBALS["CHIM_REQUEST_EXECUTION_MODE"] ?? "")));
-if ($REQUEST_EXECUTION_MODE !== "") {
+$CHAT_SHORTCUT_ROUTED = ($GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"] ?? false) === true;
+
+if ($PLAYER_INPUT_REQUEST && $CHAT_SHORTCUT_ROUTED && isset($gameRequest[3]) && is_string($gameRequest[3])) {
+    $speakerSeparator = strpos($gameRequest[3], ":");
+    $speakerPrefix = $speakerSeparator === false ? "" : substr($gameRequest[3], 0, $speakerSeparator + 1);
+    $playerDialogue = $speakerSeparator === false
+        ? $gameRequest[3]
+        : substr($gameRequest[3], $speakerSeparator + 1);
+    $symbolMode = chimParseChatModeShortcut($playerDialogue);
+
+    if ($symbolMode["matched"]) {
+        if ($symbolMode["content"] === "") {
+            Logger::warn("[chim_modes] Ignored symbol-only player submission");
+            terminate();
+        }
+
+        $SYMBOL_MODE_OVERRIDE = true;
+        $EXECUTION_MODE = $symbolMode["mode"];
+        $gameRequest[3] = $speakerPrefix . $symbolMode["content"];
+    }
+}
+
+// CHIM 3.2.4 stripped symbols client-side, so retain its validated request mode as a fallback.
+if (!$SYMBOL_MODE_OVERRIDE && $REQUEST_EXECUTION_MODE !== "") {
     $EXECUTION_MODE = $REQUEST_EXECUTION_MODE;
 }
+$REQUEST_LOCAL_MODE_OVERRIDE = $SYMBOL_MODE_OVERRIDE || $REQUEST_EXECUTION_MODE !== "";
 
 // Retire the old free-form Spawn mode without leaving upgraded installs stuck in it.
 if ($EXECUTION_MODE === "SPAWN") {
@@ -66,7 +95,7 @@ if ($EXECUTION_MODE === "SPAWN") {
     $EXECUTION_MODE = "STANDARD";
 }
 
-if (!in_array($gameRequest[0],["inputtext","inputtext_s","ginputtext","ginputtext_s","narrator_inputtext"])) {
+if (!$PLAYER_INPUT_REQUEST) {
     $EXECUTION_MODE="STANDARD";
 }
 
@@ -91,27 +120,28 @@ if ($EXECUTION_MODE=="STANDARD") {
     
     ignore_user_abort(true);
 
-    // Expected format input|ts|gamets|PLAYER_NAME::
-    $gameRequest = explode("|", $receivedData);
-    
-    $userWish=explode(":",$gameRequest[3]);
+    $userWish = preg_replace('/^[^:]+:\s*/', '', $gameRequest[3]);
     $output='';
-    $instruction=escapeshellarg("{$userWish[1]}");
-    $db->upsertRow(
-        'conf_opts',
-        array(
-            'id' => 'chim_mode',
-            'value' => 'STANDARD'
-        ),
-        "id='chim_mode'"
-    );
+    $instruction=escapeshellarg($userWish);
+    if (!$REQUEST_LOCAL_MODE_OVERRIDE) {
+        $db->upsertRow(
+            'conf_opts',
+            array(
+                'id' => 'chim_mode',
+                'value' => 'STANDARD'
+            ),
+            "id='chim_mode'"
+        );
+    }
     exec("php /var/www/html/HerikaServer/service/manager.php rolemaster instruction \"$instruction\" notify", $output, $returnCode);
     terminate();
 
 } else if ($EXECUTION_MODE=="CHEATMODE") {
     // Process all input as cheat commands
     $cleaned_player_dialogue = preg_replace('/^[^:]+:/', '', $gameRequest[3]);
-    $newSpeech = strtr($cleaned_player_dialogue, ["#"=>""]);
+    $newSpeech = $REQUEST_LOCAL_MODE_OVERRIDE
+        ? $cleaned_player_dialogue
+        : strtr($cleaned_player_dialogue, ["#"=>""]);
     $gameRequest[0] = "cheatmode";
     $gameRequest[3] = "<$newSpeech>";
     $GLOBALS["FUNCTIONS_ARE_ENABLED"] = true;

--- a/processor/chim_modes.php
+++ b/processor/chim_modes.php
@@ -53,7 +53,6 @@ $PLAYER_INPUT_REQUEST = in_array(
     true
 );
 $SYMBOL_MODE_OVERRIDE = false;
-$REQUEST_EXECUTION_MODE = strtoupper(trim((string)($GLOBALS["CHIM_REQUEST_EXECUTION_MODE"] ?? "")));
 $CHAT_SHORTCUT_ROUTED = ($GLOBALS["CHIM_CHAT_SHORTCUT_ROUTED"] ?? false) === true;
 
 if ($PLAYER_INPUT_REQUEST && $CHAT_SHORTCUT_ROUTED && isset($gameRequest[3]) && is_string($gameRequest[3])) {
@@ -75,12 +74,7 @@ if ($PLAYER_INPUT_REQUEST && $CHAT_SHORTCUT_ROUTED && isset($gameRequest[3]) && 
         $gameRequest[3] = $speakerPrefix . $symbolMode["content"];
     }
 }
-
-// CHIM 3.2.4 stripped symbols client-side, so retain its validated request mode as a fallback.
-if (!$SYMBOL_MODE_OVERRIDE && $REQUEST_EXECUTION_MODE !== "") {
-    $EXECUTION_MODE = $REQUEST_EXECUTION_MODE;
-}
-$REQUEST_LOCAL_MODE_OVERRIDE = $SYMBOL_MODE_OVERRIDE || $REQUEST_EXECUTION_MODE !== "";
+$REQUEST_LOCAL_MODE_OVERRIDE = $SYMBOL_MODE_OVERRIDE;
 
 // Retire the old free-form Spawn mode without leaving upgraded installs stuck in it.
 if ($EXECUTION_MODE === "SPAWN") {

--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -11,6 +11,12 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         $GLOBALS["db"] = new sql();
     }
 
+    require_once($enginePath . "lib/player2_health.php");
+    if (!chimPlayer2HealthHasRecentGameActivity()) {
+        Logger::debug("[MIDDLETERM] Skipping scheduled LLM work because no recent game activity was detected");
+        return;
+    }
+
     require_once($enginePath . "prompts/command_prompt.php");
     require_once($enginePath . "lib/chat_helper_functions.php");
     require_once($enginePath . "lib/data_functions.php");

--- a/service/processors/middleterm/entrypoint.php
+++ b/service/processors/middleterm/entrypoint.php
@@ -11,8 +11,8 @@ $GLOBALS["TASKS"]["middleterm"]["fn"] = function () {
         $GLOBALS["db"] = new sql();
     }
 
-    require_once($enginePath . "lib/player2_health.php");
-    if (!chimPlayer2HealthHasRecentGameActivity()) {
+    require_once($enginePath . "lib/game_activity.php");
+    if (!chimHasRecentGameActivity()) {
         Logger::debug("[MIDDLETERM] Skipping scheduled LLM work because no recent game activity was detected");
         return;
     }

--- a/unittests/tests/AsteriskParsingTest.php
+++ b/unittests/tests/AsteriskParsingTest.php
@@ -37,6 +37,41 @@ final class AsteriskParsingTest extends TestCase
         );
     }
 
+    public function testChatModeShortcutsAreParsedServerSide(): void
+    {
+        $cases = [
+            '~ Keep this quiet' => ['WHISPER', 'Keep this quiet'],
+            '~~ Only you should hear this' => ['CLOSE', 'Only you should hear this'],
+            '!! Everyone, run!' => ['SHOUT', 'Everyone, run!'],
+            '@ Describe the room' => ['NARRATOR', 'Describe the room'],
+            '> Have Lydia inspect the doorway' => ['DIRECTOR', 'Have Lydia inspect the doorway'],
+            '# Give me 1000 gold' => ['CHEATMODE', 'Give me 1000 gold'],
+            '** Warn them about the dragon' => ['AUTOCHAT', 'Warn them about the dragon'],
+            '((A dragon lands nearby.))' => ['INJECTION_LOG', 'A dragon lands nearby.'],
+            '(A dragon lands nearby.)' => ['INJECTION_CHAT', 'A dragon lands nearby.'],
+        ];
+
+        foreach ($cases as $input => [$mode, $content]) {
+            $parsed = chimParseChatModeShortcut($input);
+
+            $this->assertTrue($parsed['matched'], $input);
+            $this->assertSame($mode, $parsed['mode'], $input);
+            $this->assertSame($content, $parsed['content'], $input);
+        }
+    }
+
+    public function testChatModeShortcutParserPreservesPlainAndSymbolOnlyInput(): void
+    {
+        $plain = chimParseChatModeShortcut('Hello there');
+        $symbolOnly = chimParseChatModeShortcut('~~   ');
+
+        $this->assertFalse($plain['matched']);
+        $this->assertSame('Hello there', $plain['content']);
+        $this->assertTrue($symbolOnly['matched']);
+        $this->assertSame('CLOSE', $symbolOnly['mode']);
+        $this->assertSame('', $symbolOnly['content']);
+    }
+
     public function testFullWrappedNarrationBlockDoesNotSplitMidReply(): void
     {
         $wrappedReply = "*A slight chuckle escapes me as I straighten a few more apples, my eyes crinkling at the corners. 'Wow,' you say? I hope that's a good 'wow,' Your Majesty. My produce is usually met with enthusiasm for its quality, not surprise. Though, I suppose a king might have seen grander displays of... apples.*";

--- a/unittests/tests/PlayerPresenceSnapshotTest.php
+++ b/unittests/tests/PlayerPresenceSnapshotTest.php
@@ -88,30 +88,28 @@ final class PlayerPresenceSnapshotTest extends TestCase
         $this->assertSame([], $snapshot['present_actors']);
     }
 
-    public function testRequestMetadataIsDecodedFromRoutingSnapshot(): void
+    public function testChatShortcutRoutingMarkerIsDecodedFromRoutingSnapshot(): void
     {
         $encoded = base64_encode((string)json_encode([
             'source' => 'plugin_player_routing_v2',
             'chat_shortcut_routed' => true,
+        ]));
+
+        $snapshot = chimDecodePlayerRoutingSnapshotField($encoded);
+
+        $this->assertTrue($snapshot['chat_shortcut_routed']);
+        $this->assertSame('', $snapshot['audience']);
+    }
+
+    public function testRequestExecutionModeIsIgnored(): void
+    {
+        $encoded = base64_encode((string)json_encode([
             'execution_mode' => 'whisper',
         ]));
 
         $snapshot = chimDecodePlayerRoutingSnapshotField($encoded);
 
-        $this->assertSame('WHISPER', $snapshot['execution_mode']);
-        $this->assertTrue($snapshot['chat_shortcut_routed']);
-        $this->assertSame('', $snapshot['audience']);
-    }
-
-    public function testUnknownRequestExecutionModeIsIgnored(): void
-    {
-        $encoded = base64_encode((string)json_encode([
-            'execution_mode' => 'unsupported-mode',
-        ]));
-
-        $snapshot = chimDecodePlayerRoutingSnapshotField($encoded);
-
-        $this->assertSame('', $snapshot['execution_mode']);
+        $this->assertArrayNotHasKey('execution_mode', $snapshot);
     }
 
     public function testDirectivePeopleIncludeSelectedSpeakerAndExplicitListener(): void

--- a/unittests/tests/PlayerPresenceSnapshotTest.php
+++ b/unittests/tests/PlayerPresenceSnapshotTest.php
@@ -88,16 +88,18 @@ final class PlayerPresenceSnapshotTest extends TestCase
         $this->assertSame([], $snapshot['present_actors']);
     }
 
-    public function testRequestExecutionModeIsDecodedFromRoutingSnapshot(): void
+    public function testRequestMetadataIsDecodedFromRoutingSnapshot(): void
     {
         $encoded = base64_encode((string)json_encode([
             'source' => 'plugin_player_routing_v2',
+            'chat_shortcut_routed' => true,
             'execution_mode' => 'whisper',
         ]));
 
         $snapshot = chimDecodePlayerRoutingSnapshotField($encoded);
 
         $this->assertSame('WHISPER', $snapshot['execution_mode']);
+        $this->assertTrue($snapshot['chat_shortcut_routed']);
         $this->assertSame('', $snapshot['audience']);
     }
 


### PR DESCRIPTION
## Summary

- Promote all current `unstable` changes into `dev`.
- Parse chat mode shortcuts server-side and remove the legacy fallback.
- Pause scheduled LLM work while the game is inactive using shared activity tracking.

## Validation

- Compared `origin/dev...origin/unstable`: 6 commits are pending promotion.
- Verified a clean merge with `git merge-tree --write-tree origin/dev origin/unstable`.
- Promotion-only PR; no deployment or runtime validation performed.

## Related

- CHIM: https://github.com/Dwemer-Dynamics/CHIM/pull/135